### PR TITLE
Post processing pass optimization

### DIFF
--- a/DepthPass.js
+++ b/DepthPass.js
@@ -28,7 +28,7 @@ const oldMaterialCache = new WeakMap();
 
 class DepthPass extends Pass {
 
-	constructor( scenes, camera, {width, height, filterFn} ) {
+	constructor( scenes, camera, {width, height} ) {
 
 		super();
 
@@ -36,8 +36,6 @@ class DepthPass extends Pass {
     this.camera = camera;
     this.width = width;
     this.height = height;
-		this.filterFn = filterFn;
-
     const depthTexture = new DepthTexture();
 		// depthTexture.type = UnsignedShortType;
 
@@ -152,7 +150,7 @@ class DepthPass extends Pass {
 
 				cache.set( object, object.visible );
 
-				if ( object.isPoints || object.isLine || !self.filterFn(object) ) object.visible = false;
+				if ( object.isPoints || object.isLine ) object.visible = false;
 
 			} );
 	  }

--- a/DepthPass.js
+++ b/DepthPass.js
@@ -28,7 +28,7 @@ const oldMaterialCache = new WeakMap();
 
 class DepthPass extends Pass {
 
-	constructor( scene, camera, {width, height} ) {
+	constructor( scene, camera, {width, height, filterFn} ) {
 
 		super();
 
@@ -36,6 +36,7 @@ class DepthPass extends Pass {
     this.camera = camera;
     this.width = width;
     this.height = height;
+		this.filterFn = filterFn;
 
     const depthTexture = new DepthTexture();
 		// depthTexture.type = UnsignedShortType;
@@ -140,12 +141,13 @@ class DepthPass extends Pass {
 
 		const scene = this.scene;
 		const cache = this._visibilityCache;
+		const self = this;
 
 		scene.traverse( function ( object ) {
 
 			cache.set( object, object.visible );
 
-			if ( object.isPoints || object.isLine || object.isLowPriority ) object.visible = false;
+			if ( object.isPoints || object.isLine || !self.filterFn(object) ) object.visible = false;
 
 		} );
 

--- a/SSAOPass.js
+++ b/SSAOPass.js
@@ -27,11 +27,11 @@ import { Pass, FullScreenQuad } from 'three/examples/jsm/postprocessing/Pass.js'
 import { SimplexNoise } from 'three/examples/jsm/math/SimplexNoise.js';
 import { SSAOShader } from 'three/examples/jsm/shaders/SSAOShader.js';
 import { SSAOBlurShader } from 'three/examples/jsm/shaders/SSAOShader.js';
-import { SSAODepthShader } from 'three/examples/jsm/shaders/SSAOShader.js';
+// import { SSAODepthShader } from 'three/examples/jsm/shaders/SSAOShader.js';
 import { CopyShader } from 'three/examples/jsm/shaders/CopyShader.js';
 
-const oldParentCache = new WeakMap();
-const oldMaterialCache = new WeakMap();
+// const oldParentCache = new WeakMap();
+// const oldMaterialCache = new WeakMap();
 
 class SSAOPass extends Pass {
 
@@ -69,7 +69,7 @@ class SSAOPass extends Pass {
 
 		// beauty render target
 
-		const depthTexture = new DepthTexture();
+		// const depthTexture = new DepthTexture();
 		// depthTexture.type = UnsignedShortType;
 
 		this.beautyRenderTarget = new WebGLRenderTarget( this.width, this.height, {

--- a/SSAOPass.js
+++ b/SSAOPass.js
@@ -450,7 +450,7 @@ class SSAOPass extends Pass {
 
 	}
 
-	overrideVisibility() {
+	/* overrideVisibility() {
 
 		const scene = this.scene;
 		const cache = this._visibilityCache;
@@ -460,7 +460,7 @@ class SSAOPass extends Pass {
 
 			cache.set( object, object.visible );
 
-			if ( object.isPoints || object.isLine || !self.filterFn(object) ) object.visible = false;
+			if ( object.isPoints || object.isLine ) object.visible = false;
 
 		} );
 
@@ -480,7 +480,7 @@ class SSAOPass extends Pass {
 
 		cache.clear();
 
-	}
+	} */
 
 }
 

--- a/SSAOPass.js
+++ b/SSAOPass.js
@@ -35,13 +35,12 @@ import { CopyShader } from 'three/examples/jsm/shaders/CopyShader.js';
 
 class SSAOPass extends Pass {
 
-	constructor( scene, camera, width, height, filterFn, depthPass ) {
+	constructor( scene, camera, width, height, depthPass ) {
 
 		super();
 
 		this.width = ( width !== undefined ) ? width : 512;
 		this.height = ( height !== undefined ) ? height : 512;
-		this.filterFn = filterFn;
 		this.depthPass = depthPass;
 
 		this.clear = true;

--- a/SSAOPass.js
+++ b/SSAOPass.js
@@ -454,12 +454,13 @@ class SSAOPass extends Pass {
 
 		const scene = this.scene;
 		const cache = this._visibilityCache;
+		const self = this;
 
 		scene.traverse( function ( object ) {
 
 			cache.set( object, object.visible );
 
-			if ( object.isPoints || object.isLine || object.isLowPriority ) object.visible = false;
+			if ( object.isPoints || object.isLine || !self.filterFn(object) ) object.visible = false;
 
 		} );
 

--- a/SSAOPass.js
+++ b/SSAOPass.js
@@ -35,12 +35,13 @@ const oldMaterialCache = new WeakMap();
 
 class SSAOPass extends Pass {
 
-	constructor( scene, camera, width, height, depthPass ) {
+	constructor( scene, camera, width, height, filterFn, depthPass ) {
 
 		super();
 
 		this.width = ( width !== undefined ) ? width : 512;
 		this.height = ( height !== undefined ) ? height : 512;
+		this.filterFn = filterFn;
 		this.depthPass = depthPass;
 
 		this.clear = true;

--- a/post-processing.js
+++ b/post-processing.js
@@ -42,23 +42,6 @@ const regularScenes = [
   scene,
 ];
 
-const _isObjectChildOf = (object, parent) => {
-  for (let o = object; o; o = o.parent) {
-    if (o === parent) {
-      return true;
-    }
-  }
-};
-const filterCache = new WeakMap();
-const filterFn = object => {
-  let entry = filterCache.get(object);
-  if (entry === undefined) {
-    entry = !_isObjectChildOf(object, sceneLowPriority);
-    filterCache.set(object, entry);
-  }
-  return entry;
-};
-
 function makeDepthPass({ssao, hdr}) {
   const renderer = getRenderer();
   const size = renderer.getSize(localVector2D)
@@ -67,7 +50,6 @@ function makeDepthPass({ssao, hdr}) {
   const depthPass = new DepthPass(regularScenes, camera, {
     width: size.x,
     height: size.y,
-    filterFn,
   });
   depthPass.needsSwap = false;
   // depthPass.enabled = hqDefault;
@@ -83,7 +65,7 @@ function makeSsaoRenderPass({
   const size = renderer.getSize(localVector2D)
     .multiplyScalar(renderer.getPixelRatio());
 
-  const ssaoRenderPass = new SSAOPass(rootScene, camera, size.x, size.y, filterFn, depthPass);
+  const ssaoRenderPass = new SSAOPass(rootScene, camera, size.x, size.y, depthPass);
   ssaoRenderPass.kernelSize = kernelSize;
   ssaoRenderPass.kernelRadius = kernelRadius;
   ssaoRenderPass.minDistance = minDistance;

--- a/post-processing.js
+++ b/post-processing.js
@@ -17,6 +17,8 @@ import {
   getRenderer,
   getComposer,
   rootScene,
+  sceneHighPriority,
+  scene,
   sceneLowPriority,
   postSceneOrthographic,
   postScenePerspective,
@@ -35,38 +37,10 @@ import metaversefileApi from 'metaversefile';
 // const localVector = new THREE.Vector3();
 const localVector2D = new THREE.Vector2();
 
-/* const testSpec = {
-  "background": {
-    "color": [0, 0, 0]
-  },
-  "fog": {
-    "fogType": "exp",
-    "args": [[255, 255, 255], 0.01]
-  },
-  "ssao": {
-    "kernelRadius": 16,
-    "minDistance": 0.005,
-    "maxDistance": 0.1
-  },
-  "dof": {
-    "focus": 3.0,
-    "aperture": 0.00002,
-    "maxblur": 0.005
-  },
-  "hdr": {
-    "adaptive": true,
-    "resolution": 256,
-    "adaptionRate": 100,
-    "maxLuminance": 10,
-    "minLuminance": 0,
-    "middleGrey": 3
-  },
-  "bloom": {
-    "strength": 0.2,
-    "radius": 0.5,
-    "threshold": 0.8
-  }
-}; */
+const regularScenes = [
+  sceneHighPriority,
+  scene,
+];
 
 const _isObjectChildOf = (object, parent) => {
   for (let o = object; o; o = o.parent) {
@@ -90,7 +64,7 @@ function makeDepthPass({ssao, hdr}) {
   const size = renderer.getSize(localVector2D)
     .multiplyScalar(renderer.getPixelRatio());
 
-  const depthPass = new DepthPass(rootScene, camera, {
+  const depthPass = new DepthPass(regularScenes, camera, {
     width: size.x,
     height: size.y,
     filterFn,

--- a/post-processing.js
+++ b/post-processing.js
@@ -3,7 +3,7 @@ this file implements post processing.
 */
 
 import * as THREE from 'three';
-import {Pass} from 'three/examples/jsm/postprocessing/Pass.js';
+// import {Pass} from 'three/examples/jsm/postprocessing/Pass.js';
 import {ShaderPass} from 'three/examples/jsm/postprocessing/ShaderPass.js';
 import {UnrealBloomPass} from 'three/examples/jsm/postprocessing/UnrealBloomPass.js';
 import {AdaptiveToneMappingPass} from 'three/examples/jsm/postprocessing/AdaptiveToneMappingPass.js';

--- a/scenes/treehouse.scn
+++ b/scenes/treehouse.scn
@@ -28,8 +28,8 @@
           "maxDistance": 0.1
         },
         "dof": {
-          "focus": 3.0,
-          "aperture": 0.00002,
+          "focus": 2.0,
+          "aperture": 0.0001,
           "maxblur": 0.005
         },
         "hdr": {
@@ -41,9 +41,9 @@
           "middleGrey": 3
         },
         "bloom": {
-          "strength": 0.2,
+          "strength": 0.1,
           "radius": 0.5,
-          "threshold": 0.8
+          "threshold": 0.9
         }
       }
     },

--- a/webaverse-render-pass.js
+++ b/webaverse-render-pass.js
@@ -34,15 +34,6 @@ class WebaverseRenderPass extends Pass {
     this.onBeforeRender && this.onBeforeRender();
     
     // render
-    /* sceneHighPriority.traverse(o => {
-      o.isLowPriority = false;
-    });
-    scene.traverse(o => {
-      o.isLowPriority = false;
-    });
-    sceneLowPriority.traverse(o => {
-      o.isLowPriority = true;
-    }); */
     if (this.internalDepthPass) {
       this.internalDepthPass.renderToScreen = false;
       this.internalDepthPass.render(renderer, renderTarget, readBuffer, deltaTime, maskActive);

--- a/webaverse-render-pass.js
+++ b/webaverse-render-pass.js
@@ -34,7 +34,7 @@ class WebaverseRenderPass extends Pass {
     this.onBeforeRender && this.onBeforeRender();
     
     // render
-    sceneHighPriority.traverse(o => {
+    /* sceneHighPriority.traverse(o => {
       o.isLowPriority = false;
     });
     scene.traverse(o => {
@@ -42,7 +42,7 @@ class WebaverseRenderPass extends Pass {
     });
     sceneLowPriority.traverse(o => {
       o.isLowPriority = true;
-    });
+    }); */
     if (this.internalDepthPass) {
       this.internalDepthPass.renderToScreen = false;
       this.internalDepthPass.render(renderer, renderTarget, readBuffer, deltaTime, maskActive);


### PR DESCRIPTION
The SSAO/Depth passes need to know whether an object is in the skybox group (low priority) so it can be skipped. There was previously a separate pass to compute this, plus more caching passes to set visibility. This resulted in many extra passes over the scene for not much reason, particularly slowing down cases where there are e.g. a lot of avatars with a lot of bones.

This optimizes that entire flow by eliminating it. Instead, the correct scenes are iterated over in DepthPass and SSAOPass with no marking passes at all.

This should make the rendering loop faster, especially for SSAO post processing and any cases where there are a lot of objects and/or bones.