### PR TITLE
Player position source of truth

### DIFF
--- a/game.js
+++ b/game.js
@@ -1203,7 +1203,7 @@ const _bindPointerLock = () => {
 };
 _bindPointerLock();
 
-let lastLocalPlayerPosition;
+/* let lastLocalPlayerPosition;
 let lastLocalPlayerQuaternion;
 const _bindLocalPlayerTeleport = () => {
   const localPlayer = metaversefileApi.useLocalPlayer();
@@ -1220,7 +1220,7 @@ const _bindLocalPlayerTeleport = () => {
     }
   });
 };
-_bindLocalPlayerTeleport();
+_bindLocalPlayerTeleport(); */
 
 // let droppedThrow = false;
 let lastMouseEvent = null;

--- a/game.js
+++ b/game.js
@@ -1222,7 +1222,7 @@ const _bindLocalPlayerTeleport = () => {
 };
 _bindLocalPlayerTeleport();
 
-let droppedThrow = false;
+// let droppedThrow = false;
 let lastMouseEvent = null;
 const gameManager = {
   menuOpen: 0,

--- a/game.js
+++ b/game.js
@@ -1222,7 +1222,6 @@ const _bindLocalPlayerTeleport = () => {
 };
 _bindLocalPlayerTeleport(); */
 
-// let droppedThrow = false;
 let lastMouseEvent = null;
 const gameManager = {
   menuOpen: 0,

--- a/game.js
+++ b/game.js
@@ -900,7 +900,7 @@ const _gameUpdate = (timestamp, timeDiff) => {
       
       if (!gameManager.getMouseSelectedObject() && !gameManager.contextMenu) {
         if (/*controlsManager.isPossessed() &&*/ cameraManager.getMode() !== 'firstperson') {
-          rigManager.localRigMatrix.decompose(
+          localPlayer.matrixWorld.decompose(
             localVector,
             localQuaternion,
             localVector2
@@ -966,7 +966,7 @@ const _gameUpdate = (timestamp, timeDiff) => {
         !gameManager.contextMenu /* &&
         controlsManager.isPossessed() */
       ) {
-        rigManager.localRigMatrix.decompose(
+        localPlayer.matrixWorld.decompose(
           localVector,
           localQuaternion,
           localVector2

--- a/physics-manager.js
+++ b/physics-manager.js
@@ -576,9 +576,6 @@ const _applyAvatarPhysics = (camera, avatarOffset, cameraBasedOffset, velocityAv
         rigManager.localRig.setFloorHeight(localVector.y - getAvatarHeight());
       }
     }
-
-    // collide items
-    // _collideItems(localMatrix);
   }
 };
 const _collideCapsule = (() => {

--- a/physics-manager.js
+++ b/physics-manager.js
@@ -481,9 +481,7 @@ const _applyAvatarPhysics = (camera, avatarOffset, cameraBasedOffset, velocityAv
             )
           );
         } else {
-          // if (rigManager.localRigMatrixEnabled) {
-          rigManager.localRigMatrix.decompose(localVector4, localQuaternion, localVector5);
-          // }
+          localPlayer.matrixWorld.decompose(localVector4, localQuaternion, localVector5);
         }
       }
 
@@ -560,8 +558,16 @@ const _applyAvatarPhysics = (camera, avatarOffset, cameraBasedOffset, velocityAv
     }
     localMatrix.compose(localVector, localQuaternion, localVector2);
 
-    // apply
-    rigManager.setLocalRigMatrix(updateRig ? localMatrix : null);
+    // apply to player
+    if (updateRig) {
+      localPlayer.matrix.copy(localMatrix);
+    } else {
+      localPlayer.matrix.identity();
+    }
+    localPlayer.matrix
+      .decompose(localPlayer.position, localPlayer.quaternion, localPlayer.scale);
+    localPlayer.matrixWorld.copy(localPlayer.matrix);
+
     if (rigManager.localRig) {
       if (localPlayer.hasAction('jump')) {
        rigManager.localRig.setFloorHeight(-0xFFFFFF);

--- a/physics-manager.js
+++ b/physics-manager.js
@@ -668,9 +668,6 @@ const _updatePhysics = timeDiff => {
       );
     } else {
       physicsManager.velocity.y = 0;
-      // _collideItems(avatarWorldObject.matrix);
-      // _collideChunk(avatarWorldObject.matrix);
-      rigManager.setLocalRigMatrix(null);
     }
   } else {
     const selectedTool = cameraManager.getMode();

--- a/physics-manager.js
+++ b/physics-manager.js
@@ -648,6 +648,7 @@ const _copyPQS = (dst, src) => {
 };
 const _updatePhysics = timeDiff => {
   const timeDiffS = timeDiff / 1000;
+  const localPlayer = metaversefileApi.useLocalPlayer();
 
   const avatarWorldObject = _getAvatarWorldObject(localObject);
   const avatarCameraOffset = _getAvatarCameraOffset();
@@ -673,7 +674,6 @@ const _updatePhysics = timeDiff => {
     }
   } else {
     const selectedTool = cameraManager.getMode();
-    const localPlayer = metaversefileApi.useLocalPlayer();
     if (selectedTool === 'firstperson') {
       _applyGravity(timeDiffS);
       _applyDamping(timeDiffS);

--- a/physics-manager.js
+++ b/physics-manager.js
@@ -15,7 +15,7 @@ import {rigManager} from './rig.js';
 import {getPlayerCrouchFactor} from './character-controller.js';
 import metaversefileApi from './metaversefile-api.js';
 import {getNextPhysicsId, convertMeshToPhysicsMesh} from './util.js';
-import {world} from './world.js';
+// import {world} from './world.js';
 import {getVelocityDampingFactor} from './util.js';
 import {groundFriction} from './constants.js';
 
@@ -387,32 +387,13 @@ physicsManager.animals = animals; */
 const gravity = new THREE.Vector3(0, -9.8, 0);
 const _applyGravity = timeDiff => {
   if (rigManager.localRig) {
-    // let gliding;
     const localPlayer = metaversefileApi.useLocalPlayer();
     const isFlying = localPlayer.hasAction('fly');
     if (isFlying) {
       physicsManager.velocity.multiplyScalar(0.9);
-      // gliding = false;
     } else {
       localVector.copy(gravity)
         .multiplyScalar(timeDiff);
-
-      /* if (glideState && physicsManager.velocity.y < 0) {
-        const transforms = rigManager.getRigTransforms();
-
-        localVector
-          .add(
-            localVector2.copy(transforms[0].position)
-              .sub(transforms[1].position)
-              .normalize()
-              .applyQuaternion(leftQuaternion)
-              .multiplyScalar(3)
-          );
-        physicsManager.velocity.y *= 0.95;
-        gliding = true;
-      } else { */
-        // gliding = false;
-      // }
       physicsManager.velocity.add(localVector);
     }
   }
@@ -486,27 +467,6 @@ const _applyAvatarPhysics = (camera, avatarOffset, cameraBasedOffset, velocityAv
         localVector4.applyQuaternion(localQuaternion);
       }
       localVector.add(localVector4);
-      /* if (localVector.y < 0) {
-        let cancelled = false;
-        const e = new MessageEvent('voidout', {
-          data: {
-            cancel() {
-              cancelled = true;
-            },
-          },
-        });
-        physicsManager.dispatchEvent(e);
-        // console.log('default prevented', ignored);
-        if (!cancelled) {
-          // console.log('voided out');
-          const deltaY = -localVector.y + 1;
-          localVector.y += deltaY;
-          camera.position.y += deltaY;
-          camera.updateMatrixWorld();
-          
-          physicsManager.velocity.setScalar(0);
-        }
-      } */
       const collision = _collideCapsule(localVector, localQuaternion2.set(0, 0, 0, 1));
       
       // avatar facing direction

--- a/rig.js
+++ b/rig.js
@@ -78,22 +78,11 @@ class RigManager {
     this.scene = scene;
 
     this.localRig = null;
-    this.localRigMatrix = new THREE.Matrix4();
-    this.localRigMatrixEnabled = false;
     
     this.lastPosition = new THREE.Vector3();
     this.smoothVelocity = new THREE.Vector3();
 
     this.peerRigs = new Map();
-  }
-
-  setLocalRigMatrix(rm) {
-    if (rm) {
-      this.localRigMatrix.copy(rm);
-      this.localRigMatrixEnabled = true;
-    } else {
-      this.localRigMatrixEnabled = false;
-    }
   }
 
   async _switchAvatar(oldRig, newApp) {

--- a/rig.js
+++ b/rig.js
@@ -357,6 +357,13 @@ class RigManager {
       const _setTransforms = () => {
         let currentPosition, currentQuaternion;
         if (!session) {
+          this.localRig.inputs.hmd.position.copy(localPlayer.position);
+          this.localRig.inputs.hmd.quaternion.copy(localPlayer.quaternion);
+          this.localRig.inputs.leftGamepad.position.copy(localPlayer.leftHand.position);
+          this.localRig.inputs.leftGamepad.quaternion.copy(localPlayer.leftHand.quaternion);
+          this.localRig.inputs.rightGamepad.position.copy(localPlayer.rightHand.position);
+          this.localRig.inputs.rightGamepad.quaternion.copy(localPlayer.rightHand.quaternion);
+          
           currentPosition = this.localRig.inputs.hmd.position;
           currentQuaternion = this.localRig.inputs.hmd.quaternion;
         } else {

--- a/webaverse.js
+++ b/webaverse.js
@@ -41,8 +41,8 @@ import * as metaverseModules from './metaverse-modules.js';
 // import {WebaverseRenderPass} from './webaverse-render-pass.js';
 // import {parseQuery} from './util.js';
 
-const leftHandOffset = new THREE.Vector3(0.2, -0.2, -0.4);
-const rightHandOffset = new THREE.Vector3(-0.2, -0.2, -0.4);
+// const leftHandOffset = new THREE.Vector3(0.2, -0.2, -0.4);
+// const rightHandOffset = new THREE.Vector3(-0.2, -0.2, -0.4);
 
 const localVector = new THREE.Vector3();
 const localVector2 = new THREE.Vector3();
@@ -182,18 +182,11 @@ export default class Webaverse extends EventTarget {
     }
   }
   
-  injectRigInput() {
+  /* injectRigInput() {
     let leftGamepadPosition, leftGamepadQuaternion, leftGamepadPointer, leftGamepadGrip, leftGamepadEnabled;
     let rightGamepadPosition, rightGamepadQuaternion, rightGamepadPointer, rightGamepadGrip, rightGamepadEnabled;
 
-    if (rigManager.localRigMatrixEnabled) {
-      localMatrix.copy(rigManager.localRigMatrix);
-    } else {
-      localMatrix.copy(camera.matrixWorld);
-    }
-    localMatrix
-      .decompose(localVector, localQuaternion, localVector2);
-
+    const localPlayer = metaversefileApi.useLocalPlayer();
     const renderer = getRenderer();
     const session = renderer.xr.getSession();
     if (session) {
@@ -251,41 +244,26 @@ export default class Webaverse extends EventTarget {
       } else {
         rightGamepadEnabled = false;
       }
+    } else {
+      localMatrix.copy(localPlayer.matrixWorld)
+        .decompose(localVector, localQuaternion, localVector2);
     }
 
     const handOffsetScale = rigManager.localRig ? rigManager.localRig.height / 1.5 : 1;
     if (!leftGamepadPosition) {
-      // if (!physicsManager.getGlideState()) {
-        leftGamepadPosition = localVector2.copy(localVector)
-          .add(localVector3.copy(leftHandOffset).multiplyScalar(handOffsetScale).applyQuaternion(localQuaternion))
-          .toArray();
-        leftGamepadQuaternion = localQuaternion.toArray();
-      /* } else {
-        leftGamepadPosition = localVector2.copy(localVector)
-          .add(localVector3.copy(leftHandGlideOffset).multiplyScalar(handOffsetScale).applyQuaternion(localQuaternion))
-          .toArray();
-        leftGamepadQuaternion = localQuaternion2.copy(localQuaternion)
-          .premultiply(leftHandGlideQuaternion)
-          .toArray();
-      } */
+      leftGamepadPosition = localVector2.copy(localVector)
+        .add(localVector3.copy(leftHandOffset).multiplyScalar(handOffsetScale).applyQuaternion(localQuaternion))
+        .toArray();
+      leftGamepadQuaternion = localQuaternion.toArray();
       leftGamepadPointer = 0;
       leftGamepadGrip = 0;
       leftGamepadEnabled = false;
     }
     if (!rightGamepadPosition) {
-      // if (!physicsManager.getGlideState()) {
-        rightGamepadPosition = localVector2.copy(localVector)
-          .add(localVector3.copy(rightHandOffset).multiplyScalar(handOffsetScale).applyQuaternion(localQuaternion))
-          .toArray();
-        rightGamepadQuaternion = localQuaternion.toArray();
-      /* } else {
-        rightGamepadPosition = localVector2.copy(localVector)
-          .add(localVector3.copy(rightHandGlideOffset).multiplyScalar(handOffsetScale).applyQuaternion(localQuaternion))
-          .toArray();
-        rightGamepadQuaternion = localQuaternion2.copy(localQuaternion)
-          .premultiply(rightHandGlideQuaternion)
-          .toArray();
-      } */
+      rightGamepadPosition = localVector2.copy(localVector)
+        .add(localVector3.copy(rightHandOffset).multiplyScalar(handOffsetScale).applyQuaternion(localQuaternion))
+        .toArray();
+      rightGamepadQuaternion = localQuaternion.toArray();
       rightGamepadPointer = 0;
       rightGamepadGrip = 0;
       rightGamepadEnabled = false;
@@ -296,7 +274,7 @@ export default class Webaverse extends EventTarget {
       [leftGamepadPosition, leftGamepadQuaternion, leftGamepadPointer, leftGamepadGrip, leftGamepadEnabled],
       [rightGamepadPosition, rightGamepadQuaternion, rightGamepadPointer, rightGamepadGrip, rightGamepadEnabled],
     ]);
-  }
+  } */
   
   render(timestamp, timeDiff) {
     frameEvent.data.now = timestamp;
@@ -329,6 +307,8 @@ export default class Webaverse extends EventTarget {
       world.appManager.pretick(timestamp, frame);
 
       ioManager.update(timeDiffCapped);
+      // this.injectRigInput();
+      
       cameraManager.update(timeDiffCapped);
       
       // universe.update();
@@ -340,8 +320,6 @@ export default class Webaverse extends EventTarget {
       }
       
       characterController.update(timeDiffCapped);
-
-      this.injectRigInput();
 
       transformControls.update();
       game.update(timestamp, timeDiffCapped);

--- a/webaverse.js
+++ b/webaverse.js
@@ -25,6 +25,7 @@ import hpManager from './hp-manager.js';
 import equipmentRender from './equipment-render.js';
 import * as characterController from './character-controller.js';
 import * as postProcessing from './post-processing.js';
+// import metaversefileApi from './metaversefile-api.js';
 import {
   getRenderer,
   scene,


### PR DESCRIPTION
This PR moves the source of truth about avatar position to the `Player` instance. From there, it can be used in calculations or copied to the rig.

In addition to cleaning up the code, I think this removes a frame of input delay due to cleaner processing of the rig matrices.

Previously we were using separate matrices for this in different cases like VR. We should keep it in once place. Note that this creates a separation between the API (`Player`), animation (`Avatar`), and data (`y.js`/`state`) layers.

Soon we will probably merge the character controller and rig managers into a single "avatar manager".