### PR TITLE
Typecasting on undefined fixed

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -109,7 +109,7 @@ const _proxyUrl = (req, res, u) => {
     }
   });
 
-  const isHttps = !!!process.env.HTTP_ONLY && (!!certs.key && !!certs.cert);
+  const isHttps = !process.env.HTTP_ONLY && (!!certs.key && !!certs.cert);
   const port = parseInt(process.env.PORT, 10) || (isProduction ? 443 : 3000);
   const wsPort = port + 1;
 

--- a/index.mjs
+++ b/index.mjs
@@ -109,7 +109,7 @@ const _proxyUrl = (req, res, u) => {
     }
   });
 
-  const isHttps = !!process.env.HTTP_ONLY && (!!certs.key && !!certs.cert);
+  const isHttps = !Boolean(process.env.HTTP_ONLY) && (!!certs.key && !!certs.cert);
   const port = parseInt(process.env.PORT, 10) || (isProduction ? 443 : 3000);
   const wsPort = port + 1;
 

--- a/index.mjs
+++ b/index.mjs
@@ -109,7 +109,7 @@ const _proxyUrl = (req, res, u) => {
     }
   });
 
-  const isHttps = !Boolean(process.env.HTTP_ONLY) && (!!certs.key && !!certs.cert);
+  const isHttps = !!!process.env.HTTP_ONLY && (!!certs.key && !!certs.cert);
   const port = parseInt(process.env.PORT, 10) || (isProduction ? 443 : 3000);
   const wsPort = port + 1;
 


### PR DESCRIPTION
Seems like typecasting is working differently across node versions. This PR enforces the HTTP_ONLY typecast using the Boolean constructor instead.

