### PR TITLE
Multiplayer avatar interpolation

### DIFF
--- a/avatars/avatars.js
+++ b/avatars/avatars.js
@@ -40,13 +40,13 @@ VRMSpringBoneImporter.prototype._createSpringBone = (_createSpringBone => {
       get() {
         localVector.set(physicsManager.velocity.x, 0, physicsManager.velocity.z);
         const f = Math.pow(Math.min(Math.max(localVector.length()*2 - Math.abs(physicsManager.velocity.y)*0.5, 0), 4), 2);
-        return initialStiffnessForce * (0.05 + 0.1*f);
+        return initialStiffnessForce * (0.1 + 0.1*f);
       },
       set(v) {},
     });
     Object.defineProperty(bone, 'dragForce', {
       get() {
-        return initialDragForce * 0.75;
+        return initialDragForce * 0.7;
       },
       set(v) {},
     });

--- a/character-controller.js
+++ b/character-controller.js
@@ -55,101 +55,7 @@ class PlayerHand extends THREE.Object3D {
     this.enabled = false;
   }
 }
-class InterpolatedPlayer extends THREE.Object3D {
-  constructor() {
-    super();
-    
-    this.positionInterpolant = new PositionInterpolant(() => this.getPosition(), avatarInterpolationTimeDelay, avatarInterpolationNumFrames);
-    this.quaternionInterpolant = new QuaternionInterpolant(() => this.getQuaternion(), avatarInterpolationTimeDelay, avatarInterpolationNumFrames);
-    this.positionTimeStep = new FixedTimeStep(timeDiff => {
-      this.positionInterpolant.snapshot(timeDiff);
-    }, avatarInterpolationFrameRate);
-    this.quaternionTimeStep = new FixedTimeStep(timeDiff => {
-      this.quaternionInterpolant.snapshot(timeDiff);
-    }, avatarInterpolationFrameRate);
-    
-    this.actionBinaryInterpolants = {
-      crouch: new BinaryInterpolant(() => this.hasAction('crouch'), avatarInterpolationTimeDelay, avatarInterpolationNumFrames),
-      activate: new BinaryInterpolant(() => this.hasAction('activate'), avatarInterpolationTimeDelay, avatarInterpolationNumFrames),
-      use: new BinaryInterpolant(() => this.hasAction('use'), avatarInterpolationTimeDelay, avatarInterpolationNumFrames),
-      narutoRun: new BinaryInterpolant(() => this.hasAction('narutoRun'), avatarInterpolationTimeDelay, avatarInterpolationNumFrames),
-      fly: new BinaryInterpolant(() => this.hasAction('fly'), avatarInterpolationTimeDelay, avatarInterpolationNumFrames),
-      jump: new BinaryInterpolant(() => this.hasAction('jump'), avatarInterpolationTimeDelay, avatarInterpolationNumFrames),
-      dance: new BinaryInterpolant(() => this.hasAction('dance'), avatarInterpolationTimeDelay, avatarInterpolationNumFrames),
-      throw: new BinaryInterpolant(() => this.hasAction('throw'), avatarInterpolationTimeDelay, avatarInterpolationNumFrames),
-    };
-    this.actionBinaryInterpolantsArray = Object.keys(this.actionBinaryInterpolants).map(k => this.actionBinaryInterpolants[k]);
-    this.actionBinaryTimeSteps = {
-      crouch: new FixedTimeStep(timeDiff => {this.actionBinaryInterpolants.crouch.snapshot(timeDiff);}, avatarInterpolationFrameRate),
-      activate: new FixedTimeStep(timeDiff => {this.actionBinaryInterpolants.activate.snapshot(timeDiff);}, avatarInterpolationFrameRate),
-      use: new FixedTimeStep(timeDiff => {this.actionBinaryInterpolants.use.snapshot(timeDiff);}, avatarInterpolationFrameRate),
-      narutoRun: new FixedTimeStep(timeDiff => {this.actionBinaryInterpolants.narutoRun.snapshot(timeDiff);}, avatarInterpolationFrameRate),
-      fly: new FixedTimeStep(timeDiff => {this.actionBinaryInterpolants.fly.snapshot(timeDiff);}, avatarInterpolationFrameRate),
-      jump: new FixedTimeStep(timeDiff => {this.actionBinaryInterpolants.jump.snapshot(timeDiff);}, avatarInterpolationFrameRate),
-      dance: new FixedTimeStep(timeDiff => {this.actionBinaryInterpolants.dance.snapshot(timeDiff);}, avatarInterpolationFrameRate),
-      throw: new FixedTimeStep(timeDiff => {this.actionBinaryInterpolants.throw.snapshot(timeDiff);}, avatarInterpolationFrameRate),
-    };
-    this.actionBinaryTimeStepsArray = Object.keys(this.actionBinaryTimeSteps).map(k => this.actionBinaryTimeSteps[k]);
-    this.actionInterpolants = {
-      crouch: new BiActionInterpolant(() => this.actionBinaryInterpolants.crouch.get(), 0, crouchMaxTime),
-      activate: new UniActionInterpolant(() => this.actionBinaryInterpolants.activate.get(), 0, activateMaxTime),
-      use: new InfiniteActionInterpolant(() => this.actionBinaryInterpolants.use.get(), 0),
-      narutoRun: new InfiniteActionInterpolant(() => this.actionBinaryInterpolants.narutoRun.get(), 0),
-      fly: new InfiniteActionInterpolant(() => this.actionBinaryInterpolants.fly.get(), 0),
-      jump: new InfiniteActionInterpolant(() => this.actionBinaryInterpolants.jump.get(), 0),
-      dance: new InfiniteActionInterpolant(() => this.actionBinaryInterpolants.dance.get(), 0),
-      throw: new InfiniteActionInterpolant(() => this.actionBinaryInterpolants.throw.get(), 0),
-    };
-    this.actionInterpolantsArray = Object.keys(this.actionInterpolants).map(k => this.actionInterpolants[k]);
-    
-    this.avatarBinding = {
-      position: this.positionInterpolant.get(),
-      quaternion: this.quaternionInterpolant.get(),
-    };
-  }
-  updateInterpolation(timeDiff) {
-    this.positionTimeStep.update(timeDiff);
-    this.quaternionTimeStep.update(timeDiff);
-    
-    this.positionInterpolant.update(timeDiff);
-    this.quaternionInterpolant.update(timeDiff);
-    
-    for (const actionInterpolantTimeStep of this.actionBinaryTimeStepsArray) {
-      actionInterpolantTimeStep.update(timeDiff);
-    }
-    for (const actionBinaryInterpolant of this.actionBinaryInterpolantsArray) {
-      actionBinaryInterpolant.update(timeDiff);
-    }
-    for (const actionInterpolant of this.actionInterpolantsArray) {
-      actionInterpolant.update(timeDiff);
-    }
-  }
-}
-class UninterpolatedPlayer extends THREE.Object3D {
-  constructor() {
-    super();
-    
-    this.actionInterpolants = {
-      crouch: new BiActionInterpolant(() => this.hasAction('crouch'), 0, crouchMaxTime),
-      activate: new UniActionInterpolant(() => this.hasAction('activate'), 0, activateMaxTime),
-      use: new InfiniteActionInterpolant(() => this.hasAction('use'), 0),
-      narutoRun: new InfiniteActionInterpolant(() => this.hasAction('narutoRun'), 0),
-      fly: new InfiniteActionInterpolant(() => this.hasAction('fly'), 0),
-      jump: new InfiniteActionInterpolant(() => this.hasAction('jump'), 0),
-      dance: new InfiniteActionInterpolant(() => this.hasAction('dance'), 0),
-      throw: new InfiniteActionInterpolant(() => this.hasAction('throw'), 0),
-    };
-
-    this.avatarBinding = {
-      position: this.position,
-      quaternion: this.quaternion,
-    };
-  }
-  updateInterpolation(timeDiff) {
-    // nothing
-  }
-}
-class Player extends UninterpolatedPlayer {
+class Player extends THREE.Object3D {
   constructor({
     playerId = makeId(5),
     playersArray = new Y.Doc().getArray(playersMapName),
@@ -564,7 +470,104 @@ class Player extends UninterpolatedPlayer {
     this.appManager.destroy();
   }
 }
-class LocalPlayer extends Player {
+class InterpolatedPlayer extends Player {
+  constructor(opts) {
+    super(opts);
+    
+    this.positionInterpolant = new PositionInterpolant(() => this.getPosition(), avatarInterpolationTimeDelay, avatarInterpolationNumFrames);
+    this.quaternionInterpolant = new QuaternionInterpolant(() => this.getQuaternion(), avatarInterpolationTimeDelay, avatarInterpolationNumFrames);
+    this.positionTimeStep = new FixedTimeStep(timeDiff => {
+      this.positionInterpolant.snapshot(timeDiff);
+    }, avatarInterpolationFrameRate);
+    this.quaternionTimeStep = new FixedTimeStep(timeDiff => {
+      this.quaternionInterpolant.snapshot(timeDiff);
+    }, avatarInterpolationFrameRate);
+    
+    this.actionBinaryInterpolants = {
+      crouch: new BinaryInterpolant(() => this.hasAction('crouch'), avatarInterpolationTimeDelay, avatarInterpolationNumFrames),
+      activate: new BinaryInterpolant(() => this.hasAction('activate'), avatarInterpolationTimeDelay, avatarInterpolationNumFrames),
+      use: new BinaryInterpolant(() => this.hasAction('use'), avatarInterpolationTimeDelay, avatarInterpolationNumFrames),
+      narutoRun: new BinaryInterpolant(() => this.hasAction('narutoRun'), avatarInterpolationTimeDelay, avatarInterpolationNumFrames),
+      fly: new BinaryInterpolant(() => this.hasAction('fly'), avatarInterpolationTimeDelay, avatarInterpolationNumFrames),
+      jump: new BinaryInterpolant(() => this.hasAction('jump'), avatarInterpolationTimeDelay, avatarInterpolationNumFrames),
+      dance: new BinaryInterpolant(() => this.hasAction('dance'), avatarInterpolationTimeDelay, avatarInterpolationNumFrames),
+      throw: new BinaryInterpolant(() => this.hasAction('throw'), avatarInterpolationTimeDelay, avatarInterpolationNumFrames),
+    };
+    this.actionBinaryInterpolantsArray = Object.keys(this.actionBinaryInterpolants).map(k => this.actionBinaryInterpolants[k]);
+    this.actionBinaryTimeSteps = {
+      crouch: new FixedTimeStep(timeDiff => {this.actionBinaryInterpolants.crouch.snapshot(timeDiff);}, avatarInterpolationFrameRate),
+      activate: new FixedTimeStep(timeDiff => {this.actionBinaryInterpolants.activate.snapshot(timeDiff);}, avatarInterpolationFrameRate),
+      use: new FixedTimeStep(timeDiff => {this.actionBinaryInterpolants.use.snapshot(timeDiff);}, avatarInterpolationFrameRate),
+      narutoRun: new FixedTimeStep(timeDiff => {this.actionBinaryInterpolants.narutoRun.snapshot(timeDiff);}, avatarInterpolationFrameRate),
+      fly: new FixedTimeStep(timeDiff => {this.actionBinaryInterpolants.fly.snapshot(timeDiff);}, avatarInterpolationFrameRate),
+      jump: new FixedTimeStep(timeDiff => {this.actionBinaryInterpolants.jump.snapshot(timeDiff);}, avatarInterpolationFrameRate),
+      dance: new FixedTimeStep(timeDiff => {this.actionBinaryInterpolants.dance.snapshot(timeDiff);}, avatarInterpolationFrameRate),
+      throw: new FixedTimeStep(timeDiff => {this.actionBinaryInterpolants.throw.snapshot(timeDiff);}, avatarInterpolationFrameRate),
+    };
+    this.actionBinaryTimeStepsArray = Object.keys(this.actionBinaryTimeSteps).map(k => this.actionBinaryTimeSteps[k]);
+    this.actionInterpolants = {
+      crouch: new BiActionInterpolant(() => this.actionBinaryInterpolants.crouch.get(), 0, crouchMaxTime),
+      activate: new UniActionInterpolant(() => this.actionBinaryInterpolants.activate.get(), 0, activateMaxTime),
+      use: new InfiniteActionInterpolant(() => this.actionBinaryInterpolants.use.get(), 0),
+      narutoRun: new InfiniteActionInterpolant(() => this.actionBinaryInterpolants.narutoRun.get(), 0),
+      fly: new InfiniteActionInterpolant(() => this.actionBinaryInterpolants.fly.get(), 0),
+      jump: new InfiniteActionInterpolant(() => this.actionBinaryInterpolants.jump.get(), 0),
+      dance: new InfiniteActionInterpolant(() => this.actionBinaryInterpolants.dance.get(), 0),
+      throw: new InfiniteActionInterpolant(() => this.actionBinaryInterpolants.throw.get(), 0),
+    };
+    this.actionInterpolantsArray = Object.keys(this.actionInterpolants).map(k => this.actionInterpolants[k]);
+    
+    this.avatarBinding = {
+      position: this.positionInterpolant.get(),
+      quaternion: this.quaternionInterpolant.get(),
+    };
+  }
+  updateInterpolation(timeDiff) {
+    this.positionTimeStep.update(timeDiff);
+    this.quaternionTimeStep.update(timeDiff);
+    
+    this.positionInterpolant.update(timeDiff);
+    this.quaternionInterpolant.update(timeDiff);
+    
+    for (const actionInterpolantTimeStep of this.actionBinaryTimeStepsArray) {
+      actionInterpolantTimeStep.update(timeDiff);
+    }
+    for (const actionBinaryInterpolant of this.actionBinaryInterpolantsArray) {
+      actionBinaryInterpolant.update(timeDiff);
+    }
+    for (const actionInterpolant of this.actionInterpolantsArray) {
+      actionInterpolant.update(timeDiff);
+    }
+  }
+}
+class UninterpolatedPlayer extends Player {
+  constructor(opts) {
+    super(opts);
+    
+    this.actionInterpolants = {
+      crouch: new BiActionInterpolant(() => this.hasAction('crouch'), 0, crouchMaxTime),
+      activate: new UniActionInterpolant(() => this.hasAction('activate'), 0, activateMaxTime),
+      use: new InfiniteActionInterpolant(() => this.hasAction('use'), 0),
+      narutoRun: new InfiniteActionInterpolant(() => this.hasAction('narutoRun'), 0),
+      fly: new InfiniteActionInterpolant(() => this.hasAction('fly'), 0),
+      jump: new InfiniteActionInterpolant(() => this.hasAction('jump'), 0),
+      dance: new InfiniteActionInterpolant(() => this.hasAction('dance'), 0),
+      throw: new InfiniteActionInterpolant(() => this.hasAction('throw'), 0),
+    };
+    this.actionInterpolantsArray = Object.keys(this.actionInterpolants).map(k => this.actionInterpolants[k]);
+
+    this.avatarBinding = {
+      position: this.position,
+      quaternion: this.quaternion,
+    };
+  }
+  updateInterpolation(timeDiff) {
+    for (const actionInterpolant of this.actionInterpolantsArray) {
+      actionInterpolant.update(timeDiff);
+    }
+  }
+}
+class LocalPlayer extends UninterpolatedPlayer {
   constructor(opts) {
     super(opts);
   }
@@ -823,7 +826,7 @@ class LocalPlayer extends Player {
     };
   })()
 }
-class RemotePlayer extends Player {
+class RemotePlayer extends InterpolatedPlayer {
   constructor(opts) {
     super(opts);
   }

--- a/character-controller.js
+++ b/character-controller.js
@@ -128,6 +128,11 @@ class Player extends THREE.Object3D {
     };
     this.actionInterpolantsArray = Object.keys(this.actionInterpolants).map(k => this.actionInterpolants[k]);
     
+    this.avatarBinding = {
+      position: this.positionInterpolant.get(),
+      quaternion: this.quaternionInterpolant.get(),
+    };
+    
     this.avatarEpoch = 0;
     this.avatar = null;
     this.syncAvatarCancelFn = null;

--- a/character-controller.js
+++ b/character-controller.js
@@ -741,6 +741,9 @@ class LocalPlayer extends Player {
   }
   pushPlayerUpdates() {
     this.playersArray.doc.transact(() => {
+      if (isNaN(this.position.x) || isNaN(this.position.y) || isNaN(this.position.z)) {
+        debugger;
+      }
       this.playerMap.set('position', this.position.toArray(localArray3));
       this.playerMap.set('quaternion', this.quaternion.toArray(localArray4));
     }, 'push');

--- a/constants.js
+++ b/constants.js
@@ -61,3 +61,7 @@ export const maxFov = 120;
 export const groundFriction = 0.28;
 export const airFriction = groundFriction;
 export const flyFriction = 0.5;
+
+export const avatarInterpolationFrameRate = 60;
+export const avatarInterpolationTimeDelay = 1000/(avatarInterpolationFrameRate * 0.5);
+export const avatarInterpolationNumFrames = 4;

--- a/game.js
+++ b/game.js
@@ -591,6 +591,7 @@ const cylinderMesh = (() => {
 let lastDraggingRight = false;
 let dragRightSpec = null;
 let fovFactor = 0;
+let lastActivated = false;
 const _gameUpdate = (timestamp, timeDiff) => {
   const now = timestamp;
   const renderer = getRenderer();
@@ -1040,13 +1041,15 @@ const _gameUpdate = (timestamp, timeDiff) => {
   const _updateUses = () => {
     const localPlayer = useLocalPlayer();
     const v = localPlayer.actionInterpolants.activate.getNormalized();
+    const currentActivated = v >= 1;
     
-    if (v >= 1) {
+    if (currentActivated && !lastActivated) {
       if (grabUseMesh.target) {
         grabUseMesh.target.activate();
       }
       localPlayer.removeAction('activate');
     }
+    lastActivated = currentActivated;
   };
   _updateUses();
   

--- a/interpolants.js
+++ b/interpolants.js
@@ -55,3 +55,91 @@ export class InfiniteActionInterpolant extends ScalarInterpolant {
     }
   }
 }
+
+const _makeSnapshots = (Constructor, numFrames) => {
+  const result = Array(numFrames);
+  for (let i = 0; i < numFrames; i++) {
+    result[i] = {
+      startValue: new Constructor(),
+      // endValue: new Constructor(),
+      startTime: 0,
+      endTime: 0,
+    };
+  }
+  return result;
+};
+export class VectorInterpolant {
+  constructor(fn, timeDelay, numFrames, Constructor, lerpFnName) {
+    this.fn = fn;
+    this.timeDelay = timeDelay;
+    this.numFrames = numFrames;
+    this.lerpFnName = lerpFnName;
+    
+    this.readTime = 0;
+    this.writeTime = 0;
+
+    this.snapshots = _makeSnapshots(Constructor, numFrames);
+    this.snapshotWriteIndex = 0;
+
+    this.value = new Constructor();
+  }
+  update(timeDiff) {
+    this.readTime += timeDiff;
+
+    const effectiveReadTime = this.readTime - this.timeDelay;
+    this.seekTo(effectiveReadTime);
+  }
+  seekTo(t) {
+    for (let i = -(this.numFrames - 1); i < 0; i++) {
+      const index = this.snapshotWriteIndex + i;
+      const snapshot = this.snapshots[mod(index, this.numFrames)];
+      if (snapshot.startTime >= t && t < snapshot.endTime) {
+        const f = (t - snapshot.startTime) / (snapshot.endTime - snapshot.startTime);
+        const {startValue} = snapshot;
+        const nextSnapshot = this.snapshots[mod(index + 1, this.numFrames)];
+        const {startValue: endValue} = nextSnapshot;
+        this.value.copy(startValue)[this.lerpFnName](endValue, f);
+        return;
+      }
+    }
+    console.warn('could not seek to time', t, JSON.parse(JSON.stringify(this.snapshots)));
+  }
+  snapshot(timeDiff) {
+    const value = this.fn();
+    // console.log('got value', value.join(','), timeDiff);
+    const writeSnapshot = this.snapshots[this.snapshotWriteIndex];
+    writeSnapshot.startValue.fromArray(value);
+    writeSnapshot.startTime = this.writeTime;
+    writeSnapshot.endTime = this.writeTime + timeDiff;
+    
+    this.snapshotWriteIndex = mod(this.snapshotWriteIndex + 1, this.numFrames);
+    this.writeTime += timeDiff;
+  }
+}
+
+export class PositionInterpolant extends VectorInterpolant {
+  constructor(fn, timeDelay, numFrames) {
+    super(fn, timeDelay, numFrames, THREE.Vector3, 'lerp');
+  }
+}
+
+export class QuaternionInterpolant extends VectorInterpolant {
+  constructor(fn, timeDelay, numFrames) {
+    super(fn, timeDelay, numFrames, THREE.Quaternion, 'slerp');
+  }
+}
+
+export class FixedTimeStep {
+  constructor(fn, frameRate) {
+    this.fn = fn;
+    this.maxTime = 1000/frameRate;
+    this.timeAcc = this.maxTime;
+  }
+  update(timeDiff) {
+    this.timeAcc += timeDiff;
+    while (this.timeAcc > this.maxTime) {
+      this.fn(this.maxTime);
+      this.timeAcc -= this.maxTime;
+    }
+  }
+}

--- a/interpolants.js
+++ b/interpolants.js
@@ -1,4 +1,7 @@
-export class Interpolant {
+import * as THREE from 'three';
+import {mod} from './util.js';
+
+export class ScalarInterpolant {
   constructor(fn, minValue, maxValue) {
     this.fn = fn;
     this.value = minValue;
@@ -16,7 +19,7 @@ export class Interpolant {
   }
 }
 
-export class BiActionInterpolant extends Interpolant {
+export class BiActionInterpolant extends ScalarInterpolant {
   constructor(fn, minValue, maxValue) {
     super(fn, minValue, maxValue);
   }
@@ -26,7 +29,7 @@ export class BiActionInterpolant extends Interpolant {
   }
 }
 
-export class UniActionInterpolant extends Interpolant {
+export class UniActionInterpolant extends ScalarInterpolant {
   constructor(fn, minValue, maxValue) {
     super(fn, minValue, maxValue);
   }
@@ -40,7 +43,7 @@ export class UniActionInterpolant extends Interpolant {
   }
 }
 
-export class InfiniteActionInterpolant extends Interpolant {
+export class InfiniteActionInterpolant extends ScalarInterpolant {
   constructor(fn, minValue) {
     super(fn, minValue);
   }

--- a/interpolants.js
+++ b/interpolants.js
@@ -95,7 +95,8 @@ export class SnapshotInterpolant {
       const index = this.snapshotWriteIndex + i;
       const snapshot = this.snapshots[mod(index, this.numFrames)];
       if (snapshot.startTime >= t && t <= snapshot.endTime) {
-        const f = (t - snapshot.startTime) / (snapshot.endTime - snapshot.startTime);
+        const duration = snapshot.endTime - snapshot.startTime;
+        const f = (duration > 0 && duration < Infinity) ? ((t - snapshot.startTime) / duration) : 0;
         const {startValue} = snapshot;
         const nextSnapshot = this.snapshots[mod(index + 1, this.numFrames)];
         const {startValue: endValue} = nextSnapshot;

--- a/player-avatar-binding.js
+++ b/player-avatar-binding.js
@@ -5,21 +5,14 @@ const appSymbol = 'app'; // Symbol('app');
 const avatarSymbol = 'avatar'; // Symbol('avatar');
 
 export function applyPlayerTransformsToAvatar(player, session, rig) {
-  // let currentPosition, currentQuaternion;
   if (!session) {
-    rig.inputs.hmd.position.copy(player.position);
-    rig.inputs.hmd.quaternion.copy(player.quaternion);
+    rig.inputs.hmd.position.copy(player.positionInterpolant.value);
+    rig.inputs.hmd.quaternion.copy(player.quaternionInterpolant.value);
     rig.inputs.leftGamepad.position.copy(player.leftHand.position);
     rig.inputs.leftGamepad.quaternion.copy(player.leftHand.quaternion);
     rig.inputs.rightGamepad.position.copy(player.rightHand.position);
     rig.inputs.rightGamepad.quaternion.copy(player.rightHand.quaternion);
-    
-    // currentPosition = rig.inputs.hmd.position;
-    // currentQuaternion = rig.inputs.hmd.quaternion;
-  } /* else {
-    currentPosition = localVector.copy(dolly.position).multiplyScalar(4);
-    currentQuaternion = rig.inputs.hmd.quaternion;
-  } */
+  }
 }
 export function applyPlayerModesToAvatar(player, session, rig) {
   const aimAction = player.getAction('aim');

--- a/player-avatar-binding.js
+++ b/player-avatar-binding.js
@@ -7,7 +7,7 @@ const avatarSymbol = 'avatar'; // Symbol('avatar');
 export function applyPlayerTransformsToAvatar(player, session, rig) {
   if (!session) {
     rig.inputs.hmd.position.copy(player.positionInterpolant.value);
-    rig.inputs.hmd.quaternion.copy(player.quaternionInterpolant.value);
+    rig.inputs.hmd.quaternion.copy(player.quaternionInterpolant.get());
     rig.inputs.leftGamepad.position.copy(player.leftHand.position);
     rig.inputs.leftGamepad.quaternion.copy(player.leftHand.quaternion);
     rig.inputs.rightGamepad.position.copy(player.rightHand.position);

--- a/player-avatar-binding.js
+++ b/player-avatar-binding.js
@@ -6,8 +6,8 @@ const avatarSymbol = 'avatar'; // Symbol('avatar');
 
 export function applyPlayerTransformsToAvatar(player, session, rig) {
   if (!session) {
-    rig.inputs.hmd.position.copy(player.positionInterpolant.value);
-    rig.inputs.hmd.quaternion.copy(player.quaternionInterpolant.get());
+    rig.inputs.hmd.position.copy(player.avatarBinding.position);
+    rig.inputs.hmd.quaternion.copy(player.avatarBinding.quaternion);
     rig.inputs.leftGamepad.position.copy(player.leftHand.position);
     rig.inputs.leftGamepad.quaternion.copy(player.leftHand.quaternion);
     rig.inputs.rightGamepad.position.copy(player.rightHand.position);


### PR DESCRIPTION
This PR adds a  multiplayer avatar interpolation solution.

This allows for smoothly sampling per-frame values for avatars regardless of network noise. Interpolation is handled for the postion, quaternion, _and_ actions, so the avatar rendering should not only be smooth but synced.

Additionally, we use the interpolation method to smooth out the hair rendering to a fixed timestep.