### PR TITLE
Improve VRM performance

### DIFF
--- a/avatars/util.mjs
+++ b/avatars/util.mjs
@@ -37,7 +37,7 @@ export const getEyePosition = (() => {
   // const localVector2 = new THREE.Vector3();
   return function(modelBones) {
     // const vrmExtension = object?.parser?.json?.extensions?.VRM;
-    return modelBones.Head.getWorldPosition(localVector)
+    return localVector.setFromMatrixPosition(modelBones.Head.matrixWorld);
       // .add(localVector2.set(0, 0.06, 0));
   }
 })();


### PR DESCRIPTION
This PR:


* Cleans up eye calculations to no longer perform a `matrixWorld` update
* bumps `three-vrm` to ingest https://github.com/webaverse/three-vrm/pull/2 and remove the `Proxy` hack which was slowing down the code

Thanks to gonnaviz for the research: https://github.com/webaverse/app/pull/2122

