### PR TITLE
Unifiy depth pass

### DIFF
--- a/DepthPass.js
+++ b/DepthPass.js
@@ -1,0 +1,167 @@
+import {
+	Color,
+	MeshBasicMaterial,
+	MeshDepthMaterial,
+	MeshNormalMaterial,
+	NearestFilter,
+	LinearFilter,
+	NoBlending,
+	RGBADepthPacking,
+	ShaderMaterial,
+	UniformsUtils,
+	WebGLRenderTarget,
+	Scene,
+	DepthTexture,
+	UnsignedShortType,
+	FloatType,
+	RGBAFormat,
+} from 'three';
+import { Pass, FullScreenQuad } from 'three/examples/jsm/postprocessing/Pass.js';
+// import { BokehShader } from './BokehShader.js';
+
+const oldParentCache = new WeakMap();
+const oldMaterialCache = new WeakMap();
+
+/**
+ * Depth-of-field post-process with bokeh shader
+ */
+
+class DepthPass extends Pass {
+
+	constructor( scene, camera, {width, height} ) {
+
+		super();
+
+    this.scene = scene;
+    this.camera = camera;
+    this.width = width;
+    this.height = height;
+
+    const depthTexture = new DepthTexture();
+		// depthTexture.type = UnsignedShortType;
+
+		/* this.beautyRenderTarget = new WebGLRenderTarget( this.width, this.height, {
+			minFilter: LinearFilter,
+			magFilter: LinearFilter,
+			format: RGBAFormat
+		} ); */
+
+		// normal render target with depth buffer
+
+		this.normalRenderTarget = new WebGLRenderTarget( this.width, this.height, {
+			minFilter: NearestFilter,
+			magFilter: NearestFilter,
+			format: RGBAFormat,
+			depthTexture: depthTexture
+		} );
+
+    this.normalMaterial = new MeshNormalMaterial();
+		this.normalMaterial.blending = NoBlending;
+
+    this.customScene = new Scene();
+    this._visibilityCache = new Map();
+    this.originalClearColor = new Color();
+	}
+
+  renderOverride( renderer, overrideMaterial, renderTarget, clearColor, clearAlpha ) {
+
+    renderer.getClearColor( this.originalClearColor );
+    const originalClearAlpha = renderer.getClearAlpha();
+    const originalAutoClear = renderer.autoClear;
+
+    renderer.setRenderTarget( renderTarget );
+    renderer.autoClear = false;
+
+    clearColor = overrideMaterial.clearColor || clearColor;
+    clearAlpha = overrideMaterial.clearAlpha || clearAlpha;
+
+    if ( ( clearColor !== undefined ) && ( clearColor !== null ) ) {
+
+      renderer.setClearColor( clearColor );
+      renderer.setClearAlpha( clearAlpha || 0.0 );
+      renderer.clear();
+
+    }
+
+    const _recurse = o => {
+      if (o.isMesh && o.customPostMaterial) {
+        oldParentCache.set(o, o.parent);
+        oldMaterialCache.set(o, o.material);
+
+        o.material = o.customPostMaterial;
+        this.customScene.add(o);
+      }
+      for (const child of o.children) {
+        _recurse(child);
+      }
+    };
+    _recurse(this.scene);
+    renderer.render( this.customScene, this.camera );
+    for (const child of this.customScene.children) {
+      oldParentCache.get(child).add(child);
+      child.material = oldMaterialCache.get(child);
+
+      oldParentCache.delete(child);
+      oldMaterialCache.delete(child);
+    }
+
+    this.scene.overrideMaterial = overrideMaterial;
+    renderer.render( this.scene, this.camera );
+    this.scene.overrideMaterial = null;
+
+    // restore original state
+
+    renderer.autoClear = originalAutoClear;
+    renderer.setClearColor( this.originalClearColor );
+    renderer.setClearAlpha( originalClearAlpha );
+
+  }
+
+	render( renderer, writeBuffer /*, readBuffer, deltaTime, maskActive */ ) {
+		// render beauty
+
+		// renderer.setRenderTarget( this.normalRenderTarget );
+		// renderer.clear();
+		// renderer.render( this.scene, this.camera );
+
+		// render normals and depth (honor only meshes, points and lines do not contribute to SSAO)
+
+		this.overrideVisibility();
+		this.renderOverride( renderer, this.normalMaterial, this.normalRenderTarget, 0x7777ff, 1.0 );
+		this.restoreVisibility();
+  }
+
+  overrideVisibility() {
+
+		const scene = this.scene;
+		const cache = this._visibilityCache;
+
+		scene.traverse( function ( object ) {
+
+			cache.set( object, object.visible );
+
+			if ( object.isPoints || object.isLine || object.isLowPriority ) object.visible = false;
+
+		} );
+
+	}
+
+	restoreVisibility() {
+
+		const scene = this.scene;
+		const cache = this._visibilityCache;
+
+		scene.traverse( function ( object ) {
+
+			const visible = cache.get( object );
+			object.visible = visible;
+
+		} );
+
+		cache.clear();
+
+	}
+
+}
+
+export { DepthPass };

