### PR TITLE
Bugfix depth pass customPostMaterial

### DIFF
--- a/DepthPass.js
+++ b/DepthPass.js
@@ -59,6 +59,7 @@ class DepthPass extends Pass {
 		this.normalMaterial.blending = NoBlending;
 
     this.customScene = new Scene();
+		this.customScene.autoUpdate = false;
     this._visibilityCache = new Map();
     this.originalClearColor = new Color();
 	}


### PR DESCRIPTION
This `DepthPass` iteration was broken for a few reasons:

- `customPostMaterial` renders were duplicated with the normal render, since we would return the objects to the main scene.
- `customPostMaterial` nesting was broken due to ripping out children from the scene during iteration

This should improve performance a bit due to the mistake.