### PR TITLE
Add .wav as media type in index.mjs

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -13,7 +13,7 @@ const cwd = process.cwd();
 
 const isProduction = process.argv[2] === '-p';
 
-const _isMediaType = p => /\.(?:png|jpe?g|gif|svg|glb|mp3|webm|mp4|mov)$/.test(p);
+const _isMediaType = p => /\.(?:png|jpe?g|gif|svg|glb|mp3|wav|webm|mp4|mov)$/.test(p);
 
 const _tryReadFile = p => {
   try {


### PR DESCRIPTION
Consider `.wav` as a media type for the purposes of direct proxying. This is needed for some vocalization files, which must proxy, and which are naturally `.wav`.