### PR TITLE
Rig update timing

### DIFF
--- a/rig.js
+++ b/rig.js
@@ -85,8 +85,6 @@ class RigManager {
     this.smoothVelocity = new THREE.Vector3();
 
     this.peerRigs = new Map();
-    
-    this.lastTimetamp = Date.now();
   }
 
   setLocalRigMatrix(rm) {
@@ -359,10 +357,9 @@ class RigManager {
     }
   }
 
-  update() {
+  update(timestamp, timeDiff) {
     if (this.localRig) {
-      const now = Date.now();
-      const timeDiff = (now - this.lastTimetamp) / 1000;
+      const timeDiffS = timeDiff / 1000;
 
       const renderer = getRenderer();
       const session = renderer.xr.getSession();
@@ -379,7 +376,7 @@ class RigManager {
         }
         const positionDiff = localVector2.copy(this.lastPosition)
           .sub(currentPosition)
-          .multiplyScalar(0.1/timeDiff);
+          .multiplyScalar(0.1/timeDiffS);
         localEuler.setFromQuaternion(currentQuaternion, 'YXZ');
         localEuler.x = 0;
         localEuler.z = 0;
@@ -473,13 +470,11 @@ class RigManager {
       };
       _applyChatModifiers();
 
-      this.localRig.update(now, timeDiff);
+      this.localRig.update(timestamp, timeDiffS);
 
       this.peerRigs.forEach(rig => {
-        rig.update(now, timeDiff);
+        rig.update(timestamp, timeDiffS);
       });
-
-      this.lastTimetamp = now;
     }
   }
 }

--- a/webaverse.js
+++ b/webaverse.js
@@ -346,7 +346,7 @@ export default class Webaverse extends EventTarget {
       transformControls.update();
       game.update(timestamp, timeDiffCapped);
       
-      rigManager.update();
+      rigManager.update(timestamp, timeDiffCapped);
 
       world.appManager.tick(timestamp, frame);
       hpManager.update(timestamp, timeDiffCapped);


### PR DESCRIPTION
Rig manager update was not taking in the correct timestamp, causing incorrect simulation of rigs for differing frame rates.

This PR uses the time diff parameters of the top level engine in the rig updates.

Related issue: https://github.com/webaverse/app/issues/1530