### PR TITLE
Clean up tick flow

### DIFF
--- a/app-manager.js
+++ b/app-manager.js
@@ -42,7 +42,7 @@ class AppManager extends EventTarget {
     
     this.pendingAddPromises = new Map();
     this.pushingLocalUpdates = false;
-    this.lastTimestamp = performance.now();
+    // this.lastTimestamp = performance.now();
     this.autoSceneManagement = autoSceneManagement;
     // this.stateBlindMode = false;
     this.unbindStateFn = null;
@@ -53,15 +53,18 @@ class AppManager extends EventTarget {
   
     appManagers.push(this);
   }
-  pretick(timestamp, frame) {
+  /* pretick(timestamp, frame) {
     localData.timestamp = timestamp;
     localData.frame = frame;
     localData.timeDiff = timestamp - this.lastTimestamp;
     this.lastTimestamp = timestamp;
     this.dispatchEvent(new MessageEvent('preframe', localFrameOpts));
-  }
-  tick(timestamp, frame) {
-    // this.dispatchEvent(new MessageEvent('startframe', localFrameOpts));
+  } */
+  tick(timestamp, timeDiff, frame) {
+    // this.timeDiff(new MessageEvent('startframe', localFrameOpts));
+    localData.timestamp = timestamp;
+    localData.frame = frame;
+    localData.timeDiff = timeDiff;
     this.dispatchEvent(new MessageEvent('frame', localFrameOpts));
   }
   setPushingLocalUpdates(pushingLocalUpdates) {

--- a/webaverse.js
+++ b/webaverse.js
@@ -285,7 +285,7 @@ export default class Webaverse extends EventTarget {
       const timeDiffCapped = Math.min(Math.max(timeDiff, 0), 100);
       lastTimestamp = timestamp;
       
-      world.appManager.pretick(timestamp, frame);
+      // world.appManager.pretick(timestamp, frame);
 
       ioManager.update(timeDiffCapped);
       // this.injectRigInput();
@@ -307,7 +307,7 @@ export default class Webaverse extends EventTarget {
       const localPlayer = metaversefileApi.useLocalPlayer();
       localPlayer.update(timestamp, timeDiffCapped);
       
-      world.appManager.tick(timestamp, frame);
+      world.appManager.tick(timestamp, timeDiffCapped, frame);
 
       hpManager.update(timestamp, timeDiffCapped);
 


### PR DESCRIPTION
This PR gets rid of `pretick` and instead sets the frame data from `tick`.

It also fixes a bug in which the tick time was doubly tracked, leading to possible rendering inconsistencies. The timing is now sourced from the top render loop.