### PR TITLE
added shadow.scn demo scene

### DIFF
--- a/renderer.js
+++ b/renderer.js
@@ -31,8 +31,8 @@ function bindCanvas(c) {
   renderer.physicallyCorrectLights = true;
   renderer.outputEncoding = THREE.sRGBEncoding;
   renderer.gammaFactor = 2.2;
-  // renderer.shadowMap.enabled = true;
-  // renderer.shadowMap.type = THREE.PCFShadowMap;
+  renderer.shadowMap.enabled = true;
+  renderer.shadowMap.type = THREE.PCFSoftShadowMap;
   if (!canvas) {
     canvas = renderer.domElement;
   }

--- a/scenes/scenes.json
+++ b/scenes/scenes.json
@@ -2,6 +2,7 @@
   "street.scn",
   "treehouse.scn",
   "darkness.scn",
+  "shadows.scn",
   "classroom.scn",
   "grid.scn",
   "canyon.scn"

--- a/scenes/shadows.scn
+++ b/scenes/shadows.scn
@@ -1,0 +1,113 @@
+{
+  "objects": [
+    {
+      "type": "application/light",
+      "content": {
+        "lightType": "ambient",
+        "args": [[255, 255, 255], 0.5]
+      }
+    },
+    {
+      "type": "application/light",
+      "content": {
+        "lightType": "directional",
+        "args": [[255, 255, 255], 5],
+        "position": [1, 2, 3],
+        "shadow": [150, 5120, 0.1, 10000, -0.0001]
+      }
+    },
+    {
+      "position": [
+        0,
+        0,
+        0
+      ],
+      "start_url": "https://webaverse.github.io/desert-hill/"
+    },
+    {
+      "position": [
+        0,
+        0,
+        0
+      ],
+      "start_url": "https://webaverse.github.io/atmospheric-sky/"
+    },
+    {
+      "position": [
+        8.4,
+        -1.74,
+        -5.49
+      ],
+      "quaternion": [
+        0,
+        0.7071067811865475,
+        0,
+        0.7071067811865475
+      ],
+      "physics": false,
+      "start_url": "/avatars/gear.vrm",
+      "dynamic": true
+    },
+    {
+      "position": [
+        -13,
+        0,
+        0
+      ],
+      "quaternion": [
+        0,
+        0.7071067811865475,
+        0,
+        0.7071067811865475
+      ],
+      "start_url": "https://webaverse.github.io/treehouse/"
+    },
+    {
+      "position": [
+        -6,
+        -2,
+        32
+      ],
+      "quaternion": [
+        0,
+        0,
+        0,
+        1
+      ],
+      "start_url": "https://webaverse.github.io/hovercraft/"
+    },
+    {
+      "position": [
+        -6,
+        0.16,
+        16
+      ],
+      "quaternion": [
+        0,
+        0.7071067811865475,
+        0,
+        0.7071067811865475
+      ],
+      "start_url": "https://webaverse.github.io/fox/"
+    },
+    {
+      "position": [
+        -6,
+        1,
+        15
+      ],
+      "quaternion": [
+        0,
+        0,
+        0,
+        1
+      ],
+      "scale": [
+        0.5,
+        0.5,
+        0.5
+      ],
+      "start_url": "https://webaverse.github.io/potion/"
+    }
+  ]
+}

--- a/util.js
+++ b/util.js
@@ -542,6 +542,8 @@ export const unFrustumCull = o => {
   o.traverse(o => {
     if (o.isMesh) {
       o.frustumCulled = false;
+      o.castShadow = true;
+      o.receiveShadow = true;
     }
   });
 };


### PR DESCRIPTION
Shadows are configurable in the .scn file.

Usage: 
`"shadow": [150, 5120, 0.1, 1000, -0.0001]` (side, mapSize, near, far, bias)

Shadows are not enabled for the main avatar yet. Still need to fix the issue with render ordering.
This PR does not break any current system and shadows are completely optional.