### PR TITLE
App: give characters their own app managers

### DIFF
--- a/app-manager.js
+++ b/app-manager.js
@@ -373,15 +373,6 @@ class AppManager extends EventTarget {
       }
       case 'low': {
         sceneLowPriority.add(app);
-        /* console.log('got render priority', renderPriority, sceneLowPriority, app, app.parent);
-        Object.defineProperty(app, 'parent', {
-          get() {
-            return sceneLowPriority;
-          },
-          set(v) {
-            debugger;
-          },
-        }); */
         break;
       }
       default: {
@@ -430,8 +421,6 @@ class AppManager extends EventTarget {
     srcAppManager.state.transact(() => {
       dstAppManager.state.transact(() => {
         const srcTrackedApp = srcAppManager.getTrackedApp(instanceId);
-        // const dstTrackedApp = dstAppManager.getTrackedApp(instanceId);
-        // console.log('got tracked app in src dst', srcTrackedApp, dstTrackedApp);
         
         const contentId = srcTrackedApp.get('contentId');
         const position = srcTrackedApp.get('position');

--- a/app-manager.js
+++ b/app-manager.js
@@ -429,11 +429,10 @@ class AppManager extends EventTarget {
     
     srcAppManager.state.transact(() => {
       dstAppManager.state.transact(() => {
-        const srcTrackedApp = this.getTrackedApp(instanceId);
-        const dstTrackedApp = dstAppManager.getTrackedApp(instanceId);
-        console.log('got tracked app in src dst', srcTrackedApp, dstTrackedApp);
+        const srcTrackedApp = srcAppManager.getTrackedApp(instanceId);
+        // const dstTrackedApp = dstAppManager.getTrackedApp(instanceId);
+        // console.log('got tracked app in src dst', srcTrackedApp, dstTrackedApp);
         
-        // const instanceId = srcTrackedApp.get('instanceId');
         const contentId = srcTrackedApp.get('contentId');
         const position = srcTrackedApp.get('position');
         const quaternion = srcTrackedApp.get('quaternion');
@@ -447,8 +446,13 @@ class AppManager extends EventTarget {
           scale,
           components,
         );
-        
         srcAppManager.removeTrackedAppInternal(instanceId);
+        
+        const srcAppIndex = srcAppManager.apps.indexOf(app);
+        // const dstAppIndex = dstAppManager.apps.findIndex(app => app.instanceId === instanceId);
+        srcAppManager.apps.splice(srcAppIndex, 1);
+        
+        dstAppManager.apps.push(app);
       });
     });
     const srcTrackedApp = this.getTrackedApp(instanceId);

--- a/app-manager.js
+++ b/app-manager.js
@@ -295,6 +295,7 @@ class AppManager extends EventTarget {
     trackedApp.set('components', JSON.stringify(components));
     const originalJson = trackedApp.toJSON();
     trackedApp.set('originalJson', JSON.stringify(originalJson));
+    return trackedApp;
   }
   addTrackedApp(
     contentId,

--- a/app-manager.js
+++ b/app-manager.js
@@ -85,6 +85,14 @@ class AppManager extends EventTarget {
 
       lastApps = nextApps;
     });
+
+    const resize = e => {
+      appManager.resize(e);
+    };
+    window.addEventListener('resize', resize);
+    this.cleanup = () => {
+      window.removeEventListener('resize', resize);
+    };
   }
   bindEvents() {
     this.addEventListener('trackedappadd', async e => {
@@ -366,6 +374,9 @@ class AppManager extends EventTarget {
       await app.addModule(m);
     })();
     return app;
+  }
+  destroy() {
+    this.cleanup();
   }
 }
 export {

--- a/character-controller.js
+++ b/character-controller.js
@@ -170,6 +170,8 @@ class LocalPlayer extends Player {
     if (wearActionIndex !== -1) {
       this.actions.splice(wearActionIndex, 1);
       
+      this.appManager.transplantApp(app, world.appManager);
+      
       const wearComponent = app.getComponent('wear');
       if (wearComponent) {
         app.position.copy(this.position)

--- a/character-controller.js
+++ b/character-controller.js
@@ -11,6 +11,7 @@ import cameraManager from './camera-manager.js';
 import physx from './physx.js';
 import metaversefile from './metaversefile-api.js';
 import {crouchMaxTime, activateMaxTime, useMaxTime} from './constants.js';
+import {AppManager} from './app-manager.js';
 
 const localVector = new THREE.Vector3();
 const localVector2 = new THREE.Vector3();
@@ -88,6 +89,8 @@ class Player extends THREE.Object3D {
     // this.playerId = 'Anonymous';
     this.actions = [];
 
+    this.appManager = new AppManager();
+
     this.actionInterpolants = {
       crouch: new BiActionInterpolant(() => this.hasAction('crouch'), 0, crouchMaxTime),
       activate: new UniActionInterpolant(() => this.hasAction('activate'), 0, activateMaxTime),
@@ -139,6 +142,8 @@ class LocalPlayer extends Player {
       type: 'wearupdate',
       wear: true,
     });
+    
+    world.appManager.transplantApp(app, this.appManager);
     
     const physicsObjects = app.getPhysicsObjects();
     for (const physicsObject of physicsObjects) {

--- a/game.js
+++ b/game.js
@@ -1450,34 +1450,16 @@ const _gameUpdate = (timestamp, timeDiff) => {
     crosshairEl.style.visibility = visible ? null : 'hidden';
   }
 };
-const _pushWorldAppUpdates = () => {
-  world.appManager.setPushingLocalUpdates(true);
-  
-  for (const object of world.appManager.apps) {
-    object.updateMatrixWorld();
-    if (!object.matrix.equals(object.lastMatrix)) {
-      object.matrix.decompose(localVector, localQuaternion, localVector2);
-      world.appManager.setTrackedAppTransform(object.instanceId, localVector, localQuaternion, localVector2);
-      
-      const physicsObjects = object.getPhysicsObjects();
-      for (const physicsObject of physicsObjects) {
-        physicsObject.position.copy(object.position);
-        physicsObject.quaternion.copy(object.quaternion);
-        physicsObject.scale.copy(object.scale);
-        physicsObject.updateMatrixWorld();
-        
-        physicsManager.pushUpdate(physicsObject);
-        physicsObject.needsUpdate = false;
-      }
-      
-      object.lastMatrix.copy(object.matrix);
-    }
-  }
-
-  world.appManager.setPushingLocalUpdates(false);
-};
 const _pushAppUpdates = () => {
-  _pushWorldAppUpdates();
+  world.appManager.pushAppUpdates();
+  
+  const localPlayer = metaversefileApi.useLocalPlayer();
+  localPlayer.appManager.pushAppUpdates();
+  
+  const remotePlayers = metaversefileApi.useRemotePlayers();
+  for (const remotePlayer of remotePlayers) {
+    remotePlayer.appManager.pushAppUpdates();
+  }
 };
 
 /* const cubeMesh = new THREE.Mesh(new THREE.BoxBufferGeometry(0.01, 0.01, 0.01), new THREE.MeshBasicMaterial({

--- a/metaversefile-api.js
+++ b/metaversefile-api.js
@@ -793,10 +793,18 @@ export default () => {
     return world.appManager.removeTrackedApp.apply(world.appManager, arguments);
   },
   getAppByInstanceId() {
-    return world.appManager.getAppByInstanceId.apply(world.appManager, arguments);
+    const localPlayer = this.useLocalPlayer();
+    const remotePlayers = this.useRemotePlayers();
+    return world.appManager.getAppByInstanceId.apply(world.appManager, arguments) ||
+      localPlayer.appManager.getAppByInstanceId.apply(localPlayer.appManager, arguments) ||
+      remotePlayers.some(remotePlayer => remotePlayer.appManager.getAppByInstanceId.apply(remotePlayer.appManager, arguments));
   },
   getAppByPhysicsId() {
-    return world.appManager.getAppByPhysicsId.apply(world.appManager, arguments);
+    const localPlayer = this.useLocalPlayer();
+    const remotePlayers = this.useRemotePlayers();
+    return world.appManager.getAppByPhysicsId.apply(world.appManager, arguments) ||
+      localPlayer.appManager.getAppByPhysicsId.apply(localPlayer.appManager, arguments) ||
+      remotePlayers.some(remotePlayer => remotePlayer.appManager.getAppByPhysicsId.apply(remotePlayer.appManager, arguments));
   },
   /* addAppToList(app) {
     apps.push(app);

--- a/physics-manager.js
+++ b/physics-manager.js
@@ -568,24 +568,24 @@ const _applyAvatarPhysics = (camera, avatarOffset, cameraBasedOffset, velocityAv
       const sitAction = localPlayer.actions.find(action => action.type === 'sit');
 
       const objInstanceId = sitAction.controllingId;
-      const controlledObj = world.appManager.getAppByInstanceId(objInstanceId);
-      const sitPos = sitAction.controllingBone ? sitAction.controllingBone : controlledObj;
+      const controlledApp = metaversefileApi.getAppByInstanceId(objInstanceId);
+      const sitPos = sitAction.controllingBone ? sitAction.controllingBone : controlledApp;
 
-      const sitComponent = controlledObj.getComponent('sit');
+      const sitComponent = controlledApp.getComponent('sit');
       const {sitOffset = [0, 0, 0], damping} = sitComponent;
 
       physicsManager.setSitOffset(sitOffset);
 
-      applyVelocity(controlledObj.position, physicsManager.velocity, timeDiffS);
+      applyVelocity(controlledApp.position, physicsManager.velocity, timeDiffS);
       if (physicsManager.velocity.lengthSq() > 0) {
-        controlledObj.quaternion
+        controlledApp.quaternion
           .setFromUnitVectors(
             localVector4.set(0, 0, -1),
             localVector5.set(physicsManager.velocity.x, 0, physicsManager.velocity.z).normalize()
           )
           .premultiply(localQuaternion2.setFromAxisAngle(localVector3.set(0, 1, 0), Math.PI));
       }
-      controlledObj.updateMatrixWorld();
+      controlledApp.updateMatrixWorld();
 
       localMatrix.copy(sitPos.matrixWorld)
         .decompose(localVector, localQuaternion, localVector2);

--- a/post-processing.js
+++ b/post-processing.js
@@ -15,8 +15,8 @@ import {
   getRenderer,
   getComposer,
   scene,
-  sceneHighPriority,
-  sceneLowPriority,
+  // sceneHighPriority,
+  // sceneLowPriority,
   rootScene,
   camera,
 } from './renderer.js';

--- a/renderer.js
+++ b/renderer.js
@@ -94,6 +94,7 @@ rootScene.add(sceneLowPriority);
 const camera = new THREE.PerspectiveCamera(minFov, window.innerWidth / window.innerHeight, 0.1, 1000);
 camera.position.set(0, 1.6, 0);
 camera.rotation.order = 'YXZ';
+camera.name = 'sceneCamera';
 
 /* const avatarCamera = camera.clone();
 avatarCamera.near = 0.2;

--- a/renderer.js
+++ b/renderer.js
@@ -76,11 +76,11 @@ function getComposer() {
 
 renderTarget = new THREE.WebGLRenderTarget(window.innerWidth * window.devicePixelRatio,window.innerHeight * window.devicePixelRatio);
 
-const scene = new THREE.Scene();
+const scene = new THREE.Object3D();
 scene.name = 'scene';
-const sceneHighPriority = new THREE.Scene();
+const sceneHighPriority = new THREE.Object3D();
 sceneHighPriority.name = 'highPriorioty';
-const sceneLowPriority = new THREE.Scene();
+const sceneLowPriority = new THREE.Object3D();
 sceneLowPriority.name = 'lowPriorioty';
 const rootScene = new THREE.Scene();
 rootScene.name = 'root';

--- a/webaverse.js
+++ b/webaverse.js
@@ -125,7 +125,6 @@ export default class Webaverse extends EventTarget {
   }
   bindInput() {
     ioManager.bindInput();
-    world.bindInput();
   }
   bindInterface() {
     ioManager.bindInterface();

--- a/world.js
+++ b/world.js
@@ -261,11 +261,6 @@ world.disconnectRoom = () => {
 world.clear = () => {
   appManager.clear();
 };
-world.bindInput = () => {
-  window.addEventListener('resize', e => {
-    appManager.resize(e);
-  });
-};
 
 appManager.addEventListener('appadd', e => {
   const app = e.data;


### PR DESCRIPTION
This PR sets up per-character app managers, and transplants worn apps using a "state blind" mode on the `y.js` CRDT.

Wear updates can therefore be networked-synced and the app will not need to reload, allowing apps to move across worlds seamlessly with the party.