### PR TITLE
Fix backwards crouch animations

### DIFF
--- a/avatars/avatars.js
+++ b/avatars/avatars.js
@@ -275,13 +275,13 @@ const loadPromise = (async () => {
     `Crouched Sneaking Left.fbx`,
     `Crouched Sneaking Right.fbx`,
   ].map(name => animations.find(a => a.name === name));
-  _normalizeAnimationDurations(crouchingForwardAnimations, crouchingForwardAnimations[0]);
+  _normalizeAnimationDurations(crouchingForwardAnimations, crouchingForwardAnimations[0], 0.5);
   const crouchingBackwardAnimations = [
     `Sneaking Forward reverse.fbx`,
     `Crouched Sneaking Left reverse.fbx`,
     `Crouched Sneaking Right reverse.fbx`,
   ].map(name => animations.find(a => a.name === name));
-  _normalizeAnimationDurations(crouchingBackwardAnimations, crouchingBackwardAnimations[0]);
+  _normalizeAnimationDurations(crouchingBackwardAnimations, crouchingBackwardAnimations[0], 0.5);
   animations.forEach(animation => {
     animation.direction = (() => {
       switch (animation.name) {


### PR DESCRIPTION
The crouch animations are all based on the forward/left/right sneaks. We reverse them to get reverse modes, and cross blend side and reverse to get the "walking backwards diagonally".

However they are not only 1) inconsistent timings but 2) inconsistent footwork (double time), as you can see here:

https://user-images.githubusercontent.com/6926057/138781680-8ab6ae9a-3952-49c7-a0e5-86c126589dd0.mp4

When blended this creates a really nasty unnatural shuffle effetct. This PR fixes that by introducing time scaling factor support for animations, so we can align the footwork.

With this PR, crouches look a lot more "right" and natural.
