### PR TITLE
Add COOP headers to index.mjs serving

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -35,6 +35,9 @@ function makeId(length) {
 (async () => {
   const app = express();
   app.use('*', async (req, res, next) => {
+    res.setHeader('Cross-Origin-Opener-Policy', 'same-origin');
+    res.setHeader('Cross-Origin-Embedder-Policy', 'require-corp');
+
     const o = url.parse(req.originalUrl, true);
     if (/^\/(?:@proxy|public)\//.test(o.pathname) && o.search !== '?import') {
       const u = o.pathname


### PR DESCRIPTION
This is needed for supporting `SharedArrayBuffer`, high-resolution `performance.now()`, and also for a strict renderer process separation for child iframes, which is important for the [kalidokit implementation](https://github.com/webaverse/app/pull/1788) to be able to perform asynchronous GPU (model inference) work.

The end result is that if we do it this way, we will have faster mediapipe (pose model) inference, which does not interfere with the main game engine loop.

This is due to how the browser process architecture works (https://developers.google.com/web/updates/2020/07/referrer-policy-new-chrome-default).