### PR TITLE
feat: add post-scene renderPass

### DIFF
--- a/RenderPass.js
+++ b/RenderPass.js
@@ -1,0 +1,81 @@
+import {
+	Color
+} from 'three';
+import { Pass } from 'three/examples/jsm/postprocessing/Pass.js';
+
+class RenderPass extends Pass {
+
+	constructor( scene, camera, overrideMaterial, clearColor, clearAlpha ) {
+
+		super();
+
+		this.scene = scene;
+		this.camera = camera;
+
+		this.overrideMaterial = overrideMaterial;
+
+		this.clearColor = clearColor;
+		this.clearAlpha = ( clearAlpha !== undefined ) ? clearAlpha : 0;
+
+		this.clear = false;
+		this.clearDepth = true;
+		this.needsSwap = false;
+		this._oldClearColor = new Color();
+
+	}
+
+	render( renderer, writeBuffer, readBuffer /*, deltaTime, maskActive */ ) {
+
+		const oldAutoClear = renderer.autoClear;
+		renderer.autoClear = false;
+
+		let oldClearAlpha, oldOverrideMaterial;
+
+		if ( this.overrideMaterial !== undefined ) {
+
+			oldOverrideMaterial = this.scene.overrideMaterial;
+
+			this.scene.overrideMaterial = this.overrideMaterial;
+
+		}
+
+		if ( this.clearColor ) {
+
+			renderer.getClearColor( this._oldClearColor );
+			oldClearAlpha = renderer.getClearAlpha();
+
+			renderer.setClearColor( this.clearColor, this.clearAlpha );
+
+		}
+
+		if ( this.clearDepth ) {
+
+			renderer.clearDepth();
+
+		}
+
+		renderer.setRenderTarget( this.renderToScreen ? null : readBuffer );
+
+		// TODO: Avoid using autoClear properties, see https://github.com/mrdoob/three.js/pull/15571#issuecomment-465669600
+		if ( this.clear ) renderer.clear( renderer.autoClearColor, renderer.autoClearDepth, renderer.autoClearStencil );
+		renderer.render( this.scene, this.camera );
+
+		if ( this.clearColor ) {
+
+			renderer.setClearColor( this._oldClearColor, oldClearAlpha );
+
+		}
+
+		if ( this.overrideMaterial !== undefined ) {
+
+			this.scene.overrideMaterial = oldOverrideMaterial;
+
+		}
+
+		renderer.autoClear = oldAutoClear;
+
+	}
+
+}
+
+export { RenderPass };

--- a/metaversefile-api.js
+++ b/metaversefile-api.js
@@ -12,7 +12,7 @@ import React from 'react';
 import * as ReactThreeFiber from '@react-three/fiber';
 import * as Z from 'zjs';
 import metaversefile from 'metaversefile';
-import {getRenderer, scene, sceneHighPriority, rootScene, camera} from './renderer.js';
+import {getRenderer, scene, sceneHighPriority, rootScene, postScene, camera} from './renderer.js';
 import physicsManager from './physics-manager.js';
 import Avatar from './avatars/avatars.js';
 import {world} from './world.js';
