### PR TITLE
Move computed velocity computation out of avatars.js

### DIFF
--- a/avatars/avatars.js
+++ b/avatars/avatars.js
@@ -1699,29 +1699,12 @@ class Avatar {
     const walkRunFactor = Math.min(Math.max((currentSpeed - walkSpeed) / (runSpeed - walkSpeed), 0), 1);
     // console.log('current speed', currentSpeed, idleWalkFactor, walkRunFactor);
 
-    const _updatePosition = () => {
-      const currentPosition = this.inputs.hmd.position;
-      const currentQuaternion = this.inputs.hmd.quaternion;
-      
-      const positionDiff = localVector.copy(this.lastPosition)
-        .sub(currentPosition)
-        .divideScalar(timeDiffS)
-        .multiplyScalar(0.1);
-      localEuler.setFromQuaternion(currentQuaternion, 'YXZ');
-      localEuler.x = 0;
-      localEuler.z = 0;
-      localEuler.y += Math.PI;
-      localEuler2.set(-localEuler.x, -localEuler.y, -localEuler.z, localEuler.order);
-      positionDiff.applyEuler(localEuler2);
-      this.velocity.copy(positionDiff);
-      this.lastPosition.copy(currentPosition);
-      this.direction.copy(positionDiff).normalize();
-
+    const _updateLastMoveTime = () => {
       if (this.velocity.length() > maxIdleVelocity) {
         this.lastMoveTime = now;
       }
     };
-    _updatePosition();
+    _updateLastMoveTime();
     
     const _applyAnimation = () => {
       const runSpeed = 0.5;

--- a/player-avatar-binding.js
+++ b/player-avatar-binding.js
@@ -15,6 +15,9 @@ export function applyPlayerTransformsToAvatar(player, session, rig) {
     rig.inputs.leftGamepad.quaternion.copy(player.leftHand.quaternion);
     rig.inputs.rightGamepad.position.copy(player.rightHand.position);
     rig.inputs.rightGamepad.quaternion.copy(player.rightHand.quaternion);
+
+    rig.velocity.copy(player.characterPhysics.computedVelocity);
+    rig.direction.copy(player.characterPhysics.computedDirection);
   }
 }
 /* export function applyPlayerMetaTransformsToAvatar(player, session, rig) {


### PR DESCRIPTION
This PR pulls the velocity computation code out of `avatars.js` and puts the same code on the `player.characterPhysics`. The avatar system simply copies it over.

The avatar state should be a specification of "what to render", not a way to compute what to render -- that is what `Player` is for.

This refactor aids in sprite crunching logic, since the sprite can pull the source of truth from the avatar.