### PR TITLE
Add script to generate self signed cert

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -19,8 +19,8 @@ const _tryReadFile = p => {
   }
 };
 const certs = {
-  key: _tryReadFile('./certs/privkey.pem'),
-  cert: _tryReadFile('./certs/fullchain.pem'),
+  key: _tryReadFile('./certs/webaverse-self-signed.key'),
+  cert: _tryReadFile('./certs/webaverse-self-signed.crt'),
 };
 
 function makeId(length) {

--- a/scripts/gen-self-signed-cert.sh
+++ b/scripts/gen-self-signed-cert.sh
@@ -3,18 +3,18 @@ openssl req -x509 -new -nodes -key rootCA.key -sha256 -days 1024 -out rootCA.crt
 openssl genrsa -out webaverse-self-signed.key 2048
 openssl req -new \
   -key webaverse-self-signed.key \
-  -subj '/C=US/ST=CA/O=Webaverse, Inc./CN=webaverse.com' \
+  -subj '/C=US/ST=CA/O=Webaverse, Inc./CN=local.webaverse.com' \
   -reqexts SAN \
   -extensions SAN \
   -config <(cat /etc/ssl/openssl.cnf \
-    <(printf "\n[SAN]\nsubjectAltName=DNS:webaverse.com,DNS:webaverse.link,DNS:*.webaverse.com,DNS:*.webaverse.link")) \
+    <(printf "\n[SAN]\nsubjectAltName=DNS:local.webaverse.com,DNS:local.webaverse.online,DNS:local.webaverse.live")) \
   -out webaverse-self-signed.csr
 openssl x509 -req \
   -in webaverse-self-signed.csr \
   -CA rootCA.crt -CAkey rootCA.key -CAcreateserial \
   -extensions SAN \
   -extfile <(cat /etc/ssl/openssl.cnf \
-    <(printf "\n[SAN]\nsubjectAltName=DNS:webaverse.com,DNS:webaverse.link,DNS:*.webaverse.com,DNS:*.webaverse.link")) \
+    <(printf "\n[SAN]\nsubjectAltName=DNS:local.webaverse.com,DNS:local.webaverse.online,DNS:local.webaverse.live")) \
   -out webaverse-self-signed.crt \
   -days 1024
 openssl x509 -in webaverse-self-signed.crt -text -noout

--- a/scripts/gen-self-signed-cert.sh
+++ b/scripts/gen-self-signed-cert.sh
@@ -1,0 +1,20 @@
+openssl genrsa -out rootCA.key 4096
+openssl req -x509 -new -nodes -key rootCA.key -sha256 -days 1024 -out rootCA.crt -subj "/C=US/ST=Test/L=Test/O=Test/CN=localhost"
+openssl genrsa -out webaverse-self-signed.key 2048
+openssl req -new \
+  -key webaverse-self-signed.key \
+  -subj '/C=US/ST=CA/O=Webaverse, Inc./CN=webaverse.com' \
+  -reqexts SAN \
+  -extensions SAN \
+  -config <(cat /etc/ssl/openssl.cnf \
+    <(printf "\n[SAN]\nsubjectAltName=DNS:webaverse.com,DNS:webaverse.link,DNS:*.webaverse.com,DNS:*.webaverse.link")) \
+  -out webaverse-self-signed.csr
+openssl x509 -req \
+  -in webaverse-self-signed.csr \
+  -CA rootCA.crt -CAkey rootCA.key -CAcreateserial \
+  -extensions SAN \
+  -extfile <(cat /etc/ssl/openssl.cnf \
+    <(printf "\n[SAN]\nsubjectAltName=DNS:webaverse.com,DNS:webaverse.link,DNS:*.webaverse.com,DNS:*.webaverse.link")) \
+  -out webaverse-self-signed.crt \
+  -days 1024
+openssl x509 -in webaverse-self-signed.crt -text -noout


### PR DESCRIPTION
We might need this for our face tracking and/or preview implementations.

Those features, in order to force process isolation, require a TLD + 1 isolated secure origin separate from the app, necessitating the local dev server to have a valid HTTPS certificate on the server. It could be self signed, as long as the root CA is installed, and that is what this script implements.

In the future we might ship a pre-signed `localhost`-only domain cert from Let's Encrypt, but this is a working alternative right now, as long as the user installs the CA certificate they generated with this script.