### PR TITLE
Remove originalJson tracking

### DIFF
--- a/app-manager.js
+++ b/app-manager.js
@@ -409,8 +409,8 @@ class AppManager extends EventTarget {
     trackedApp.set('quaternion', quaternion);
     trackedApp.set('scale', scale);
     trackedApp.set('components', JSON.stringify(components));
-    const originalJson = trackedApp.toJSON();
-    trackedApp.set('originalJson', JSON.stringify(originalJson));
+    // const originalJson = trackedApp.toJSON();
+    // trackedApp.set('originalJson', JSON.stringify(originalJson));
     return trackedApp;
   }
   addTrackedApp(


### PR DESCRIPTION
This used to be for scene reload support but I don't think it's used anymore; it's just wasting space in `yjs`...