### PR TITLE
Avatar first class citizens

### DIFF
--- a/app-manager.js
+++ b/app-manager.js
@@ -59,6 +59,14 @@ class AppManager extends EventTarget {
   setPushingLocalUpdates(pushingLocalUpdates) {
     this.pushingLocalUpdates = pushingLocalUpdates;
   }
+  getPeerOwnerAppManager(instanceId) {
+    for (const appManager of appManagers) {
+      if (appManager !== this && appManager.state === this.state && appManager.hasTrackedApp(instanceId)) {
+        return appManager;
+      }
+    }
+    return null;
+  }
   bindState(state) {
     const apps = state.getArray(this.prefix);
     let lastApps = [];

--- a/app-manager.js
+++ b/app-manager.js
@@ -408,18 +408,19 @@ class AppManager extends EventTarget {
     const appsJson = apps.toJSON();
     const removeIndex = appsJson.indexOf(removeInstanceId);
     if (removeIndex !== -1) {
-      const allRemoveIndices = [removeIndex];
-      for (const removeIndex of allRemoveIndices) {
+      // const allRemoveIndices = [removeIndex];
+      // for (const removeIndex of allRemoveIndices) {
         const instanceId = appsJson[removeIndex];
 
         apps.delete(removeIndex, 1);
 
-        const trackedApp = state.getMap(this.prefix + '.' + instanceId);
+        const trackedAppKey = this.prefix + '.' + instanceId;
+        const trackedApp = state.getMap(trackedAppKey);
         const keys = Array.from(trackedApp.keys());
         for (const key of keys) {
           trackedApp.delete(key);
         }
-      }
+      // }
     } else {
       console.warn('invalid remove instance id', {removeInstanceId, appsJson});
     }

--- a/app-manager.js
+++ b/app-manager.js
@@ -83,7 +83,7 @@ class AppManager extends EventTarget {
               // console.log('accept migration add', this.prefix, instanceId);
             } else {
               const trackedApp = this.getOrCreateTrackedApp(instanceId);
-              // console.log('detected add app', instanceId, trackedApp.toJSON());
+              // console.log('detected add app', instanceId, trackedApp.toJSON(), new Error().stack);
               this.dispatchEvent(new MessageEvent('trackedappadd', {
                 data: {
                   trackedApp,
@@ -102,6 +102,8 @@ class AppManager extends EventTarget {
             const peerOwnerAppManager = this.getPeerOwnerAppManager(instanceId);
             
             if (peerOwnerAppManager) {
+              // console.log('detected migrate app 1', instanceId, trackedApp.toJSON(), appManagers.length);
+              
               const e = new MessageEvent('trackedappmigrate', {
                 data: {
                   // instanceId,
@@ -362,6 +364,7 @@ class AppManager extends EventTarget {
     scale,
     components,
   ) {
+    // console.log('add tracked app internal', instanceId, contentId);
     const trackedApp = this.getOrCreateTrackedApp(instanceId);
     trackedApp.set('instanceId', instanceId);
     trackedApp.set('contentId', contentId);
@@ -403,6 +406,7 @@ class AppManager extends EventTarget {
     }
   }
   removeTrackedAppInternal(removeInstanceId) {
+    // console.log('remove tracked app internal', removeInstanceId);
     const {state} = this;
     const apps = state.getArray(this.prefix);
     const appsJson = apps.toJSON();

--- a/app-manager.js
+++ b/app-manager.js
@@ -99,33 +99,22 @@ class AppManager extends EventTarget {
             
             const app = this.getAppByInstanceId(instanceId);
             let migrated = false;
-            for (const appManager of appManagers) {
-              if (appManager !== this && appManager.state === this.state) {
-                const trackedPeerApp = appManager.getTrackedApp(instanceId);
-                if (trackedPeerApp) {
-                  /* console.log('detected migrate', {
-                    instanceId,
-                    trackedApp,
-                    app,
-                    sourceAppManager: this.prefix,
-                    destinationAppManager: appManager.prefix,
-                  }); */
-                  
-                  const e = new MessageEvent('trackedappmigrate', {
-                    data: {
-                      instanceId,
-                      trackedApp,
-                      app,
-                      sourceAppManager: this,
-                      destinationAppManager: appManager,
-                    },
-                  });
-                  this.dispatchEvent(e);
-                  appManager.dispatchEvent(e);
-                  migrated = true;
-                  break;
-                }
-              }
+            const peerOwnerAppManager = this.getPeerOwnerAppManager(instanceId);
+            
+            if (peerOwnerAppManager) {
+              const e = new MessageEvent('trackedappmigrate', {
+                data: {
+                  // instanceId,
+                  // trackedApp,
+                  app,
+                  sourceAppManager: this,
+                  destinationAppManager: peerOwnerAppManager,
+                },
+              });
+              this.dispatchEvent(e);
+              peerOwnerAppManager.dispatchEvent(e);
+              migrated = true;
+              break;
             }
             
             // console.log('detected remove app 2', instanceId, trackedApp.toJSON(), appManagers.length);
@@ -287,8 +276,8 @@ class AppManager extends EventTarget {
     });
     this.addEventListener('trackedappmigrate', async e => {
       const {
-        instanceId,
-        trackedApp,
+        // instanceId,
+        // trackedApp,
         app,
         sourceAppManager,
         destinationAppManager,

--- a/app-manager.js
+++ b/app-manager.js
@@ -11,7 +11,7 @@ import {makePromise, getRandomString} from './util.js';
 import physicsManager from './physics-manager.js';
 import metaversefile from './metaversefile-api.js';
 import * as metaverseModules from './metaverse-modules.js';
-import {appsMapName} from './constants.js';
+import {worldMapName} from './constants.js';
 
 const localVector = new THREE.Vector3();
 const localVector2 = new THREE.Vector3();
@@ -28,7 +28,7 @@ const localFrameOpts = {
 
 const appManagers = [];
 class AppManager extends EventTarget {
-  constructor({prefix = appsMapName, state = new Y.Doc(), apps = []} = {}) {
+  constructor({prefix = worldMapName, state = new Y.Doc(), apps = []} = {}) {
     super();
     
     this.prefix = prefix;

--- a/app-manager.js
+++ b/app-manager.js
@@ -106,8 +106,6 @@ class AppManager extends EventTarget {
               
               const e = new MessageEvent('trackedappmigrate', {
                 data: {
-                  // instanceId,
-                  // trackedApp,
                   app,
                   sourceAppManager: this,
                   destinationAppManager: peerOwnerAppManager,
@@ -278,8 +276,6 @@ class AppManager extends EventTarget {
     });
     this.addEventListener('trackedappmigrate', async e => {
       const {
-        // instanceId,
-        // trackedApp,
         app,
         sourceAppManager,
         destinationAppManager,

--- a/character-controller.js
+++ b/character-controller.js
@@ -96,11 +96,14 @@ class Player extends THREE.Object3D {
     'fly',
     'sit',
   ]
-  getActions() {
-    return this.state.getArray(actionsMapName);
+  getActionsState() {
+    return this.state.getArray(this.prefix + '.' + actionsMapName);
+  }
+  getAvatarState() {
+    return this.state.getMap(this.prefix + '.' + avatarMapName);
   }
   findAction(fn) {
-    const actions = this.getActions();
+    const actions = this.getActionsState();
     for (const action of actions) {
       if (fn(action)) {
         return action;
@@ -109,7 +112,7 @@ class Player extends THREE.Object3D {
     return null;
   }
   findActionIndex(fn) {
-    const actions = this.getActions();
+    const actions = this.getActionsState();
     let i = 0;
     for (const action of actions) {
       if (fn(action)) {
@@ -120,7 +123,7 @@ class Player extends THREE.Object3D {
     return -1;
   }
   getAction(type) {
-    const actions = this.getActions();
+    const actions = this.getActionsState();
     for (const action of actions) {
       if (action.type === type) {
         return action;
@@ -129,7 +132,7 @@ class Player extends THREE.Object3D {
     return null;
   }
   getActionIndex(type) {
-    const actions = this.getActions();
+    const actions = this.getActionsState();
     let i = 0;
     for (const action of actions) {
       if (action.type === type) {
@@ -140,7 +143,7 @@ class Player extends THREE.Object3D {
     return -1;
   }
   indexOfAction(action) {
-    const actions = this.getActions();
+    const actions = this.getActionsState();
     let i = 0;
     for (const a of actions) {
       if (a === action) {
@@ -151,7 +154,7 @@ class Player extends THREE.Object3D {
     return -1;
   }
   hasAction(type) {
-    const actions = this.getActions();
+    const actions = this.getActionsState();
     for (const action of actions) {
       if (action.type === type) {
         return true;
@@ -162,10 +165,10 @@ class Player extends THREE.Object3D {
   addAction(action) {
     action = clone(action);
     action.actionId = makeId(5);
-    this.getActions().push([action]);
+    this.getActionsState().push([action]);
   }
   removeAction(type) {
-    const actions = this.getActions();
+    const actions = this.getActionsState();
     let i = 0;
     for (const action of actions) {
       if (action.type === type) {
@@ -176,10 +179,10 @@ class Player extends THREE.Object3D {
     }
   }
   removeActionIndex(index) {
-    this.getActions().delete(index);
+    this.getActionsState().delete(index);
   }
   setControlAction(action) {
-    const actions = this.getActions();
+    const actions = this.getActionsState();
     for (let i = 0; i < actions.length; i++) {
       const action = actions.get(i);
       const isControlAction = Player.controlActionTypes.includes(action.type);
@@ -302,7 +305,7 @@ class LocalPlayer extends Player {
     }
   }
   ungrab() {
-    const actions = Array.from(this.getActions());
+    const actions = Array.from(this.getActionsState());
     let removeOffset = 0;
     for (let i = 0; i < actions.length; i++) {
       const action = actions[i];

--- a/character-controller.js
+++ b/character-controller.js
@@ -40,6 +40,7 @@ class Player extends THREE.Object3D {
     this.appManager = new AppManager({
       prefix,
       state,
+      autoSceneManagement: false,
     });
 
     this.leftHand = new PlayerHand();

--- a/character-controller.js
+++ b/character-controller.js
@@ -193,6 +193,10 @@ class Player extends THREE.Object3D {
     }
     actions.push([action]);
   }
+  destroy() {
+    this.cleanup();
+    this.appManager.destroy();
+  }
 }
 class LocalPlayer extends Player {
   constructor(opts) {
@@ -378,9 +382,6 @@ class LocalPlayer extends Player {
       physicsManager.velocity.set(0, 0, 0);
     };
   })()
-  destroy() {
-    this.cleanup();
-  }
 }
 class RemotePlayer extends Player {
   constructor(opts) {

--- a/character-controller.js
+++ b/character-controller.js
@@ -375,6 +375,9 @@ class LocalPlayer extends Player {
       physicsManager.velocity.set(0, 0, 0);
     };
   })()
+  destroy() {
+    this.cleanup();
+  }
 }
 class RemotePlayer extends Player {
   constructor(opts) {

--- a/character-controller.js
+++ b/character-controller.js
@@ -106,8 +106,6 @@ class Player extends THREE.Object3D {
       if (lastAvatarInstanceId !== instanceId) {
         lastAvatarInstanceId = instanceId;
         
-        window.lastAvatarApp = lastAvatarApp;
-        
         // remove last app
         if (lastAvatarApp) {
           const oldPeerOwnerAppManager = this.appManager.getPeerOwnerAppManager(lastAvatarApp.instanceId);

--- a/character-controller.js
+++ b/character-controller.js
@@ -89,7 +89,6 @@ class Player extends THREE.Object3D {
     actions.observe(observeActionsFn);
     
     const avatar = this.getAvatarState();
-    let lastAvatarContentId = '';
     let lastAvatarInstanceId = '';
     let lastAvatarApp = null;
     let observeAvatarEpoch = 0;

--- a/character-controller.js
+++ b/character-controller.js
@@ -11,7 +11,7 @@ import {world} from './world.js';
 import cameraManager from './camera-manager.js';
 import physx from './physx.js';
 import metaversefile from './metaversefile-api.js';
-import {actionsMapName, crouchMaxTime, activateMaxTime, useMaxTime} from './constants.js';
+import {actionsMapName, avatarMapName, crouchMaxTime, activateMaxTime, useMaxTime} from './constants.js';
 import {AppManager} from './app-manager.js';
 import {BiActionInterpolant, UniActionInterpolant, InfiniteActionInterpolant} from './interpolants.js';
 import {getState, setState} from './state.js';
@@ -59,10 +59,10 @@ class Player extends THREE.Object3D {
       throw: new InfiniteActionInterpolant(() => this.hasAction('throw'), 0),
     };
     
-    const actions = this.getActions();
+    const actions = this.getActionsState();
     let lastActions = [];
-    const observe = () => {
-      const nextActions = Array.from(this.getActions());
+    const observeActionsFn = () => {
+      const nextActions = Array.from(this.getActionsState());
       for (const nextAction of nextActions) {
         if (!lastActions.some(lastAction => lastAction.actionId === nextAction.actionId)) {
           this.dispatchEvent({
@@ -84,8 +84,11 @@ class Player extends THREE.Object3D {
       // console.log('actions changed');
       lastActions = nextActions;
     };
-    actions.observe(observe);
-    actions.unobserve = actions.unobserve.bind(actions, observe);
+    actions.observe(observeActionsFn);
+  
+    this.cleanup = () => {
+      actions.unobserve(observeActionsFn);
+    };
   }
   static controlActionTypes = [
     'jump',

--- a/constants.js
+++ b/constants.js
@@ -46,7 +46,7 @@ export const worldUrl = 'worlds.webaverse.com';
 
 export const worldMapName = 'world';
 export const actionsMapName = 'actions';
-export const avatarMapName = 'avatars';
+export const avatarMapName = 'avatar';
 
 export const ceramicNodeUrl = `https://ceramic-clay.3boxlabs.com`;
 export const metaverseProfileDefinition = `kjzl6cwe1jw145wm7u2sy1wpa33hglvmuy6th9lys7x4iadaizn4zqgpp3tmu34`;

--- a/constants.js
+++ b/constants.js
@@ -44,7 +44,7 @@ export const web3MainnetSidechainEndpoint = 'https://mainnetsidechain.exokit.org
 export const web3TestnetSidechainEndpoint = 'https://testnetsidechain.exokit.org';
 export const worldUrl = 'worlds.webaverse.com';
 
-export const appsMapName = 'apps';
+export const worldMapName = 'world';
 export const actionsMapName = 'actions';
 export const avatarMapName = 'avatars';
 

--- a/constants.js
+++ b/constants.js
@@ -46,6 +46,7 @@ export const worldUrl = 'worlds.webaverse.com';
 
 export const appsMapName = 'apps';
 export const actionsMapName = 'actions';
+export const avatarMapName = 'avatars';
 
 export const ceramicNodeUrl = `https://ceramic-clay.3boxlabs.com`;
 export const metaverseProfileDefinition = `kjzl6cwe1jw145wm7u2sy1wpa33hglvmuy6th9lys7x4iadaizn4zqgpp3tmu34`;

--- a/equipment-render.js
+++ b/equipment-render.js
@@ -55,13 +55,14 @@ class EquipmentRender {
     this.previewRenderer.xr.enabled = true;
 
     let avatar = null;
-    world.appManager.addEventListener('avatarupdate', (e) => {
+    const localPlayer = metaversefile.useLocalPlayer();
+    localPlayer.addEventListener('avatarupdate', e => {
       if (avatar) {
         avatar.parent.remove(avatar);
         avatar = null;
       }
       
-      const newAvatar = e.data.app.clone();
+      const newAvatar = e.app.clone();
 
       newAvatar.position.set(0, 0, 0);
       newAvatar.rotation.set(0, 0, 0);

--- a/game.js
+++ b/game.js
@@ -326,7 +326,7 @@ const _click = () => {
 let lastPistolUseStartTime = -Infinity;
 const _startUse = () => {
   const localPlayer = useLocalPlayer();
-  const wearApps = Array.from(localPlayer.getActions())
+  const wearApps = Array.from(localPlayer.getActionsState())
     .filter(action => action.type === 'wear')
     .map(({instanceId}) => metaversefileApi.getAppByInstanceId(instanceId));
   for (const wearApp of wearApps) {
@@ -1534,7 +1534,7 @@ const gameManager = {
     const localPlayer = useLocalPlayer();
     const jumpAction = localPlayer.getAction('jump');
     
-    const wearActions = Array.from(localPlayer.getActions()).filter(action => action.type === 'wear');
+    const wearActions = Array.from(localPlayer.getActionsState()).filter(action => action.type === 'wear');
     for (const wearAction of wearActions) {
       const instanceId = wearAction.instanceId;
       const app = metaversefileApi.getAppByInstanceId(instanceId);

--- a/rig.js
+++ b/rig.js
@@ -155,7 +155,7 @@ class RigManager {
       const _setIkModes = () => {
         const aimAction = localPlayer.getAction('aim');
         const aimComponent = (() => {
-          for (const action of localPlayer.getActions()) {
+          for (const action of localPlayer.getActionsState()) {
             if (action.type === 'wear') {
               const app = metaversefile.getAppByInstanceId(action.instanceId);
               for (const {key, value} of app.components) {
@@ -187,7 +187,7 @@ class RigManager {
       applyPlayerActionsToAvatar(localPlayer, this.localRig);
       
       const _applyChatModifiers = () => {
-        const localPlayerChatActions = Array.from(localPlayer.getActions()).filter(action => action.type === 'chat');
+        const localPlayerChatActions = Array.from(localPlayer.getActionsState()).filter(action => action.type === 'chat');
         const lastMessage = localPlayerChatActions.length > 0 ? localPlayerChatActions[localPlayerChatActions.length - 1] : null;
         const _applyChatEmote = message => {
           const localPlayerEmotion = message?.emotion;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -23,14 +23,9 @@ const _startApp = async (weba, canvas) => {
   universe.handleUrlUpdate();
   await weba.startLoop();
   
-  {
-    const defaultAvatarUrl = './avatars/citrine.vrm';
-    const contentId = defaultAvatarUrl;
-    const avatarApp = await metaversefileApi.load(contentId);
-    avatarApp.instanceId = metaversefileApi.getNextInstanceId();
-    const localPlayer = useLocalPlayer();
-    localPlayer.setAvatar(avatarApp);
-  }
+  const defaultAvatarUrl = './avatars/citrine.vrm';
+  const localPlayer = metaversefileApi.useLocalPlayer();
+  await localPlayer.setAvatarUrl(defaultAvatarUrl);
 };
 
 const Crosshair = () => (

--- a/src/Chat.jsx
+++ b/src/Chat.jsx
@@ -130,7 +130,7 @@ function ChatMessages() {
     const update = () => {
       const newMessageGroups = [];
       
-      const localPlayerChatMessages = Array.from(localPlayer.getActions()).filter(action => action.type === 'chat');
+      const localPlayerChatMessages = Array.from(localPlayer.getActionsState()).filter(action => action.type === 'chat');
       if (localPlayerChatMessages.length > 0) {
         const localPlayerMessageGroup = {
           player: localPlayer,

--- a/src/Header.jsx
+++ b/src/Header.jsx
@@ -301,7 +301,7 @@ export default function Header({
   app,
 }) {
   
-  const _getWearActions = () => Array.from(localPlayer.getActions()).filter(action => action.type === 'wear');
+  const _getWearActions = () => Array.from(localPlayer.getActionsState()).filter(action => action.type === 'wear');
   
 	// console.log('index 2');
   const previewCanvasRef = useRef();

--- a/world.js
+++ b/world.js
@@ -11,13 +11,13 @@ import {AppManager} from './app-manager.js';
 import {getState, setState} from './state.js';
 import {makeId} from './util.js';
 import metaversefileApi from './metaversefile-api.js';
-import {appsMapName} from './constants.js';
+import {worldMapName} from './constants.js';
 
 // world
 export const world = {};
 
 const appManager = new AppManager({
-  prefix: appsMapName,
+  prefix: worldMapName,
   state: getState(),
 });
 world.appManager = appManager;


### PR DESCRIPTION
This PR makes avatar objects first class citizens in the world, following world object rules.

We use the automatic transactional app transplant logic to move the ownership of avatars between world and player context, so it is kept track of for multiplayer/world crossing. Additionally, we try to make the logic robust against player state conflicts (two players try to wear the same avatar).