### PR TITLE
WebaverseShaderMaterial

### DIFF
--- a/materials.js
+++ b/materials.js
@@ -1,0 +1,63 @@
+import * as THREE from 'three';
+import {parser, generate} from '@shaderfrog/glsl-parser';
+
+// const baseUrl = import.meta.url.replace(/(\/)[^\/\\]*$/, '$1');
+
+const replaceStatementText = 'bool _webaverseShaderReplace = false;';
+const appendMain = (shaderText, postfixLine) => {
+  const replaceStatmentAst = parser.parse(replaceStatementText);
+
+  const ast = parser.parse(shaderText);
+  const {program} = ast;
+  // console.log('got program', program);
+  const mainProgram = program.find(p => p.type === 'function' && p.prototype.header.name.identifier === 'main');
+  if (mainProgram) {
+    const {body: {statements}} = mainProgram;
+    statements.push(...replaceStatmentAst.program);
+  }
+  const s = generate(ast)
+    .replace(replaceStatementText, postfixLine + '\n');
+  // console.log('got o', ast, s);
+  return s;
+};
+
+/* window.shaderText = `\
+  ${THREE.ShaderChunk.common}
+  uniform float iTime;
+  varying vec2 uvs;
+  varying vec3 vNormal;
+  varying vec3 vWorldPosition;
+  ${THREE.ShaderChunk.logdepthbuf_pars_vertex}
+  void main() {
+    uvs = uv;
+    gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+    vNormal = normal;
+    vec4 worldPosition = modelMatrix * vec4( position, 1.0 );
+    vWorldPosition = worldPosition.xyz;
+    ${THREE.ShaderChunk.logdepthbuf_vertex}
+  }
+`; */
+
+const formatVertexShader = vertexShader => `\
+${THREE.ShaderChunk.common}
+${THREE.ShaderChunk.logdepthbuf_pars_vertex}
+    
+${appendMain(vertexShader, THREE.ShaderChunk.logdepthbuf_vertex)}
+`;
+
+const formatFragmentShader = fragmentShader => `\
+${THREE.ShaderChunk.logdepthbuf_pars_fragment}
+    
+${appendMain(fragmentShader, THREE.ShaderChunk.logdepthbuf_fragment)}
+`;
+
+class WebaverseShaderMaterial extends THREE.ShaderMaterial {
+  constructor(opts = {}) {
+    opts.vertexShader = formatVertexShader(opts.vertexShader);
+    opts.fragmentShader = formatFragmentShader(opts.fragmentShader);
+    super(opts);
+  }
+}
+export {
+  WebaverseShaderMaterial,
+};

--- a/metaversefile-api.js
+++ b/metaversefile-api.js
@@ -32,6 +32,7 @@ import * as postProcessing from './post-processing.js';
 import {makeId, getRandomString, getPlayerPrefix} from './util.js';
 import JSON6 from 'json-6';
 import {rarityColors, initialPosY} from './constants.js';
+import * as materials from './materials.js';
 import soundManager from './sound-manager.js';
 
 import {CapsuleGeometry} from './CapsuleGeometry.js';
@@ -947,6 +948,9 @@ export default () => {
   },
   useTextInternal() {
     return Text;
+  },
+  useMaterials() {
+    return materials;
   },
   useJSON6Internal() {
     return JSON6;

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@glazed/devtools": "^0.1.3",
         "@pixiv/three-vrm": "./packages/three-vrm",
         "@react-three/fiber": "^7.0.6",
+        "@shaderfrog/glsl-parser": "^0.1.20",
         "borc": "^3.0.0",
         "classnames": "^2.3.1",
         "dids": "^2.4.0",
@@ -1215,6 +1216,14 @@
       },
       "engines": {
         "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/@shaderfrog/glsl-parser": {
+      "version": "0.1.20",
+      "resolved": "https://registry.npmjs.org/@shaderfrog/glsl-parser/-/glsl-parser-0.1.20.tgz",
+      "integrity": "sha512-geGGyFiQF2JXP7PbsJF8KIXyMxMut1/+f567KBqMsJSx7pRlPtjFCeeiLwJhVLDxi4jceTyqrnwcjyE23pEVKg==",
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/@sovpro/delimited-stream": {
@@ -11630,6 +11639,11 @@
         "estree-walker": "^2.0.1",
         "picomatch": "^2.2.2"
       }
+    },
+    "@shaderfrog/glsl-parser": {
+      "version": "0.1.20",
+      "resolved": "https://registry.npmjs.org/@shaderfrog/glsl-parser/-/glsl-parser-0.1.20.tgz",
+      "integrity": "sha512-geGGyFiQF2JXP7PbsJF8KIXyMxMut1/+f567KBqMsJSx7pRlPtjFCeeiLwJhVLDxi4jceTyqrnwcjyE23pEVKg=="
     },
     "@sovpro/delimited-stream": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@glazed/devtools": "^0.1.3",
     "@pixiv/three-vrm": "./packages/three-vrm",
     "@react-three/fiber": "^7.0.6",
+    "@shaderfrog/glsl-parser": "^0.1.20",
     "borc": "^3.0.0",
     "classnames": "^2.3.1",
     "dids": "^2.4.0",


### PR DESCRIPTION
With this PR, `WebaverseShaderMaterial` can be used from the metaversefile api:

```
const {WebaverseShaderMaterial} = metaversefile.useMaterial();
```

`WebaverseShaderMaterial` replaces `THREE.ShaderMaterial` but uses GLSL injection to add logarithmic depth buffer chunks (currently) and possibly other necessary custom chunks (in the future).

The idea is to abstract away Webaverse-specific shader decorations so that user code is not littered with this complexity.