### PR TITLE
Eye target update

### DIFF
--- a/avatars/avatars.js
+++ b/avatars/avatars.js
@@ -2590,14 +2590,14 @@ class Avatar {
           .premultiply(localMatrix2.copy(this.modelBoneOutputs.Neck.parent.matrixWorld).invert())
           .decompose(this.modelBoneOutputs.Neck.position, this.modelBoneOutputs.Neck.quaternion, localVector2);
       } else {
-        localMatrix.compose(localVector.set(0, 0, 0), this.startEyeTargetQuaternion, localVector2.set(1, 1, 1))
-          .premultiply(localMatrix2.copy(this.modelBoneOutputs.Neck.parent.matrixWorld).invert())
-          .decompose(localVector, localQuaternion, localVector2);
-        localQuaternion
-          .slerp(localQuaternion2.identity(), cubicBezier(eyeTargetFactor));
-        this.modelBoneOutputs.Neck.quaternion.copy(localQuaternion);
+        if (eyeTargetFactor < 1) {
+          localQuaternion2.copy(this.startEyeTargetQuaternion)
+            .slerp(localQuaternion, cubicBezier(eyeTargetFactor));
+          localMatrix.compose(localVector.set(0, 0, 0), localQuaternion2, localVector2.set(1, 1, 1))
+            .premultiply(localMatrix2.copy(this.modelBoneOutputs.Neck.parent.matrixWorld).invert())
+            .decompose(localVector, localQuaternion, localVector2);
+        }
       }
-      
     };
     _updateEyeTarget();
     this.modelBoneOutputs.Root.updateMatrixWorld();

--- a/avatars/avatars.js
+++ b/avatars/avatars.js
@@ -1274,7 +1274,7 @@ class Avatar {
     this.backwardAnimationSpec = null;
     this.startEyeTargetQuaternion = new THREE.Quaternion();
     this.lastNeedsEyeTarget = false;
-    this.lastEyeTargetTime = 0;
+    this.lastEyeTargetTime = -Infinity;
   }
   static bindAvatar(object) {
     const model = object.scene;


### PR DESCRIPTION
This PR fixes the eyes constantly following the eye target even after targeting is over.

The glitch was seen when animating and teleporting NPCs.