### PR TITLE
Performance: no autoupdate [WIP]

### DIFF
--- a/preview.js
+++ b/preview.js
@@ -287,6 +287,7 @@ window.onload = async () => {
         context,
       });
       const scene = new THREE.Scene();
+      scene.autoUpdate = false;
       const camera = new THREE.PerspectiveCamera(60, window.innerWidth / window.innerHeight, 0.1, 1000);
       camera.position.set(0, o.rig.height, -2);
       const target = new THREE.Vector3(0, o.rig.height / 2, 0);
@@ -337,6 +338,7 @@ window.onload = async () => {
         context,
       });
       const scene = new THREE.Scene();
+      scene.autoUpdate = false;
       const camera = new THREE.PerspectiveCamera(60, window.innerWidth / window.innerHeight, 0.1, 1000);
       camera.position.copy(center)
         .add(
@@ -384,6 +386,7 @@ window.onload = async () => {
         context,
       });
       const scene = new THREE.Scene();
+      scene.autoUpdate = false;
       const camera = new THREE.PerspectiveCamera(60, window.innerWidth / window.innerHeight, 0.1, 1000);
       camera.position.copy(center)
         .add(

--- a/renderer.js
+++ b/renderer.js
@@ -84,6 +84,7 @@ const sceneLowPriority = new THREE.Object3D();
 sceneLowPriority.name = 'lowPriorioty';
 const rootScene = new THREE.Scene();
 rootScene.name = 'root';
+rootScene.autoUpdate = false;
 rootScene.add(sceneHighPriority);
 rootScene.add(scene);
 rootScene.add(sceneLowPriority);

--- a/renderer.js
+++ b/renderer.js
@@ -7,6 +7,9 @@ import * as THREE from 'three';
 import {EffectComposer} from 'three/examples/jsm/postprocessing/EffectComposer.js';
 import {minFov} from './constants.js';
 
+// XXX enable this when the code is stable; then, we will have many more places to add missing matrix updates
+// THREE.Object3D.DefaultMatrixAutoUpdate = false;
+
 let canvas = null, context = null, renderer = null, composer = null;
 
 function bindCanvas(c) {

--- a/screenshot-object.js
+++ b/screenshot-object.js
@@ -9,6 +9,7 @@ export async function screenshotObject(o) {
   console.log('add o', o);
 
   const newScene = new THREE.Scene();
+  newScene.autoUpdate = false;
   {
     const ambientLight = new THREE.AmbientLight(0x808080);
     newScene.add(ambientLight);
@@ -50,6 +51,7 @@ export async function exportObject(o) {
   const dataPromise = makePromise();
   const exporter = new GLTFExporter();
   const exportScene = new THREE.Scene();
+  exportScene.autoUpdate = false;
   exportScene.add(o);
   exporter.parse(exportScene, gltf => {
     dataPromise.accept(gltf);

--- a/screenshot.js
+++ b/screenshot.js
@@ -32,6 +32,7 @@ const _makeRenderer = (width, height) => {
   renderer.setSize(width, height);
 
   const scene = new THREE.Scene();
+  scene.autoUpdate = false;
 
   /* const cubeMesh = new THREE.Mesh(new THREE.BoxBufferGeometry(1, 1, 1), new THREE.MeshBasicMaterial({
     color: 0x0000FF,

--- a/shaders.js
+++ b/shaders.js
@@ -1564,6 +1564,7 @@ const copyScene = (() => {
     }),
   );
   const scene = new THREE.Scene();
+  scene.autoUpdate = false;
   scene.add(mesh);
   scene.mesh = mesh;
   return scene;

--- a/shadertoy.js
+++ b/shadertoy.js
@@ -97,6 +97,7 @@ class ShaderToyPass {
       })
     );
     this.scene = new THREE.Scene();
+    this.scene.autoUpdate = false;
     this.scene.add(this.mesh);
     
     this._copyBuffer = _makeRenderTarget(renderTarget.width, renderTarget.height);


### PR DESCRIPTION
This PR improves performance massively by eliding matrix update operations. However, app fixes are needed before we can ship this performance boost.

## Context
THREE.js by default updates all matrices (local and world, composed from position/quaternion/scale) in a scene each frame. This is a very heavy CPU operation. It is the most expensive thing during rendering, and depends O(n) on the number of objects in the scene.

However, most of this math is pointless. We know when things are being updated in the code, so we can just call updateMatrix() at that time, rather than for all objects each frame (in _addition_ to the update we are already doing).

It is easy to turn off this feature in THREE; it is the `scene.autoUpdate` property on all scenes. I have added that in this PR, and it massively improves the performance and the profile.

However, the downside is that if you update P/Q/S but do not call the matrix update, the object will _not_ have the correct transform during rendering. The fix is to make sure that all cases of updates are followed -- once the transformation math is fully complete — by `Object3D.updateMatrixWorld()`. Then we would have a significant performance improvement while everything would still render correctly.

## Progress
This PR is not done; there are plenty of corner cases in our apps and internal objects that need to be fixed to update their matrices correctly with this PR, by adding `.updateMatrixWorld()` on the errant objects whenever they update. That should be done regardless of this PR.

Once everything renders correctly with this PR and it passes QA, we can merge it.

