### PR TITLE
Emending AWS Codepipeline Docker Automation Scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,4 +27,4 @@ EXPOSE 443
 	
 
 	# Launch application
-CMD ["pm2-runtime", "index.mjs", "--", "-p", "--secret", "$PM2_SECRET_KEY", "--public", "$PM2_PUBLIC_KEY"]
+CMD ["pm2-runtime", "index.mjs", "--", "-p", "--secret", "$PM2_SECRET_KEY", "--public", "$PM2_PUBLIC_KEY", "--no-auto-exit"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ WORKDIR /app
 RUN apt update -y
 RUN npm install -g pm2
 RUN npm install
-RUN npm list
+RUN pm2 link ${PM2_SECRET_KEY} ${PM2_PUBLIC_KEY}
 	
 
 # Expose API port to the outside

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ ARG pm2_secret_key
 ENV LAST_UPDATED 20160605T165400
 ENV PM2_PUBLIC_KEY wicmdcymxzyukdq
 ENV PM2_SECRET_KEY=$pm2_secret_key
+ENV HOSTNAME=0
 LABEL description="webaverse-app"
 	
 # Copy source code
@@ -17,7 +18,8 @@ WORKDIR /app
 RUN apt update -y
 RUN npm install -g pm2
 RUN npm install
-RUN pm2 link $PM2_SECRET_KEY $PM2_PUBLIC_KEY
+#RUN date +%s%3N | export HOSTNAME=standin
+#RUN pm2 link $PM2_SECRET_KEY $PM2_PUBLIC_KEY $HOSTNAME
 	
 
 # Expose API port to the outside
@@ -25,4 +27,4 @@ EXPOSE 443
 	
 
 	# Launch application
-CMD ["pm2-runtime", "index.mjs", "--", "-p"]
+CMD ["pm2-runtime", "index.mjs", "--", "-p", "--secret", "$PM2_SECRET_KEY", "--public", "$PM2_PUBLIC_KEY"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,4 +24,4 @@ EXPOSE 443
 
 	# Launch application
 # CMD forever -a -l /host/forever.log -o stdout.log -e stderr.log index.mjs -p
-CMD ["pm2-runtime", "--instances", "4", "--", "-p", "start", "index.mjs"]
+CMD ["pm2-runtime", "--instances", "4", "--args", "-p", "start", "index.mjs"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,4 +27,4 @@ EXPOSE 443
 	
 
 	# Launch application
-CMD ["pm2-runtime", "index.mjs", "--", "-p", "--secret", "$PM2_SECRET_KEY", "--public", "$PM2_PUBLIC_KEY", "--no-auto-exit"]
+CMD ["pm2-runtime", "index.mjs", "--", "-p", "--secret", "$PM2_SECRET_KEY", "--public", "$PM2_PUBLIC_KEY", "--no-auto-exit", "--raw"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,4 +24,4 @@ EXPOSE 443
 
 	# Launch application
 # CMD forever -a -l /host/forever.log -o stdout.log -e stderr.log index.mjs -p
-CMD ["pm2-runtime", "--instances", "4", "--raw", "index.mjs"]
+CMD ["pm2-runtime", "--instances", "4", "--raw", "start", "index.mjs"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,4 +24,4 @@ EXPOSE 443
 
 	# Launch application
 # CMD forever -a -l /host/forever.log -o stdout.log -e stderr.log index.mjs -p
-CMD ["pm2-runtime", "index.mjs"]
+CMD ["pm2-runtime", "--instances", "4", "--raw", "index.mjs"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,9 +19,8 @@ RUN npm list
 	
 
 # Expose API port to the outside
-EXPOSE 3000
-EXPOSE 3001
+EXPOSE 443
 	
 
 	# Launch application
-CMD forever -a -l /host/forever.log -o stdout.log -e stderr.log index.js
+CMD forever -a -l /host/forever.log -o stdout.log -e stderr.log index.mjs -p

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,8 @@ WORKDIR /app
 
 # Install dependencies
 RUN apt update -y
-RUN apt install sudo -y
-RUN npm install forever -g
+RUN npm install -g pm2
+RUN pm2 link 0ve2nlmollwq16k wicmdcymxzyukdq
 RUN npm install
 RUN npm list
 	
@@ -23,4 +23,5 @@ EXPOSE 443
 	
 
 	# Launch application
-CMD forever -a -l /host/forever.log -o stdout.log -e stderr.log index.mjs -p
+# CMD forever -a -l /host/forever.log -o stdout.log -e stderr.log index.mjs -p
+CMD pm2 start index.mjs -p

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,4 +24,4 @@ EXPOSE 443
 
 	# Launch application
 # CMD forever -a -l /host/forever.log -o stdout.log -e stderr.log index.mjs -p
-CMD pm2 start index.mjs -p
+CMD pm2 start index.mjs -i 4

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,4 +27,4 @@ EXPOSE 443
 	
 
 	# Launch application
-CMD ["pm2-runtime", "index.mjs", "--", "-p", "--secret", "$PM2_SECRET_KEY", "--public", "$PM2_PUBLIC_KEY", "--no-auto-exit", "--raw"]
+CMD ["pm2-runtime", "index.mjs", "--", "-p", "--secret", "$PM2_SECRET_KEY", "--public", "$PM2_PUBLIC_KEY", "--no-auto-exit", "--instances", "1", "--restart-delay", "60000"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ RUN npm install
 
 # Expose API port to the outside
 EXPOSE 443
+EXPOSE 444
 	
 
 	# Launch application

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,4 +24,4 @@ EXPOSE 443
 
 	# Launch application
 # CMD forever -a -l /host/forever.log -o stdout.log -e stderr.log index.mjs -p
-CMD ["pm2-runtime", "--instances", "4", "--raw", "start", "index.mjs"]
+CMD ["pm2-runtime", "--instances", "4", "--", "-p", "start", "index.mjs"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,4 +24,4 @@ EXPOSE 443
 
 	# Launch application
 # CMD forever -a -l /host/forever.log -o stdout.log -e stderr.log index.mjs -p
-CMD ["pm2-runtime", "--instances", "4", "--args", "-p", "start", "index.mjs"]
+CMD ["pm2-runtime", "index.mjs", "--", "-p"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM node	
-ENV LAST_UPDATED 20160605T165400	
+ENV LAST_UPDATED 20160605T165400
+ENV PM2_PUBLIC_KEY wicmdcymxzyukdq
 LABEL description="webaverse-app"
 	
 # Copy source code
@@ -13,7 +14,6 @@ WORKDIR /app
 # Install dependencies
 RUN apt update -y
 RUN npm install -g pm2
-RUN pm2 link 0ve2nlmollwq16k wicmdcymxzyukdq
 RUN npm install
 RUN npm list
 	
@@ -24,4 +24,4 @@ EXPOSE 443
 
 	# Launch application
 # CMD forever -a -l /host/forever.log -o stdout.log -e stderr.log index.mjs -p
-CMD pm2 start index.mjs -i 4
+CMD ["pm2-runtime", "index.mjs"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
-FROM node	
+FROM node
+ARG pm2_secret_key	
 ENV LAST_UPDATED 20160605T165400
 ENV PM2_PUBLIC_KEY wicmdcymxzyukdq
+ENV PM2_SECRET_KEY=$pm2_secret_key
 LABEL description="webaverse-app"
 	
 # Copy source code
@@ -15,7 +17,7 @@ WORKDIR /app
 RUN apt update -y
 RUN npm install -g pm2
 RUN npm install
-RUN pm2 link ${PM2_SECRET_KEY} ${PM2_PUBLIC_KEY}
+RUN pm2 link $PM2_SECRET_KEY $PM2_PUBLIC_KEY
 	
 
 # Expose API port to the outside
@@ -23,5 +25,4 @@ EXPOSE 443
 	
 
 	# Launch application
-# CMD forever -a -l /host/forever.log -o stdout.log -e stderr.log index.mjs -p
 CMD ["pm2-runtime", "index.mjs", "--", "-p"]

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -9,7 +9,7 @@ phases:
       - npm install forever -g
       - git submodule init
       - git submodule update
-      - npm install -y
+      - npm install -y --verbose
   pre_build:
     commands:
       - REPOSITORY_URI=907263135169.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/ecrrepository-app-$AWS_DEFAULT_REGION

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -6,7 +6,7 @@ phases:
       nodejs: latest
     commands:
       - echo Entered the install phase...
-      - sudo npm install forever -g
+      - npm install forever -g
       - git submodule init
       - git submodule update
       - npm install -y

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -8,6 +8,8 @@ phases:
       - echo Entered the install phase...
       - apt update -y
       - sudo npm install forever -g
+      - git submodule init
+      - git submodule update
       - npm install -y
   pre_build:
     commands:

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -3,7 +3,7 @@ version: 0.2
 phases:
   install:
     runtime-versions:
-      nodejs: latest
+      nodejs: 16
     commands:
       - echo Entered the install phase...
       - npm install forever -g

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -3,7 +3,7 @@ version: 0.2
 phases:
   install:
     runtime-versions:
-      nodejs: 16
+      node: 16
     commands:
       - echo Entered the install phase...
       - npm install forever -g

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -19,7 +19,7 @@ phases:
       - echo Building the Docker image...
       - echo Logging in to Docker Hub...
       - echo "${DOCKERHUB_PASSWORD}" | docker login -u "${DOCKERHUB_USERNAME}" --password-stdin
-      - docker build -t $REPOSITORY_URI:latest --build-arg PM2_SECRET_KEY=${PM2_SECRET_KEY} .
+      - docker build -t $REPOSITORY_URI:latest --build-arg pm2_secret_key=${PM2_SECRET_KEY} .
       - docker tag $REPOSITORY_URI:latest $REPOSITORY_URI:$IMAGE_TAG
   post_build:
     commands:

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -6,7 +6,6 @@ phases:
       nodejs: latest
     commands:
       - echo Entered the install phase...
-      - apt update -y
       - sudo npm install forever -g
       - git submodule init
       - git submodule update

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -3,13 +3,11 @@ version: 0.2
 phases:
   install:
     runtime-versions:
-      node: 16
+      nodejs: latest
     commands:
       - echo Entered the install phase...
-      - npm install forever -g
       - git submodule init
       - git submodule update
-      - npm install -y --verbose
   pre_build:
     commands:
       - REPOSITORY_URI=907263135169.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/ecrrepository-app-$AWS_DEFAULT_REGION

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -19,7 +19,7 @@ phases:
       - echo Building the Docker image...
       - echo Logging in to Docker Hub...
       - echo "${DOCKERHUB_PASSWORD}" | docker login -u "${DOCKERHUB_USERNAME}" --password-stdin
-      - docker build -t $REPOSITORY_URI:latest .
+      - docker build -t $REPOSITORY_URI:latest --build-arg PM2_SECRET_KEY=${PM2_SECRET_KEY} .
       - docker tag $REPOSITORY_URI:latest $REPOSITORY_URI:$IMAGE_TAG
   post_build:
     commands:


### PR DESCRIPTION
In order to implement AWS Codepipeline to ECS, we use buildspec.yml and Dockerfile to incorporate the code changes from the repo and then integrate them into a new container image. And on ken's recommendation, we're implementing PM2 to replace Forever as the service manager, which adds several features like cloud-based control over the node instances and metric dashboards.

