### PR TITLE
use png instead of jpg for avatar pic transparency

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -47,7 +47,7 @@ export const colors = [
   '78909c',
   '333333',
 ]; */
-export const previewExt = 'jpg';
+export const previewExt = 'png';
 
 export const storageHost = 'https://ipfs.exokit.org';
 export const previewHost = 'https://preview.exokit.org'


### PR DESCRIPTION
## Before
![ava2](https://user-images.githubusercontent.com/29695350/103454523-a7e6bc80-4caa-11eb-9fdc-816fec2f4113.PNG)

## After
![ava1](https://user-images.githubusercontent.com/29695350/103454527-aa491680-4caa-11eb-963a-04821b429393.PNG)