@@ -455,6 +455,9 @@ metaversefile.setApi({
   useScene() {
     return scene;
   },
+  usePostScene() {
+    return postScene;
+  },
   useWorld() {
     return {
       /* addObject() {
@@ -831,6 +834,7 @@ export default () => {
       renderer,
       scene,
       rootScene,
+      postScene,
       camera,
       sceneHighPriority,
       iframeContainer,

--- a/post-processing.js
+++ b/post-processing.js
@@ -231,7 +231,7 @@ function setPasses(rendersettings) {
   composer.addPass(webaverseRenderPass);
   
   if (rendersettings) {
-    const {ssao, dof, hdr, bloom, usePostScene} = rendersettings;
+    const {ssao, dof, hdr, bloom, enablePostScene} = rendersettings;
     // console.log('got', ssao, dof, hdr, bloom);
     
     if (ssao) {
@@ -253,7 +253,7 @@ function setPasses(rendersettings) {
       const bloomPass = makeBloomPass(bloom);
       composer.addPass(bloomPass);
     }
-    if(usePostScene) {
+    if(enablePostScene) {
       const postRenderPass = new RenderPass(postScene, camera);
       composer.addPass(postRenderPass);
     }

--- a/post-processing.js
+++ b/post-processing.js
@@ -11,6 +11,7 @@ import {AdaptiveToneMappingPass} from 'three/examples/jsm/postprocessing/Adaptiv
 // import {AfterimagePass} from 'three/examples/jsm/postprocessing/AfterimagePass.js';
 import {BokehPass} from 'three/examples/jsm/postprocessing/BokehPass.js';
 import {SSAOPass} from './SSAOPass.js';
+import {RenderPass} from './RenderPass';
 import {
   getRenderer,
   getComposer,
@@ -18,6 +19,7 @@ import {
   // sceneHighPriority,
   // sceneLowPriority,
   rootScene,
+  postScene,
   camera,
 } from './renderer.js';
 // import {rigManager} from './rig.js';
@@ -229,7 +231,7 @@ function setPasses(rendersettings) {
   composer.addPass(webaverseRenderPass);
   
   if (rendersettings) {
-    const {ssao, dof, hdr, bloom} = rendersettings;
+    const {ssao, dof, hdr, bloom, usePostScene} = rendersettings;
     // console.log('got', ssao, dof, hdr, bloom);
     
     if (ssao) {
@@ -250,6 +252,10 @@ function setPasses(rendersettings) {
     if (bloom) {
       const bloomPass = makeBloomPass(bloom);
       composer.addPass(bloomPass);
+    }
+    if(usePostScene) {
+      const postRenderPass = new RenderPass(postScene, camera);
+      composer.addPass(postRenderPass);
     }
   }
   

--- a/renderer.js
+++ b/renderer.js
@@ -84,6 +84,8 @@ const sceneLowPriority = new THREE.Object3D();
 sceneLowPriority.name = 'lowPriorioty';
 const rootScene = new THREE.Scene();
 rootScene.name = 'root';
+const postScene = new THREE.Scene();
+postScene.name = 'postScene';
 rootScene.add(sceneHighPriority);
 rootScene.add(scene);
 rootScene.add(sceneLowPriority);
@@ -172,6 +174,7 @@ export {
   getComposer,
   scene,
   rootScene,
+  postScene,
   // avatarScene,
   camera,
   // orthographicCamera,

--- a/world.js
+++ b/world.js
@@ -12,7 +12,7 @@ import hpManager from './hp-manager.js';
 import {AppManager} from './app-manager.js';
 // import {getState, setState} from './state.js';
 // import {makeId} from './util.js';
-import {scene, sceneHighPriority, sceneLowPriority} from './renderer.js';
+import {scene, postScene, sceneHighPriority, sceneLowPriority} from './renderer.js';
 import metaversefileApi from 'metaversefile';
 import {worldMapName, appsMapName, playersMapName} from './constants.js';
 import {playersManager} from './players-manager.js';
@@ -295,6 +295,9 @@ const _getBindSceneForRenderPriority = renderPriority => {
     }
     case 'low': {
       return sceneLowPriority;
+    }
+    case 'postScene': {
+      return postScene;
     }
     default: {
       return scene;


### PR DESCRIPTION
Added the postScene to render the gltj app or other objects after post-processing. The postScene render pass has to be enabled from renderSettings in scn file.
{
  "type": "application/rendersettings",
  "content": {
    "enablePostScene": true
  }
}
Gltj app or object can be added to postScene by setting renderPriority to postScene in components:
{
  "start_url": "https://webaverse.github.io/eyeblaster/",
  "component": [
    {
      "key": "renderPriority",
      "value": "postScene"
    }
  ]
}




