### PR TITLE
Add WebaverseShaderMaterial shaders compilation memoization

### DIFF
--- a/materials.js
+++ b/materials.js
@@ -38,18 +38,31 @@ const appendMain = (shaderText, postfixLine) => {
   }
 `; */
 
-const formatVertexShader = vertexShader => `\
+// memoize a function which takes a string and returns a string
+const _memoize = fn => {
+  const cache = new Map();
+  return s => {
+    let result = cache.get(s);
+    if (result === undefined) {
+      result = fn(s);
+      cache.set(s, result);
+    }
+    return result;
+  };
+}
+
+const formatVertexShader = _memoize(vertexShader => `\
 ${THREE.ShaderChunk.common}
 ${THREE.ShaderChunk.logdepthbuf_pars_vertex}
     
 ${appendMain(vertexShader, THREE.ShaderChunk.logdepthbuf_vertex)}
-`;
+`);
 
-const formatFragmentShader = fragmentShader => `\
+const formatFragmentShader = _memoize(fragmentShader => `\
 ${THREE.ShaderChunk.logdepthbuf_pars_fragment}
     
 ${appendMain(fragmentShader, THREE.ShaderChunk.logdepthbuf_fragment)}
-`;
+`);
 
 class WebaverseShaderMaterial extends THREE.ShaderMaterial {
   constructor(opts = {}) {


### PR DESCRIPTION
`WebaverseShaderMaterial` compiles our custom shaders to work with the non-three.js standard math we use in the renderer. It is transparent to the user except the string substitution.

This PR adds an automatic memoization style cache to the `WebaverseShaderMaterial` compilation process to speed up shader initialization for the case of the same vertex/fragment -- now in that case, `WebaverseShaderMaterial` is basically free performance-wise.

This might clean up a hitch or two.