### PR TITLE
Fix hit tracking

### DIFF
--- a/game.js
+++ b/game.js
@@ -1029,12 +1029,14 @@ const _gameUpdate = (timestamp, timeDiff) => {
                 localEuler.z = 0;
                 const hitQuaternion = new THREE.Quaternion().setFromEuler(localEuler);
 
+                const willDie = object.willDieFrom(damage);
                 object.hit(damage, {
-                  collisionId: object.willDieFrom(damage) ? collisionId : null,
+                  collisionId,
                   // collisionId,
                   hitPosition,
                   hitQuaternion,
                   hitDirection,
+                  willDie,
                 });
               
                 lastHitTimes.set(object, now);

--- a/world.js
+++ b/world.js
@@ -337,23 +337,24 @@ const _bindHitTracker = app => {
     const result = hitTracker.hit(damage);
     const {hit, died} = result;
     if (hit) {
-      const {collisionId, hitPosition, hitDirection, hitQuaternion} = opts;
-      if (collisionId) {
+      const {collisionId, hitPosition, hitDirection, hitQuaternion, willDie} = opts;
+      if (willDie) {
         hpManager.triggerDamageAnimation(collisionId);
       }
 
-      const app = metaversefileApi.createApp();
-      (async () => {
-        await metaverseModules.waitForLoad();
-        const {modules} = metaversefileApi.useDefaultModules();
-        const m = modules['damageMesh'];
-        await app.addModule(m);
-      })();
-      app.position.copy(hitPosition);
-      app.quaternion.copy(hitQuaternion);
-      app.updateMatrixWorld();
-      // console.log('new damage mesh', app, hitPosition, hitDirection, hitQuaternion);
-      scene.add(app);
+      {
+        const damageMeshApp = metaversefileApi.createApp();
+        (async () => {
+          await metaverseModules.waitForLoad();
+          const {modules} = metaversefileApi.useDefaultModules();
+          const m = modules['damageMesh'];
+          await damageMeshApp.addModule(m);
+        })();
+        damageMeshApp.position.copy(hitPosition);
+        damageMeshApp.quaternion.copy(hitQuaternion);
+        damageMeshApp.updateMatrixWorld();
+        scene.add(damageMeshApp);
+      }
       
       app.dispatchEvent({
         type: 'hit',
@@ -361,6 +362,7 @@ const _bindHitTracker = app => {
         hitPosition,
         hitDirection,
         hitQuaternion,
+        willDie,
         hp: hitTracker.hp,
         totalHp: hitTracker.totalHp,
       });


### PR DESCRIPTION
Objects hit was broken due to the addition of the text mesh (variable scoping of the damage mesh app).

This PR fixes that, as well as cleaning up the logic for when we should play the dying object animation (only do it when it is actually dying from the hit).