### PR TITLE
App name/description from Totum

### DIFF
--- a/app-manager.js
+++ b/app-manager.js
@@ -253,6 +253,8 @@ class AppManager extends EventTarget {
         app.updateMatrixWorld();
         app.lastMatrix.copy(app.matrixWorld);
 
+        app.name = m.name ?? contentId.match(/([^\/\.]*)$/)[1];
+        app.description = m.description ?? '';
         app.contentId = contentId;
         app.instanceId = instanceId;
         app.setComponent('physics', true);


### PR DESCRIPTION
Adds a name/description to `App` objects, coming from Totum/the app's metaversefile.

Depends on and ingests https://github.com/webaverse/totum/pull/64