### PR TITLE
Temporary fix for subapp glb animation in silsword

### DIFF
--- a/metaverse-components.js
+++ b/metaverse-components.js
@@ -187,19 +187,19 @@ const componentTemplates = {
       // const localPlayer = metaversefile.useLocalPlayer();
       if (wearSpec && localPlayer.avatar) {
         const {instanceId} = app;
-
+        const glb = app.glb || app.children[0].glb;
         // animations
-        if (app.glb) {
+        if (glb) {
           const appAimAction = Array.from(localPlayer.getActionsState())
             .find(action => action.type === 'aim' && action.instanceId === instanceId);
-          const {animations} = app.glb;
+          const {animations} = glb;
 
           const appAnimation = appAimAction?.appAnimation ? animations.find(a => a.name === appAimAction.appAnimation) : null;
           if (appAnimation && !appAimAnimationMixers) {
             const clip = animations.find(a => a.name === appAimAction.appAnimation);
             if (clip) {
               appAimAnimationMixers = [];
-              app.glb.scene.traverse(o => {
+              glb.scene.traverse(o => {
                 if (o.isMesh) {
                   const mixer = new THREE.AnimationMixer(o);
                   


### PR DESCRIPTION
https://github.com/webaverse/app/issues/2206

The structuring occurs in silsword/index.js and the glb ends up as the subApp of the actual app and metaverse-components ends up trying to access the animation through the app, so there is a difference here.

This fix is not scalable and needs probably just one more pass.

