### PR TITLE
Remove import maps

### DIFF
--- a/CapsuleGeometry.js
+++ b/CapsuleGeometry.js
@@ -1,5 +1,5 @@
-import * as THREE from 'three';
-import {Vector3, Color} from 'three';
+import * as THREE from 'https://lib.webaverse.com/three.js';
+import {Vector3, Color} from 'https://lib.webaverse.com/three.js';
 
 class Face3 {
 

--- a/TransformGizmo.js
+++ b/TransformGizmo.js
@@ -1,5 +1,5 @@
-import { Object3D, Color, Vector3 } from 'three';
-import { GLTFLoader } from 'GLTFLoader';
+import { Object3D, Color, Vector3 } from 'https://lib.webaverse.com/three.js';
+import { GLTFLoader } from 'https://lib.webaverse.com/GLTFLoader.js';
 const transformGizmoUrl = './assets/TransformGizmo.glb';
 import cloneObject3D from "./cloneObject3D.js";
 // import { TransformMode, TransformAxis } from "./SpokeControls.js";

--- a/activate-manager.js
+++ b/activate-manager.js
@@ -1,4 +1,4 @@
-import * as THREE from 'three';
+import * as THREE from 'https://lib.webaverse.com/three.js';
 import geometryManager from './geometry-manager.js';
 import physicsManager from './physics-manager.js';
 import {rigManager} from './rig.js';

--- a/api.js
+++ b/api.js
@@ -1,5 +1,5 @@
-import * as THREE from 'three';
-import React from 'react';
+import * as THREE from 'https://lib.webaverse.com/three.js';
+import React from 'https://lib.webaverse.com/react.js';
 const {useEffect} = React;
 import physicsManager from './physics-manager.js';
 

--- a/app-object.js
+++ b/app-object.js
@@ -1,4 +1,4 @@
-import * as THREE from 'three';
+import * as THREE from 'https://lib.webaverse.com/three.js';
 // import {CSS3DRenderer} from './CSS3DRenderer.js';
 import {addDefaultLights} from './util.js';
 

--- a/app.js
+++ b/app.js
@@ -1,4 +1,4 @@
-import * as THREE from 'three';
+import * as THREE from 'https://lib.webaverse.com/three.js';
 import {loginManager} from './login.js';
 import {tryTutorial} from './tutorial.js';
 import runtime from './runtime.js';

--- a/avatars/avatars.js
+++ b/avatars/avatars.js
@@ -1,4 +1,4 @@
-import THREE, {BufferGeometryUtils, VRMSpringBoneImporter} from 'three';
+import THREE, {BufferGeometryUtils, VRMSpringBoneImporter} from 'https://lib.webaverse.com/three.js';
 import {fixSkeletonZForward} from './vrarmik/SkeletonUtils.js';
 import PoseManager from './vrarmik/PoseManager.js';
 import ShoulderTransforms from './vrarmik/ShoulderTransforms.js';

--- a/avatars/vrarmik/ArmTransforms.js
+++ b/avatars/vrarmik/ArmTransforms.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import THREE from 'https://lib.webaverse.com/three.js';
 
 class ArmTransforms {
 	constructor() {

--- a/avatars/vrarmik/LegsManager.js
+++ b/avatars/vrarmik/LegsManager.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import THREE from 'https://lib.webaverse.com/three.js';
 import {Helpers} from './Unity.js';
 
 const stepRate = 0.2;

--- a/avatars/vrarmik/ShoulderPoser.js
+++ b/avatars/vrarmik/ShoulderPoser.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import THREE from 'https://lib.webaverse.com/three.js';
 import {
   Helpers
 } from './Unity.js';

--- a/avatars/vrarmik/ShoulderTransforms.js
+++ b/avatars/vrarmik/ShoulderTransforms.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import THREE from 'https://lib.webaverse.com/three.js';
 import ArmTransforms from './ArmTransforms.js';
 import ShoulderPoser from './ShoulderPoser.js';
 import VRArmIK from './VRArmIK.js';

--- a/avatars/vrarmik/SkeletonUtils.js
+++ b/avatars/vrarmik/SkeletonUtils.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import THREE from 'https://lib.webaverse.com/three.js';
 
 /**
 * Takes in a rootBone and recursively traverses the bone heirarchy,

--- a/avatars/vrarmik/Unity.js
+++ b/avatars/vrarmik/Unity.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import THREE from 'https://lib.webaverse.com/three.js';
 
 const localVector = new THREE.Vector3();
 const localVector2 = new THREE.Vector3();

--- a/avatars/vrarmik/VRArmIK.js
+++ b/avatars/vrarmik/VRArmIK.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import THREE from 'https://lib.webaverse.com/three.js';
 import {Helpers} from './Unity.js';
 
 const zeroVector = new THREE.Vector3();

--- a/avatars/vrarmik/VRTrackingReferences.js
+++ b/avatars/vrarmik/VRTrackingReferences.js
@@ -1,4 +1,4 @@
-import THREE from 'three';
+import THREE from 'https://lib.webaverse.com/three.js';
 
 const _makeFingers = () => {
   const result = Array(25);

--- a/bakeUtils.js
+++ b/bakeUtils.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-inner-declarations */
 
-import * as THREE from 'three';
-import {GLTFLoader, GLTFExporter, OrbitControls} from 'three';
+import * as THREE from 'https://lib.webaverse.com/three.js';
+import {GLTFLoader, GLTFExporter, OrbitControls} from 'https://lib.webaverse.com/three.js';
 // import {XRPackage, XRPackageEngine} from 'https://static.xrpackage.org/xrpackage.js';
 // import {getWireframeMesh, getDefaultAabb, getPreviewMesh} from './volume.js';
 // import {readFile} from './util.js';

--- a/build-tool.js
+++ b/build-tool.js
@@ -1,4 +1,4 @@
-import * as THREE from 'three';
+import * as THREE from 'https://lib.webaverse.com/three.js';
 import {rigManager} from './rig.js';
 import physicsManager from './physics-manager.js';
 import {buildMaterial} from './shaders.js';

--- a/camera-manager.js
+++ b/camera-manager.js
@@ -1,4 +1,4 @@
-import * as THREE from 'three';
+import * as THREE from 'https://lib.webaverse.com/three.js';
 import {appManager, getRenderer, camera/*, orbitControls*/} from './app-object.js';
 import controlsManager from './controls-manager.js';
 import physicsManager from './physics-manager.js';

--- a/cloneObject3D.js
+++ b/cloneObject3D.js
@@ -1,4 +1,4 @@
-import { PropertyBinding, AnimationClip } from "three";
+import { PropertyBinding, AnimationClip } from 'https://lib.webaverse.com/three.js';
 
 // Modified version of Don McCurdy's AnimationUtils.clone
 // https://github.com/mrdoob/three.js/pull/14494

--- a/controls-manager.js
+++ b/controls-manager.js
@@ -1,4 +1,4 @@
-import * as THREE from 'three';
+import * as THREE from 'https://lib.webaverse.com/three.js';
 
 let possessed = false;
 const controlsManager = {

--- a/drop-manager.js
+++ b/drop-manager.js
@@ -1,5 +1,5 @@
-import * as THREE from 'three';
-import {GLTFLoader} from 'three';
+import * as THREE from 'https://lib.webaverse.com/three.js';
+import {GLTFLoader} from 'https://lib.webaverse.com/three.js';
 import {scene} from './app-object.js';
 import {rigManager} from './rig.js';
 import Simplex from './simplex-noise.js';

--- a/editor.html
+++ b/editor.html
@@ -4,24 +4,6 @@
 <link rel=stylesheet href="editor.css">
 <link rel=stylesheet href="https://codemirror.net/lib/codemirror.css">
 <link rel=stylesheet href="https://codemirror.net/theme/material.css">
-<script type="importmap">
-  {
-    "imports": {
-      "three": "https://lib.webaverse.com/three.js",
-      "BufferGeometryUtils": "https://lib.webaverse.com/BufferGeometryUtils.js",
-      "GLTFLoader": "https://lib.webaverse.com/GLTFLoader.js",
-      "GLTFExporter": "https://lib.webaverse.com/GLTFExporter.js",
-      "OrbitControls": "https://lib.webaverse.com/OrbitControls.js",
-      "VOXLoader": "https://lib.webaverse.com/VOXLoader.js",
-      "react": "https://lib.webaverse.com/react.js",
-      "react-dom": "https://lib.webaverse.com/react-dom.js",
-      "@react-three/fiber": "https://lib.webaverse.com/react-three-fiber.js",
-      "@babel/standalone": "https://lib.webaverse.com/babel-standalone.js",
-      "jszip": "https://lib.webaverse.com/jszip.js",
-      "html-render": "https://html-render.webaverse.com/html-render-api.js"
-    }
-  }
-</script>
 <script src="./bin/geometry.js"></script>
 </head>
 <body>

--- a/editor.js
+++ b/editor.js
@@ -18,7 +18,7 @@ import {downloadFile, getExt, flipGeomeryUvs, updateRaycasterFromMouseEvent, get
 import App from './app.js';
 import {camera, getRenderer} from './app-object.js';
 import {CapsuleGeometry} from './CapsuleGeometry.js';
-import HtmlRenderer from 'html-render';
+import HtmlRenderer from 'https://html-render.webaverse.com/html-render-api.js';
 import {storageHost, tokensHost} from './constants.js';
 // import TransformGizmo from './TransformGizmo.js';
 // import transformControls from './transform-controls.js';

--- a/editor.js
+++ b/editor.js
@@ -1,11 +1,11 @@
-import * as THREE from 'three';
-import {BufferGeometryUtils} from 'BufferGeometryUtils';
-import React from 'react';
+import * as THREE from 'https://lib.webaverse.com/three.js';
+import {BufferGeometryUtils} from 'https://lib.webaverse.com/BufferGeometryUtils.js';
+import React from 'https://lib.webaverse.com/react.js';
 const {Fragment, useState, useEffect, useRef} = React;
-import ReactDOM from 'react-dom';
-import ReactThreeFiber from '@react-three/fiber';
-import Babel from '@babel/standalone';
-import JSZip from 'jszip';
+import ReactDOM from 'https://lib.webaverse.com/react-dom.js';
+import ReactThreeFiber from 'https://lib.webaverse.com/react-three-fiber.js';
+import Babel from 'https://lib.webaverse.com/babel-standalone.js';
+import JSZip from 'https://lib.webaverse.com/jszip.js';
 // import {jsx} from 'jsx-tmpl';
 import {world} from './world.js';
 import transformControls from './transform-controls.js';

--- a/fx.js
+++ b/fx.js
@@ -1,4 +1,4 @@
-import * as THREE from 'three';
+import * as THREE from 'https://lib.webaverse.com/three.js';
 import {scene, camera} from './app-object.js';
 import physicsManager from './physics-manager.js';
 import {epochStartTime} from './util.js';

--- a/geometry-manager.js
+++ b/geometry-manager.js
@@ -1,4 +1,4 @@
-import * as THREE from 'three';
+import * as THREE from 'https://lib.webaverse.com/three.js';
 // import {BasisTextureLoader} from './BasisTextureLoader.js';
 import alea from './alea.js';
 import easing from './easing.js';

--- a/hp-manager.js
+++ b/hp-manager.js
@@ -1,4 +1,4 @@
-import * as THREE from 'three';
+import * as THREE from 'https://lib.webaverse.com/three.js';
 import geometryManager from './geometry-manager.js';
 import physicsManager from './physics-manager.js';
 import {rigManager} from './rig.js';

--- a/index.html
+++ b/index.html
@@ -8,24 +8,6 @@
 <link href="/mithril-ui/menu/menu.css" rel=stylesheet> -->
 
 <link href="https://fonts.googleapis.com/css2?family=Muli:wght@400;600&display=swap" rel="stylesheet">
-<script type="importmap">
-  {
-    "imports": {
-      "three": "https://lib.webaverse.com/three.js",
-      "BufferGeometryUtils": "https://lib.webaverse.com/BufferGeometryUtils.js",
-      "GLTFLoader": "https://lib.webaverse.com/GLTFLoader.js",
-      "GLTFExporter": "https://lib.webaverse.com/GLTFExporter.js",
-      "OrbitControls": "https://lib.webaverse.com/OrbitControls.js",
-      "VOXLoader": "https://lib.webaverse.com/VOXLoader.js",
-      "react": "https://lib.webaverse.com/react.js",
-      "react-dom": "https://lib.webaverse.com/react-dom.js",
-      "@react-three/fiber": "https://lib.webaverse.com/react-three-fiber.js",
-      "@babel/standalone": "https://lib.webaverse.com/babel-standalone.js",
-      "jszip": "https://lib.webaverse.com/jszip.js"
-    }
-  }
-</script>
-<!-- <script src="https://kit.fontawesome.com/0735724151.js" crossorigin="anonymous"></script> -->
 </head>
 
 <body class=no-ui>

--- a/inventory.js
+++ b/inventory.js
@@ -1,4 +1,4 @@
-import * as THREE from 'three';
+import * as THREE from 'https://lib.webaverse.com/three.js';
 import Avatar from './avatars/avatars.js';
 import {rigManager} from './rig.js';
 import {RigAux} from './rig-aux.js';

--- a/io-manager.js
+++ b/io-manager.js
@@ -1,4 +1,4 @@
-import * as THREE from 'three';
+import * as THREE from 'https://lib.webaverse.com/three.js';
 import cameraManager from './camera-manager.js';
 import controlsManager from './controls-manager.js';
 import weaponsManager from './weapons-manager.js';

--- a/map.html
+++ b/map.html
@@ -3,23 +3,6 @@
   <title>Webaverse Map</title>
   <link rel=stylesheet type='text/css' href="map.css">
   <meta name="viewport" content="width=device-width, user-scalable=no" />
-<script type="importmap">
-  {
-    "imports": {
-      "three": "https://lib.webaverse.com/three.js",
-      "BufferGeometryUtils": "https://lib.webaverse.com/BufferGeometryUtils.js",
-      "GLTFLoader": "https://lib.webaverse.com/GLTFLoader.js",
-      "GLTFExporter": "https://lib.webaverse.com/GLTFExporter.js",
-      "OrbitControls": "https://lib.webaverse.com/OrbitControls.js",
-      "VOXLoader": "https://lib.webaverse.com/VOXLoader.js",
-      "react": "https://lib.webaverse.com/react.js",
-      "react-dom": "https://lib.webaverse.com/react-dom.js",
-      "@react-three/fiber": "https://lib.webaverse.com/react-three-fiber.js",
-      "@babel/standalone": "https://lib.webaverse.com/babel-standalone.js",
-      "jszip": "https://lib.webaverse.com/jszip.js"
-    }
-  }
-</script>
 <body>
   <div id=container class=container></div>
 

--- a/map.js
+++ b/map.js
@@ -1,4 +1,4 @@
-import * as THREE from 'three';
+import * as THREE from 'https://lib.webaverse.com/three.js';
 import App from './app.js';
 import {getRenderer, scene, camera, orthographicCamera} from './app-object.js';
 import {world} from './world.js';

--- a/messages.js
+++ b/messages.js
@@ -1,4 +1,4 @@
-import * as THREE from 'three';
+import * as THREE from 'https://lib.webaverse.com/three.js';
 import {appManager, scene, orthographicScene, camera, dolly} from './app-object.js';
 
 const maxMessages = 8;

--- a/minimap.js
+++ b/minimap.js
@@ -1,5 +1,5 @@
-import * as THREE from 'three';
-import {BufferGeometryUtils} from 'three';
+import * as THREE from 'https://lib.webaverse.com/three.js';
+import {BufferGeometryUtils} from 'https://lib.webaverse.com/BufferGeometryUtils.js';
 import {rigManager} from './rig.js';
 import {camera} from './app-object.js';
 import {world} from './world.js';

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  reactStrictMode: true,
+}

--- a/next.config.js
+++ b/next.config.js
@@ -1,3 +1,0 @@
-module.exports = {
-  reactStrictMode: true,
-}

--- a/npc-manager.js
+++ b/npc-manager.js
@@ -1,4 +1,4 @@
-import * as THREE from 'three';
+import * as THREE from 'https://lib.webaverse.com/three.js';
 import runtime from './runtime.js';
 import {world} from './world.js';
 import physicsManager from './physics-manager.js';

--- a/physics-manager.js
+++ b/physics-manager.js
@@ -1,4 +1,4 @@
-import * as THREE from 'three';
+import * as THREE from 'https://lib.webaverse.com/three.js';
 import uiManager from './ui-manager.js';
 import {getRenderer, camera, dolly} from './app-object.js';
 import geometryManager from './geometry-manager.js';

--- a/popovers.js
+++ b/popovers.js
@@ -1,4 +1,4 @@
-import * as THREE from 'three';
+import * as THREE from 'https://lib.webaverse.com/three.js';
 import {appManager, getRenderer, scene, orthographicScene, camera, dolly} from './app-object.js';
 
 const localVector = new THREE.Vector3();

--- a/preview.html
+++ b/preview.html
@@ -2,23 +2,6 @@
 <html>
 <head>
 <link href="/preview.css" rel=stylesheet>
-<script type="importmap">
-  {
-    "imports": {
-      "three": "https://lib.webaverse.com/three.js",
-      "BufferGeometryUtils": "https://lib.webaverse.com/BufferGeometryUtils.js",
-      "GLTFLoader": "https://lib.webaverse.com/GLTFLoader.js",
-      "GLTFExporter": "https://lib.webaverse.com/GLTFExporter.js",
-      "OrbitControls": "https://lib.webaverse.com/OrbitControls.js",
-      "VOXLoader": "https://lib.webaverse.com/VOXLoader.js",
-      "react": "https://lib.webaverse.com/react.js",
-      "react-dom": "https://lib.webaverse.com/react-dom.js",
-      "@react-three/fiber": "https://lib.webaverse.com/react-three-fiber.js",
-      "@babel/standalone": "https://lib.webaverse.com/babel-standalone.js",
-      "jszip": "https://lib.webaverse.com/jszip.js"
-    }
-  }
-</script>
 </head>
 <body>
 <div class=container id=container></div>

--- a/preview.js
+++ b/preview.js
@@ -8,7 +8,7 @@ import {storageHost} from './constants.js';
 import Avatar from './avatars/avatars.js';
 import extractPeaks from './webaudio-peaks.js';
 
-import App from '/app.js';
+import App from './app.js';
 
 const _loadVrm = async src => {
   let o;

--- a/preview.js
+++ b/preview.js
@@ -1,7 +1,7 @@
-import * as THREE from 'three';
-import {GLTFLoader} from 'GLTFLoader';
-import {OrbitControls} from 'OrbitControls';
-import {VOXLoader} from 'VOXLoader';
+import * as THREE from 'https://lib.webaverse.com/three.js';
+import {GLTFLoader} from 'https://lib.webaverse.com/GLTFLoader.js';
+import {OrbitControls} from 'https://lib.webaverse.com/OrbitControls.js';
+import {VOXLoader} from 'https://lib.webaverse.com/VOXLoader.js';
 import {world} from './world.js';
 import {parseQuery, addDefaultLights} from './util.js';
 import {storageHost} from './constants.js';

--- a/rig-aux.js
+++ b/rig-aux.js
@@ -1,4 +1,4 @@
-import * as THREE from 'three';
+import * as THREE from 'https://lib.webaverse.com/three.js';
 import runtime from './runtime.js';
 import physicsManager from './physics-manager.js';
 import dropManager from './drop-manager.js';

--- a/rig.js
+++ b/rig.js
@@ -1,5 +1,5 @@
-import * as THREE from 'three';
-import {GLTFLoader, BufferGeometryUtils} from 'three';
+import * as THREE from 'https://lib.webaverse.com/three.js';
+import {GLTFLoader, BufferGeometryUtils} from 'https://lib.webaverse.com/three.js';
 // import {MeshLine, MeshLineMaterial} from './MeshLine.js';
 import cameraManager from './camera-manager.js';
 import {makeTextMesh, makeRigCapsule} from './vr-ui.js';

--- a/runtime.js
+++ b/runtime.js
@@ -1,7 +1,7 @@
-import * as THREE from 'three';
-import {GLTFLoader, VOXLoader, BufferGeometryUtils} from 'three';
-import React from 'react';
-import ReactThreeFiber from '@react-three/fiber';
+import * as THREE from 'https://lib.webaverse.com/three.js';
+import {GLTFLoader, VOXLoader, BufferGeometryUtils} from 'https://lib.webaverse.com/three.js';
+import React from 'https://lib.webaverse.com/react.js';
+import ReactThreeFiber from 'https://lib.webaverse.com/react-three-fiber.js';
 // import {KTX2Loader} from './KTX2Loader.js';
 // import {CSS3DObject} from './CSS3DRenderer.js';
 import {MeshoptDecoder} from './meshopt_decoder.module.js';

--- a/runtime.js
+++ b/runtime.js
@@ -82,9 +82,9 @@ const startMonetization = (instanceId, monetizationPointer, ownerAddress) => {
 
 const _importMapUrl = u => new URL(u, location.protocol + '//' + location.host).href;
 const importMap = {
-  three: 'three',
-  BufferGeometryUtils: 'BufferGeometryUtils',
-  GLTFLoader: 'GLTFLoader',
+  three: 'https://lib.webaverse.com/three.js',
+  BufferGeometryUtils: 'https://lib.webaverse.com/BufferGeometryUtils.js',
+  GLTFLoader: 'https://lib.webaverse.com/GLTFLoader.js',
   // GLTF1Loader: _importMapUrl('./GLTF1Loader.js'),
   app: _importMapUrl('./app-object.js'),
   api: _importMapUrl('./api.js'),

--- a/screenshot.html
+++ b/screenshot.html
@@ -2,24 +2,6 @@
 <head>
 <title>Screenshot | Webaverse</title>
 <link rel=stylesheet type='text/css' href="screenshot.css">
-<script type="importmap">
-  {
-    "imports": {
-      "runtime": "https://lib.webaverse.com/runtime.js",
-      "three": "https://lib.webaverse.com/three.js",
-      "BufferGeometryUtils": "https://lib.webaverse.com/BufferGeometryUtils.js",
-      "GLTFLoader": "https://lib.webaverse.com/GLTFLoader.js",
-      "GLTFExporter": "https://lib.webaverse.com/GLTFExporter.js",
-      "OrbitControls": "https://lib.webaverse.com/OrbitControls.js",
-      "VOXLoader": "https://lib.webaverse.com/VOXLoader.js",
-      "react": "https://lib.webaverse.com/react.js",
-      "react-dom": "https://lib.webaverse.com/react-dom.js",
-      "@react-three/fiber": "https://lib.webaverse.com/react-three-fiber.js",
-      "@babel/standalone": "https://lib.webaverse.com/babel-standalone.js",
-      "jszip": "https://lib.webaverse.com/jszip.js"
-    }
-  }
-</script>
 </head>
 <body>
   <div id=baking>

--- a/screenshot.js
+++ b/screenshot.js
@@ -1,5 +1,5 @@
-import * as THREE from 'three';
-import {OrbitControls, GLTFLoader, VOXLoader} from 'three';
+import * as THREE from 'https://lib.webaverse.com/three.js';
+import {OrbitControls, GLTFLoader, VOXLoader} from 'https://lib.webaverse.com/three.js';
 import {bake, toggleElements} from './bakeUtils.js';
 import {getExt, parseQuery} from './util.js';
 import Avatar from './avatars/avatars.js';

--- a/shaders.js
+++ b/shaders.js
@@ -1,4 +1,4 @@
-import * as THREE from 'three';
+import * as THREE from 'https://lib.webaverse.com/three.js';
 
 /* const _makeHeightfieldShader = land => ({
   uniforms: {

--- a/shadertoy.js
+++ b/shadertoy.js
@@ -1,4 +1,4 @@
-import * as THREE from 'three';
+import * as THREE from 'https://lib.webaverse.com/three.js';
 import {scene, camera, getRenderer} from './app-object.js';
 import {copyScenePlaneGeometry, copySceneVertexShader, copyScene, copySceneCamera} from './shaders.js';
 

--- a/teleport.js
+++ b/teleport.js
@@ -1,5 +1,5 @@
-import * as THREE from 'three';
-import {BufferGeometryUtils} from 'three';
+import * as THREE from 'https://lib.webaverse.com/three.js';
+import {BufferGeometryUtils} from 'https://lib.webaverse.com/BufferGeometryUtils.js';
 import {getRenderer, scene} from './app-object.js';
 
 const localVector = new THREE.Vector3();

--- a/textmesh-standalone.esm.js
+++ b/textmesh-standalone.esm.js
@@ -1,4 +1,4 @@
-import { Color, DataTexture, LuminanceFormat, LinearFilter, Vector3, InstancedBufferGeometry, Sphere, InstancedBufferAttribute, PlaneBufferGeometry, Vector2, Vector4, Matrix3, MeshBasicMaterial, DoubleSide, Matrix4, Mesh } from 'three';
+import { Color, DataTexture, LuminanceFormat, LinearFilter, Vector3, InstancedBufferGeometry, Sphere, InstancedBufferAttribute, PlaneBufferGeometry, Vector2, Vector4, Matrix3, MeshBasicMaterial, DoubleSide, Matrix4, Mesh } from 'https://lib.webaverse.com/three.js';
 import { defineWorkerModule, ThenableWorkerModule } from './troika-worker-utils.esm.js';
 import { createDerivedMaterial, voidMainRegExp } from './troika-three-utils.esm.js';
 

--- a/transform-controls.js
+++ b/transform-controls.js
@@ -90,37 +90,39 @@ const transformControls = {
     this.dragging = false;
   },
   handleMouseMove(raycaster) {
-    if (this.dragging) {
-      /* this.transformRay.origin.setFromMatrixPosition(this.camera.matrixWorld);
-      this.transformRay.direction
-        .set(cursorPosition.x, cursorPosition.y, 0.5)
-        .unproject(this.camera)
-        .sub(this.transformRay.origin);
-      this.transformRay.intersectPlane(this.transformPlane, this.planeIntersection); */
+    if (this.transformGizmo) {
+      if (this.dragging) {
+        /* this.transformRay.origin.setFromMatrixPosition(this.camera.matrixWorld);
+        this.transformRay.direction
+          .set(cursorPosition.x, cursorPosition.y, 0.5)
+          .unproject(this.camera)
+          .sub(this.transformRay.origin);
+        this.transformRay.intersectPlane(this.transformPlane, this.planeIntersection); */
 
-      raycaster.ray.intersectPlane(this.transformPlane, localVector);
-      const endPosition = localVector;
-      this.startMouseMatrix.decompose(
-        localVector2,
-        localQuaternion,
-        localVector3
-      );
-      const startPosition = localVector2;
-      const diffVector = localVector3.copy(endPosition)
-        .sub(startPosition);
-    
-      this.transformGizmo.matrix.copy(this.startMatrix)
-        .premultiply(
-          localMatrix.compose(
-            diffVector,
-            localQuaternion.set(0, 0, 0, 1),
-            localVector4.set(1, 1, 1)
-          )
+        raycaster.ray.intersectPlane(this.transformPlane, localVector);
+        const endPosition = localVector;
+        this.startMouseMatrix.decompose(
+          localVector2,
+          localQuaternion,
+          localVector3
         );
+        const startPosition = localVector2;
+        const diffVector = localVector3.copy(endPosition)
+          .sub(startPosition);
+      
+        this.transformGizmo.matrix.copy(this.startMatrix)
+          .premultiply(
+            localMatrix.compose(
+              diffVector,
+              localQuaternion.set(0, 0, 0, 1),
+              localVector4.set(1, 1, 1)
+            )
+          );
 
-      const constraint = TransformAxisConstraints[this.transformAxis];
-    } else {
-      this.transformGizmo.highlightHoveredAxis(raycaster);
+        const constraint = TransformAxisConstraints[this.transformAxis];
+      } else {
+        this.transformGizmo.highlightHoveredAxis(raycaster);
+      }
     }
   },
   update() {

--- a/transform-controls.js
+++ b/transform-controls.js
@@ -1,4 +1,4 @@
-import * as THREE from 'three';
+import * as THREE from 'https://lib.webaverse.com/three.js';
 import {scene, sceneLowPriority} from './app-object.js';
 import weaponsManager from './weapons-manager.js';
 import TransformGizmo from './TransformGizmo.js';

--- a/troika-three-utils.esm.js
+++ b/troika-three-utils.esm.js
@@ -1,4 +1,4 @@
-import { ShaderChunk, UniformsUtils, MeshDepthMaterial, RGBADepthPacking, MeshDistanceMaterial, ShaderLib, Matrix4, Vector3, Mesh, CylinderBufferGeometry, Vector2, MeshStandardMaterial, DoubleSide } from 'three';
+import { ShaderChunk, UniformsUtils, MeshDepthMaterial, RGBADepthPacking, MeshDistanceMaterial, ShaderLib, Matrix4, Vector3, Mesh, CylinderBufferGeometry, Vector2, MeshStandardMaterial, DoubleSide } from 'https://lib.webaverse.com/three.js';
 
 /**
  * Regular expression for matching the `void main() {` opener line in GLSL.

--- a/ui-manager.js
+++ b/ui-manager.js
@@ -1,5 +1,5 @@
-import * as THREE from 'three';
-import {BufferGeometryUtils} from 'three';
+import * as THREE from 'https://lib.webaverse.com/three.js';
+import {BufferGeometryUtils} from 'https://lib.webaverse.com/three.js';
 import geometryManager from './geometry-manager.js';
 import weaponsManager from './weapons-manager.js';
 // import inventory from './inventory.js';

--- a/universe.js
+++ b/universe.js
@@ -1,4 +1,4 @@
-import * as THREE from 'three';
+import * as THREE from 'https://lib.webaverse.com/three.js';
 import {rigManager} from './rig.js';
 import {getRenderer, scene, camera, dolly} from './app-object.js';
 import {world} from './world.js';

--- a/util.js
+++ b/util.js
@@ -1,5 +1,5 @@
-import * as THREE from 'three';
-import {BufferGeometryUtils} from 'BufferGeometryUtils';
+import * as THREE from 'https://lib.webaverse.com/three.js';
+import {BufferGeometryUtils} from 'https://lib.webaverse.com/BufferGeometryUtils.js';
 import atlaspack from './atlaspack.js';
 import {maxGrabDistance, tokensHost, storageHost} from './constants.js';
 

--- a/vr-ui.js
+++ b/vr-ui.js
@@ -1,5 +1,5 @@
-import * as THREE from 'three';
-import {BufferGeometryUtils} from 'three';
+import * as THREE from 'https://lib.webaverse.com/three.js';
+import {BufferGeometryUtils} from 'https://lib.webaverse.com/BufferGeometryUtils.js';
 // import {scene} from './run.js';
 import {TextMesh} from './textmesh-standalone.esm.js';
 import {CapsuleGeometry} from './CapsuleGeometry.js';

--- a/weapons-manager.js
+++ b/weapons-manager.js
@@ -1,5 +1,5 @@
-import * as THREE from 'three';
-import {GLTFLoader, BufferGeometryUtils} from 'three';
+import * as THREE from 'https://lib.webaverse.com/three.js';
+import {GLTFLoader, BufferGeometryUtils} from 'https://lib.webaverse.com/three.js';
 import geometryManager from './geometry-manager.js';
 import cameraManager from './camera-manager.js';
 import uiManager from './ui-manager.js';

--- a/world.js
+++ b/world.js
@@ -1,4 +1,4 @@
-import * as THREE from 'three';
+import * as THREE from 'https://lib.webaverse.com/three.js';
 import storage from './storage.js';
 import {XRChannelConnection} from './xrrtc.js';
 import Y from './yjs.js';


### PR DESCRIPTION
This PR removes import maps from the `html` and `js` files.

External objects will need to be updated to support this.

Fixes https://github.com/webaverse/app/issues/1375.