### PR TITLE
Depth render cleanup

### DIFF
--- a/BokehShader.js
+++ b/BokehShader.js
@@ -103,7 +103,7 @@
 
 			float viewZ = getViewZ( getDepth( vUv ) );
 
-			if (viewZ < -30000.) {
+			if (viewZ < (-farClip + 1.)) {
         gl_FragColor = texture2D( tColor, vUv.xy );
 				gl_FragColor.a = 1.;
 			} else {

--- a/DepthPass.js
+++ b/DepthPass.js
@@ -132,7 +132,7 @@ class DepthPass extends Pass {
 		// render normals and depth (honor only meshes, points and lines do not contribute to SSAO)
 
 		this.overrideVisibility();
-		this.renderOverride( renderer, this.normalMaterial, this.normalRenderTarget, 0x7777ff, 1.0 );
+		this.renderOverride( renderer, this.normalMaterial, this.normalRenderTarget, 0xffffff, 1.0 );
 		this.restoreVisibility();
   }
 


### PR DESCRIPTION
Cleans up ininity/"camera far" treatment of the depth buffer render pass.

Instead of hardcoding infinity at 30K, we now treat infinity as camera far + 1 for the purposes of depth.