### PR TITLE
Update grass.scn urls to point at webaverse repos

### DIFF
--- a/scenes/grass.scn
+++ b/scenes/grass.scn
@@ -41,7 +41,7 @@
         0,
         0
       ],
-      "start_url": "../floor/"
+      "start_url": "https://webaverse.github.io/floor/"
     },
     {
       "position": [
@@ -49,7 +49,7 @@
         0,
         0
       ],
-      "start_url": "../grass-anime/"
+      "start_url": "https://webaverse.github.io/grass-anime/"
     }
   ]
 }


### PR DESCRIPTION
missing urls