--- a/SSAOPass.js
+++ b/SSAOPass.js
@@ -34,12 +34,13 @@ const oldMaterialCache = new WeakMap();
 
 class SSAOPass extends Pass {
 
-	constructor( scene, camera, width, height ) {
+	constructor( scene, camera, width, height, depthPass ) {
 
 		super();
 
 		this.width = ( width !== undefined ) ? width : 512;
 		this.height = ( height !== undefined ) ? height : 512;
+		this.depthPass = depthPass;
 
 		this.clear = true;
 
@@ -77,12 +78,12 @@ class SSAOPass extends Pass {
 
 		// normal render target with depth buffer
 
-		this.normalRenderTarget = new WebGLRenderTarget( this.width, this.height, {
+		/* this.normalRenderTarget = new WebGLRenderTarget( this.width, this.height, {
 			minFilter: NearestFilter,
 			magFilter: NearestFilter,
 			format: RGBAFormat,
 			depthTexture: depthTexture
-		} );
+		} ); */
 
 		// ssao render target
 
@@ -111,8 +112,8 @@ class SSAOPass extends Pass {
 		} );
 
 		this.ssaoMaterial.uniforms[ 'tDiffuse' ].value = this.beautyRenderTarget.texture;
-		this.ssaoMaterial.uniforms[ 'tNormal' ].value = this.normalRenderTarget.texture;
-		this.ssaoMaterial.uniforms[ 'tDepth' ].value = this.normalRenderTarget.depthTexture;
+		this.ssaoMaterial.uniforms[ 'tNormal' ].value = this.depthPass.normalRenderTarget.texture;
+		this.ssaoMaterial.uniforms[ 'tDepth' ].value = this.depthPass.normalRenderTarget.depthTexture;
 		this.ssaoMaterial.uniforms[ 'tNoise' ].value = this.noiseTexture;
 		this.ssaoMaterial.uniforms[ 'kernel' ].value = this.kernel;
 		this.ssaoMaterial.uniforms[ 'cameraNear' ].value = this.camera.near;
@@ -178,7 +179,7 @@ class SSAOPass extends Pass {
 		// dispose render targets
 
 		this.beautyRenderTarget.dispose();
-		this.normalRenderTarget.dispose();
+		// this.normalRenderTarget.dispose();
 		this.ssaoRenderTarget.dispose();
 		this.blurRenderTarget.dispose();
 
@@ -205,9 +206,9 @@ class SSAOPass extends Pass {
 
 		// render normals and depth (honor only meshes, points and lines do not contribute to SSAO)
 
-		this.overrideVisibility();
+		/* this.overrideVisibility();
 		this.renderOverride( renderer, this.normalMaterial, this.normalRenderTarget, 0x7777ff, 1.0 );
-		this.restoreVisibility();
+		this.restoreVisibility(); */
 
 		// render SSAO
 
@@ -371,7 +372,7 @@ class SSAOPass extends Pass {
 
 		this.beautyRenderTarget.setSize( width, height );
 		this.ssaoRenderTarget.setSize( width, height );
-		this.normalRenderTarget.setSize( width, height );
+		// this.normalRenderTarget.setSize( width, height );
 		this.blurRenderTarget.setSize( width, height );
 
 		this.ssaoMaterial.uniforms[ 'resolution' ].value.set( width, height );

--- a/webaverse-render-pass.js
+++ b/webaverse-render-pass.js
@@ -15,12 +15,16 @@ class WebaverseRenderPass extends Pass {
     this.needsSwap = true;
     this.clear = true;
 
+    this.internalDepthPass = null;
     this.internalRenderPass = null;
     this.onBeforeRender = null;
     this.onAfterRender = null;
   }
   setSize( width, height ) {
     
+    if (this.internalDepthPass) {
+      this.internalDepthPass.setSize(width, height);
+    }
     if (this.internalRenderPass) {
       this.internalRenderPass.setSize(width,height);
     }
@@ -39,6 +43,10 @@ class WebaverseRenderPass extends Pass {
     sceneLowPriority.traverse(o => {
       o.isLowPriority = true;
     });
+    if (this.internalDepthPass) {
+      this.internalDepthPass.renderToScreen = false;
+      this.internalDepthPass.render(renderer, renderTarget, readBuffer, deltaTime, maskActive);
+    }
     if (this.internalRenderPass) {
       this.internalRenderPass.renderToScreen = this.renderToScreen;
       this.internalRenderPass.render(renderer, renderTarget, readBuffer, deltaTime, maskActive);


### PR DESCRIPTION
Fixes https://github.com/webaverse/app/issues/2203.

This basically gets rid of one complete render of the entire scene that was being wasted, when using both SSAO+DOF (and we always use both). It should result in a significant performance increase for post processing 🎉.

We don't need to keep the depth/normal texture renders separate; it can be one render target that is fed into the SSAO + Depth passes. That is what this PR implements.