### PR TITLE
VRM Hairgel

### DIFF
--- a/avatars/avatars.js
+++ b/avatars/avatars.js
@@ -14,28 +14,31 @@ import easing from '../easing.js';
 import CBOR from '../cbor.js';
 import Simplex from '../simplex-noise.js';
 
-VRMSpringBoneImporter.prototype._createSpringBone = (_createSpringBone => function(a, b) {
-  const bone = _createSpringBone.apply(this, arguments);
-  const initialDragForce = bone.dragForce;
-  const initialStiffnessForce = bone.stiffnessForce;
-  // const initialGravityPower = bone.gravityPower;
-  
-  Object.defineProperty(bone, 'stiffnessForce', {
-    get() {
-      localVector.set(physicsManager.velocity.x, 0, physicsManager.velocity.z);
-      const f = Math.pow(Math.min(Math.max(localVector.length()*2 - Math.abs(physicsManager.velocity.y)*0.5, 0), 4), 2);
-      return initialStiffnessForce * (0.05 + 0.1*f);
-    },
-    set(v) {},
-  });
-  Object.defineProperty(bone, 'dragForce', {
-    get() {
-      return initialDragForce * 0.75;
-    },
-    set(v) {},
-  });
-  
-  return bone;
+VRMSpringBoneImporter.prototype._createSpringBone = (_createSpringBone => {
+  const localVector = new THREE.Vector3();
+  return function(a, b) {
+    const bone = _createSpringBone.apply(this, arguments);
+    const initialDragForce = bone.dragForce;
+    const initialStiffnessForce = bone.stiffnessForce;
+    // const initialGravityPower = bone.gravityPower;
+    
+    Object.defineProperty(bone, 'stiffnessForce', {
+      get() {
+        localVector.set(physicsManager.velocity.x, 0, physicsManager.velocity.z);
+        const f = Math.pow(Math.min(Math.max(localVector.length()*2 - Math.abs(physicsManager.velocity.y)*0.5, 0), 4), 2);
+        return initialStiffnessForce * (0.05 + 0.1*f);
+      },
+      set(v) {},
+    });
+    Object.defineProperty(bone, 'dragForce', {
+      get() {
+        return initialDragForce * 0.75;
+      },
+      set(v) {},
+    });
+    
+    return bone;
+  };
 })(VRMSpringBoneImporter.prototype._createSpringBone);
 
 const _makeSimplexes = numSimplexes => {


### PR DESCRIPTION
This implements my idea of VRM hairgel, brought to you by YGOTAS and L'Oreal.

It's like relativity, the density of your hair increases exponentially with speed.

This means that the character's hair becomes stiffer as they go faster, but remains soft and fluffy at low speeds. The effect is that the interestingness gradient of the image is constant. When the character moves a lot, we keep the hair out of the way, but when the character is still we need to wave the hair a bit to increase the interestingness.

It ends up looking decent on the characters I tried, but we can remove it if this causes problems.

Related: https://github.com/webaverse/app/issues/1598