### PR TITLE
Add WebaverseRawShaderMaterial

### DIFF
--- a/materials.js
+++ b/materials.js
@@ -61,7 +61,7 @@ class WebaverseShaderMaterial extends THREE.ShaderMaterial {
 class WebaverseRawShaderMaterial extends THREE.RawShaderMaterial {
   constructor(opts = {}) {
     opts.vertexShader = formatVertexShader(opts.vertexShader);
-    opts.vertexShader = opts.vertexShader.replace('#define EPSILON 1e-6', '#define EPSILON 1e-6\n#define USE_LOGDEPTHBUF 1');
+    // opts.vertexShader = opts.vertexShader.replace('#define EPSILON 1e-6', '#define EPSILON 1e-6\n#define USE_LOGDEPTHBUF 1');
     opts.fragmentShader = formatFragmentShader(opts.fragmentShader);
     super(opts);
   }

--- a/materials.js
+++ b/materials.js
@@ -61,6 +61,7 @@ class WebaverseShaderMaterial extends THREE.ShaderMaterial {
 class WebaverseRawShaderMaterial extends THREE.RawShaderMaterial {
   constructor(opts = {}) {
     opts.vertexShader = formatVertexShader(opts.vertexShader);
+    opts.vertexShader = opts.vertexShader.replace('#define EPSILON 1e-6', '#define EPSILON 1e-6\n#define USE_LOGDEPTHBUF 1');
     opts.fragmentShader = formatFragmentShader(opts.fragmentShader);
     super(opts);
   }

--- a/materials.js
+++ b/materials.js
@@ -58,6 +58,14 @@ class WebaverseShaderMaterial extends THREE.ShaderMaterial {
     super(opts);
   }
 }
+class WebaverseRawShaderMaterial extends THREE.RawShaderMaterial {
+  constructor(opts = {}) {
+    opts.vertexShader = formatVertexShader(opts.vertexShader);
+    opts.fragmentShader = formatFragmentShader(opts.fragmentShader);
+    super(opts);
+  }
+}
 export {
   WebaverseShaderMaterial,
+  WebaverseRawShaderMaterial,
 };


### PR DESCRIPTION
`WebaverseRawShaderMaterial` corresponds to `RawShaderMaterial`, just like `WebaverseShaderMaterial` corresponds to `ShaderMaterial`.

The point of these wrapper materials is to inject any shader chunks we need by default in webaverse (like logarithmic depth buffer support).

