### PR TITLE
ContentId fix for non-tracked apps

### DIFF
--- a/metaversefile-api.js
+++ b/metaversefile-api.js
@@ -439,7 +439,6 @@ metaversefile.setApi({
     }
   },
   async load(u) {
-    debugger;
     const m = await metaversefile.import(u);
     const app = metaversefile.createApp();
     await metaversefile.addModule(app, m);
@@ -766,7 +765,6 @@ const {Vector3, Quaternion, Euler, Matrix4, Box3, Object3D, Texture} = THREE;
 const {apps, createApp, createModule, addApp, removeApp, useFrame, useLocalPlayer, getAppByName, getAppsByName, getAppsByType, getAppsByTypes, getAppsByComponent} = metaversefile;
 
 export default () => {
-  debugger;
 `;
     const jsSuffix = '\n};';
     return s => {

--- a/metaversefile-api.js
+++ b/metaversefile-api.js
@@ -439,6 +439,7 @@ metaversefile.setApi({
     }
   },
   async load(u) {
+    debugger;
     const m = await metaversefile.import(u);
     const app = metaversefile.createApp();
     await metaversefile.addModule(app, m);
@@ -733,6 +734,7 @@ metaversefile.setApi({
     const app = new App();
     // app.name = name;
     app.type = type;
+    app.contentId = start_url;
     // app.components = components;
     if (in_front) {
       app.position.copy(localPlayer.position).add(new THREE.Vector3(0, 0, -1).applyQuaternion(localPlayer.quaternion));
@@ -764,6 +766,7 @@ const {Vector3, Quaternion, Euler, Matrix4, Box3, Object3D, Texture} = THREE;
 const {apps, createApp, createModule, addApp, removeApp, useFrame, useLocalPlayer, getAppByName, getAppsByName, getAppsByType, getAppsByTypes, getAppsByComponent} = metaversefile;
 
 export default () => {
+  debugger;
 `;
     const jsSuffix = '\n};';
     return s => {


### PR DESCRIPTION
The approach to reach it which I thought of is that when we actually create the app instance we attach the contentId to it. Although the start URL will be empty we still won't have the contentId going as null. And when the trackedApps will be added their empty string contentId will be replaced by the actual contentId so adding the contentId here comes with no harm. 