### PR TITLE
Apps: remove type parameter

### DIFF
--- a/app-manager.js
+++ b/app-manager.js
@@ -237,14 +237,14 @@ class AppManager extends EventTarget {
         if (!live) return _bailout(null);
         const app = metaversefile.createApp({
           name: contentId,
-          type: (() => {
+          /* type: (() => {
             const match = contentId.match(/\.([a-z0-9]+)$/i);
             if (match) {
               return match[1];
             } else {
               return '';
             }
-          })(),
+          })(), */
         });
         
         app.position.fromArray(position);

--- a/metaversefile-api.js
+++ b/metaversefile-api.js
@@ -738,10 +738,10 @@ metaversefile.setApi({
   getNextInstanceId() {
     return getRandomString();
   },
-  createApp({/* name = '', */start_url = '', type = '', /*components = [], */in_front = false} = {}) {
+  createApp({/* name = '', */start_url = '', /*components = [], */in_front = false} = {}) {
     const app = new App();
     // app.name = name;
-    app.type = type;
+    // app.type = type;
     app.contentId = start_url;
     // app.components = components;
     if (in_front) {


### PR DESCRIPTION
I don't think this was being used, so this PR removes it to clean up the API.

It does not seem to break anything but if it does, we can fix it.