### PR TITLE
Add noimport support in index.mjs

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -87,7 +87,7 @@ const _proxyUrl = (req, res, u) => {
         next();
       }
     } else if (o.query['noimport'] !== undefined) {
-      const p = path.join(cwd, o.pathname);
+      const p = path.join(cwd, path.resolve(o.pathname));
       const rs = fs.createReadStream(p);
       rs.on('error', err => {
         if (err.code === 'ENOENT') {

--- a/index.mjs
+++ b/index.mjs
@@ -38,7 +38,6 @@ function makeId(length) {
 }
 
 const _proxyUrl = (req, res, u) => {
-  console.log('got u', {u});
   const proxyReq = /https/.test(u) ? https.request(u) : http.request(u);
   proxyReq.on('response', proxyRes => {
     for (const header in proxyRes.headers) {


### PR DESCRIPTION
With this PR, passing `?noimport` in the query string will not compile local files but rather serve them raw.

It's needed for nested apps support, since the inner app hits via absolute URL and this confuses the import with a double compile that ultimately errors.

