### PR TITLE
Add hit direction support

### DIFF
--- a/game.js
+++ b/game.js
@@ -957,8 +957,14 @@ const _gameUpdate = (timestamp, timeDiff) => {
               if (timeDiff > 1000) {
                 // const worldPosition = object.getWorldPosition(localVector);
                 const damage = typeof useAction.damage === 'number' ? useAction.damage : 10;
+                const hitDirection = object.position.clone()
+                  .sub(localPlayer.position);
+                hitDirection.y = 0;
+                hitDirection.normalize();
+                
                 object.hit(damage, {
                   collisionId,
+                  hitDirection,
                 });
               
                 lastHitTimes.set(object, now);

--- a/physics-manager.js
+++ b/physics-manager.js
@@ -210,12 +210,15 @@ physicsManager.simulatePhysics = timeDiff => {
     const updatesOut = physx.physxWorker.simulatePhysics(physx.physics, physicsUpdates, t);
     physicsUpdates.length = 0;
     for (const updateOut of updatesOut) {
-      const {id, position, quaternion} = updateOut;
+      const {id, position, quaternion, collided, grounded} = updateOut;
       const physicsObject = metaversefileApi.getPhysicsObjectByPhysicsId(id);
       if (physicsObject) {
         physicsObject.position.copy(position);
         physicsObject.quaternion.copy(quaternion);
         physicsObject.updateMatrixWorld();
+
+        physicsObject.collided = collided;
+        physicsObject.grounded = grounded;
       } /* else {
         console.warn('failed to get physics object', id);
       } */

--- a/physx.js
+++ b/physx.js
@@ -551,8 +551,8 @@ const physxWorker = (() => {
         position: new THREE.Vector3().fromArray(positions, i*3),
         quaternion: new THREE.Quaternion().fromArray(quaternions, i*4),
         scale: new THREE.Vector3().fromArray(scales, i*3),
-        // collided: !!(bitfields[i] & 0x1),
-        // grounded: !!(bitfields[i] & 0x2),
+        collided: !!(bitfields[i] & 0x1),
+        grounded: !!(bitfields[i] & 0x2),
       };
     }
     /* if (updates.length > 0) {

--- a/world.js
+++ b/world.js
@@ -336,15 +336,15 @@ const _bindHitTracker = app => {
     const result = hitTracker.hit(damage);
     const {hit, died} = result;
     if (hit) {
-      const {collisionId} = opts;
+      const {collisionId, hitDirection} = opts;
       if (collisionId) {
         hpManager.triggerDamageAnimation(collisionId);
       }
       
       app.dispatchEvent({
         type: 'hit',
-        // position: cylinderMesh.position,
-        // quaternion: cylinderMesh.quaternion,
+        collisionId,
+        hitDirection,
         hp: hitTracker.hp,
         totalHp: hitTracker.totalHp,
       });


### PR DESCRIPTION
This PR adds a `hitDirection` `THREE.Vector3` for hit weapon types, which can be used to do additional hit math in the receiving app.