### PR TITLE
Remove old custom scene priority hook

### DIFF
--- a/app-manager.js
+++ b/app-manager.js
@@ -243,14 +243,14 @@ class AppManager extends EventTarget {
         
         this.addApp(app);
 
-        const _bindRender = () => {
+        /* const _bindRender = () => {
           // unFrustumCull(app);
 
           if (app.renderOrder === -Infinity) {
             sceneHighPriority.add(app);
           }
         };
-        _bindRender();
+        _bindRender(); */
 
         this.bindTrackedApp(trackedApp, app);
 


### PR DESCRIPTION
This was previously used by some apps to determine render priority, but that has now moved to the `renderPriority` component which any app can set: https://github.com/webaverse/app/blob/f1f063c4470557c4b28effe04e175792fd008dc6/app-manager.js#L449

This removes a hack respecting the old API. Going through PR in case it seriously breaks some app (in which case it should be updated to the new API).