### PR TITLE
Avatars update timestamp

### DIFF
--- a/avatars/avatars.js
+++ b/avatars/avatars.js
@@ -1196,8 +1196,6 @@ class Avatar {
 
     this.microphoneWorker = null;
     this.volume = -1;
-    
-    this.now = 0;
 
     this.shoulderTransforms.Start();
     this.legsManager.Start();
@@ -1685,8 +1683,8 @@ class Avatar {
     );
     return localEuler.y;
   }
-  update(timeDiff) {
-    const {now} = this;
+  update(timestamp, timeDiff) {
+    const now = timestamp;
     const timeDiffS = timeDiff / 1000;
     const currentSpeed = localVector.set(this.velocity.x, 0, this.velocity.z).length();
     
@@ -2766,8 +2764,6 @@ class Avatar {
       }
       this.debugMeshes.geometry.attributes.position.needsUpdate = true;
     } */
-    
-    this.now += timeDiff;
 	}
 
   async setMicrophoneMediaStream(microphoneMediaStream, options = {}) {

--- a/character-controller.js
+++ b/character-controller.js
@@ -546,7 +546,7 @@ class StatePlayer extends PlayerBase {
       const session = renderer.xr.getSession();
       applyPlayerToAvatar(this, session, this.avatar);
 
-      this.avatar.update(timeDiff);
+      this.avatar.update(timestamp, timeDiff);
     }
 
     this.characterPhysics.updateCamera(timeDiff);
@@ -1064,7 +1064,7 @@ class NpcPlayer extends StaticInterpolatedPlayer {
       // const session = renderer.xr.getSession();
       applyPlayerToAvatar(this, null, this.avatar);
 
-      this.avatar.update(timeDiff);
+      this.avatar.update(timestamp, timeDiff);
     }
 
     // this.characterPhysics.updateCamera(timeDiff);


### PR DESCRIPTION
Use the `timestamp` argument as part of avatars update, so it does not track its own `this.now`.

This improves ability to reason about controlled avatars (e.g. animating them offline, or using bullet time) if they do not hold their own view of time.