### PR TITLE
Minimap

### DIFF
--- a/metaversefile-api.js
+++ b/metaversefile-api.js
@@ -33,7 +33,7 @@ import {chatManager} from './chat-manager.js';
 import loreAI from './lore-ai.js';
 import loreAIScene from './lore-ai-scene.js';
 import npcManager from './npc-manager.js';
-import {isSceneLoaded, waitForSceneLoaded} from './universe.js';
+import universe from './universe.js';
 import {PathFinder} from './npc-utils.js';
 import loaders from './loaders.js';
 import {getHeight} from './avatars/util.mjs';
@@ -887,10 +887,10 @@ export default () => {
     return gradientMaps;
   },
   isSceneLoaded() {
-    return isSceneLoaded();
+    return universe.isSceneLoaded();
   },
   async waitForSceneLoaded() {
-    await waitForSceneLoaded();
+    await universe.waitForSceneLoaded();
   },
   async addModule(app, m) {
     currentAppRender = app;

--- a/minimap.js
+++ b/minimap.js
@@ -357,7 +357,7 @@ const _makeMapRenderTarget = (w, h) => new THREE.WebGLRenderTarget(w, h, {
   format: THREE.RGBAFormat,
 });
 
-const minimapWorldSize = 100;
+// const minimapWorldSize = 100;
 const pixelRatio = window.devicePixelRatio;
 
 const minimaps = [];
@@ -370,10 +370,10 @@ class MiniMap {
 
     this.mapRenderTarget = null;
     this.topCamera = new THREE.OrthographicCamera(
-      -minimapWorldSize*0.5,
-      minimapWorldSize*0.5,
-      minimapWorldSize*0.5,
-      -minimapWorldSize*0.5,
+      -this.worldWidth*0.5,
+      this.worldWidth*0.5,
+      this.worldHeight*0.5,
+      -this.worldHeight*0.5,
       0,
       1000
     );

--- a/minimap.js
+++ b/minimap.js
@@ -21,6 +21,11 @@ const localMatrix = new THREE.Matrix4();
 
 const cameraHeight = 50;
 
+// XXX TODO:
+// render at mose once per frame
+// do not render avatars
+// debug mirrors
+
 const vertexShader = `\
   varying vec2 vUv;
 

--- a/minimap.js
+++ b/minimap.js
@@ -181,10 +181,10 @@ class MiniMap {
   constructor(width, height, worldWidth, worldHeight) {
     this.width = width;
     this.height = height;
-    this.worldWidth = worldWidth;
-    this.worldHeight = worldHeight;
-    this.worldWidthD3 = worldWidth / 3;
-    this.worldHeightD3 = worldHeight / 3;
+    this.worldWidthD3 = Math.floor(worldWidth / 3);
+    this.worldHeightD3 = Math.floor(worldHeight / 3);
+    this.worldWidth = this.worldWidthD3 * 3;
+    this.worldHeight = this.worldHeightD3 * 3;
 
     this.topCamera = new THREE.OrthographicCamera(
       -this.worldWidth/3*0.5,

--- a/minimap.js
+++ b/minimap.js
@@ -238,6 +238,8 @@ class MiniMap {
     };
     _copyToCanvases();
 
+    renderer.clear();
+
     // pop old state
     renderer.setRenderTarget(oldRenderTarget);
     renderer.setViewport(oldViewport);

--- a/minimap.js
+++ b/minimap.js
@@ -30,7 +30,6 @@ const cameraHeight = 50;
 // debug mirrors
 
 const fullscreenVertexShader = `\
-  // uniform vec4 uUvOffset;
   varying vec2 vUv;
 
   void main() {
@@ -44,14 +43,7 @@ const fullscreenFragmentShader = `\
   varying vec2 vUv;
 
   void main() {
-    // vec2 uv = uUvOffset.xy + vUv + uUvOffset.zw;
-    // gl_FragColor = texture2D(uTex, uv);
-    // vec2 uv = vUv;
-    // uv.y = 1. - uv.y;
-    // vec2 oUv = uUvOffset.xy;
-    // oUv.y = 1. - oUv.y;
     gl_FragColor = texture2D(uTex, (vUv + 1. +  uUvOffset.xy) * uUvOffset.zw);
-    // gl_FragColor.gb += uv * 0.05;
   }
 `;
 

--- a/minimap.js
+++ b/minimap.js
@@ -25,7 +25,7 @@ const cameraHeight = 50;
 // XXX TODO:
 // add compass border circle
 // add compass north
-// render at mose once per frame
+// render at most once per frame
 // do not render avatars
 // debug mirrors
 

--- a/minimap.js
+++ b/minimap.js
@@ -4,6 +4,7 @@ import {
   sceneHighPriority,
   scene,
   sceneLowPriority,
+  camera,
 } from './renderer.js';
 // import * as BufferGeometryUtils from 'three/examples/jsm/utils/BufferGeometryUtils.js';
 // import {world} from './world.js';
@@ -427,7 +428,7 @@ class MiniMap {
             .add(localVector3.set(0, cameraHeight, 0)),
           localPlayer.position,
           localVector2.set(0, 0, -1)
-            .applyQuaternion(localPlayer.quaternion),
+            .applyQuaternion(camera.quaternion),
         )
       );
       this.topCamera.updateMatrixWorld();

--- a/minimap.js
+++ b/minimap.js
@@ -1,0 +1,486 @@
+import * as THREE from 'three';
+import {
+  getRenderer,
+  sceneHighPriority,
+  scene,
+  sceneLowPriority,
+} from './renderer.js';
+// import * as BufferGeometryUtils from 'three/examples/jsm/utils/BufferGeometryUtils.js';
+// import {world} from './world.js';
+import metaversefileApi from 'metaversefile';
+// import {fitCameraToBoundingBox} from './util.js';
+
+const localVector = new THREE.Vector3();
+const localVector2 = new THREE.Vector3();
+const localVector3 = new THREE.Vector3();
+const localVector2D = new THREE.Vector2();
+const localVector2D2 = new THREE.Vector2();
+const localVector4D = new THREE.Vector4();
+const localMatrix = new THREE.Matrix4();
+
+const regularScenes = [
+  scene,
+  sceneHighPriority,
+];
+const cameraHeight = 50;
+
+const bgVertexShader = `\
+  varying vec2 tex_coords;
+
+  void main() {
+    tex_coords = uv;
+    gl_Position = vec4(position.xy, 1., 1.);
+  }
+`;
+const outlineShader = `\
+  varying vec4 v_colour;
+  varying vec2 tex_coords;
+
+  uniform sampler2D t0;
+  uniform float outline_thickness;
+  uniform vec3 uColor1;
+  uniform vec3 uColor2;
+  uniform float outline_threshold;
+
+  #define pixel gl_FragColor
+  #define PI 3.1415926535897932384626433832795
+
+  void main() {
+    /* float sum = 0.0;
+    int passes = 64;
+    float passesFloat = float(passes);
+    float step = outline_thickness / passesFloat;
+    // top
+    for (int i = 0; i < passes; ++i) {
+      float n = float(i);
+      vec2 uv = tex_coords + vec2(-outline_thickness*0.5 + step * n, outline_thickness);
+      sum += texture(t0, uv).a;
+    }
+    // bottom
+    for (int i = 0; i < passes; ++i) {
+      float n = float(i);
+      vec2 uv = tex_coords + vec2(-outline_thickness*0.5 + step * n, -outline_thickness);
+      sum += texture(t0, uv).a;
+    }
+    // left
+    for (int i = 0; i < passes; ++i) {
+      float n = float(i);
+      vec2 uv = tex_coords + vec2(-outline_thickness, -outline_thickness*0.5 + step * n);
+      sum += texture(t0, uv).a;
+    }
+    // right
+    for (int i = 0; i < passes; ++i) {
+      float n = float(i);
+      vec2 uv = tex_coords + vec2(outline_thickness, -outline_thickness*0.5 + step * n);
+      sum += texture(t0, uv).a;
+    } */
+
+    float sum = 0.0;
+    int passes = 32;
+    float passesFloat = float(passes);
+    float angleStep = 2.0 * PI / passesFloat;
+    for (int i = 0; i < passes; ++i) {
+        float n = float(i);
+        float angle = angleStep * n;
+
+        vec2 uv = tex_coords + vec2(cos(angle), sin(angle)) * outline_thickness;
+        sum += texture(t0, uv).a; // / passesFloat;
+    }
+
+    if (sum > 0.) {
+      vec3 c = mix(uColor1, uColor2, 1. - tex_coords.y) * 0.35;
+      pixel = vec4(c, 1);
+    } else {
+      discard;
+      // pixel = texture(t0, tex_coords);
+    }
+  }
+`;
+const animeLightningFragmentShader = `\
+  uniform float iTime;
+  uniform int iFrame;
+  uniform vec3 uColor1;
+  uniform vec3 uColor2;
+  uniform sampler2D iChannel0;
+  uniform sampler2D iChannel1;
+  varying vec2 tex_coords;
+
+  // Quick and dirty line experiment to generate electric bolts :)
+
+  // http://extremelearning.com.au/unreasonable-effectiveness-of-quasirandom-sequences/
+  float R1seq(int n)
+  {
+    return fract(float(n) * 0.618033988749894848204586834365641218413556121186522017520);
+  }
+
+  vec2 R2seq(int n)
+  {
+    return fract(vec2(n) * vec2(0.754877666246692760049508896358532874940835564978799543103, 0.569840290998053265911399958119574964216147658520394151385));
+  }
+
+  // modified iq's segment: https://www.shadertoy.com/view/ldj3Wh
+  vec2 Line(vec2 a, vec2 b, vec2 p, vec2 identity, float sa, float sb)
+  {
+      vec2 pa = p - a;
+      vec2 pb = p - b;
+      vec2 ba = b - a;
+      float t = clamp(dot(pa,ba)/dot(ba,ba), 0.0, 1.0);    
+      vec2 pp = a + ba * t;
+      vec2 y = vec2(-identity.y, identity.x);
+      float cutoff = max(dot(pb, identity), dot(pa, -identity));
+      float s = mix(sa, sb, t);
+      return vec2(max(cutoff - .005, abs(dot(y, p - pp)) - s), t);
+  }
+
+  float Rythm(float x)
+  {
+    x = x * 6.28318 * 10.0 / 60.0;
+    x = smoothstep(-1.0, 1.0, sin(x));
+    x = smoothstep(0.0, 1.0, x);
+    x = smoothstep(0.0, 1.0, x);
+    x = smoothstep(0.0, 1.0, x);
+    x = smoothstep(0.0, 1.0, x);
+    return x;
+  }
+
+  vec3 Background(vec2 uv, vec2 baseDir, float time)
+  {
+      uv = uv * vec2(.75, .75);
+      vec3 result = vec3(0.91, 0.56, 0.02);
+      
+      vec2 n = vec2(-baseDir.y, baseDir.x);
+      
+      result = mix(result, vec3(1.0) - result, Rythm(time));
+      
+      float lines = texture(iChannel0, vec2(uv.x * 0.1, uv.y * 2.) + vec2(time * 1.35, 0.0)).r;
+      result += lines * lines * .75 + lines * lines * lines * .35;    
+      // result *= smoothstep(.5, .0, abs(dot(uv, n)));
+      
+      return result;
+  }
+
+  vec3 Magic(float leadTime, vec3 baseColor, vec2 uv, vec2 baseDir, float time, float spread, float freq, float intensity)
+  {
+      int frame = iFrame / 12;
+      
+      float speed = -1.5 - ((Rythm(time)) * .5 + .5) * 2.0;
+      //speed *= .2;
+      vec2 dir = normalize(baseDir);
+      
+      
+      uv -= dir * mix(.1, .3, Rythm(time));
+      
+      vec2 normal = vec2(-dir.y, dir.x);
+      
+      vec2 baseOffset = dir * speed * floor(float(iFrame) / 24.0);
+      
+      vec2 p = uv;
+      p.y -= 0.4;
+      p += dir * speed * (float(iFrame) / 24.0);
+      p -= R2seq(int(floor(float(iFrame)/3.0))) * .05;
+      p += normal * sin(time * 12.0) * .05;
+              
+      float ray = 0.0;
+      float glow = 0.0;
+      
+      p += (texture(iChannel1, p * .015 + leadTime * .25).xy * 2.0 - 1.0) * .1;
+      
+      float leadIntro = mix(.3, .015, smoothstep(10.0, 14.0, time));
+      
+      float leadingTime = 1.0 - smoothstep(leadTime - .5, leadTime, time);
+      float distanceToLead = dot(uv - .5, dir) - leadingTime * 2.0 - leadIntro;
+      float leadingMask = smoothstep(-.85, -.0, distanceToLead);
+      
+      p += leadingMask * (texture(iChannel1, vec2(time * .01 + leadTime * .35)).xy * 2.0 - 1.0) * .35;
+      
+      float sizeIntro = smoothstep(13.85, 14.15, time);
+      spread *= leadingMask * (1.0 - Rythm(time) * .75) * sizeIntro;
+      
+      for(int i = -12; i < 10; i++)
+      {
+      float offsetA = R1seq(i+frame) * 2.0 - 1.0;
+          float offsetB = R1seq(i+frame+1) * 2.0 - 1.0;
+          
+          vec2 a = baseOffset + dir * float(i) * freq + normal * offsetA * spread;
+          vec2 b = baseOffset + dir * float(i+1) * freq + normal * offsetB * spread;
+          
+          float sa = mix(.05, 3.0 * intensity, R1seq(frame*7+i-1)) * .005;
+          float sb = mix(.05, 3.0 * intensity, R1seq(frame*7+i)) * .005;
+          
+          vec2 l = Line(a, b, p, dir, sa, sb);
+          float d = .025 * leadingMask;
+      
+          ray += smoothstep(d, d * .75 - .0001, l.x);
+          glow += .5 * leadingMask * smoothstep(d * 20.0, d, l.x);
+      }
+
+      ray = clamp(ray, 0.0, 1.0);
+      return baseColor * (1.0 + glow * (Rythm(time * 16.0) * .05 + .025)) + vec3(ray) * intensity;
+  }
+
+  vec3 Background2(vec2 uv, float time) {
+    // uv = uv * vec2(.75, .75);
+    vec3 result = mix(uColor1, uColor2, 1. - uv.y);
+    
+    // vec2 n = vec2(-baseDir.y, baseDir.x);
+    
+    // result = mix(result, vec3(1.0) - result, Rythm(time));
+    
+    float lines = texture(iChannel0, vec2(uv.x * 0.1, uv.y * 2.) + vec2(time * 1.35, 0.0)).r;
+    result += lines * lines * .75 + lines * lines * lines * .35;    
+    // result *= smoothstep(.5, .0, abs(dot(uv, n)));
+    
+    return result;
+  }
+
+  void mainImage( out vec4 fragColor, in vec2 fragCoord )
+  {
+      float time = -.25 + floor(iTime * 1.1 * 24.0) / 24.0;
+      // float intro = 1.; // smoothstep(12.85, 13.15, time);
+      // vec2 uv = fragCoord/iResolution.xy;
+      vec2 uv = fragCoord;
+      
+      uv.y -= .075;
+      uv.x -= sin(time*4.0) * .2;
+      
+      vec2 baseDir = vec2(1., 0.);
+      
+      // vec3 col = Background(uv, baseDir, time);
+      vec3 col = Background2(uv, time);
+      
+      float spread = .35 + (sin(time * 10.0) * .5 + .5);
+      float freq = .6 - (sin(time * 4.0) * .5 + .5) * .2;
+      
+      
+      float offset = 1.0 - (smoothstep(5.0, 7.0, time) * smoothstep( 14.0, 13.0, time));
+      
+      spread *= offset;
+      
+      col = Magic(.5, col, uv + vec2(.4, .1) * offset, baseDir, time, .2, .35, 1.0);
+      col = Magic(3.0, col, uv + vec2(.2, .0) * offset, baseDir, time, .05, .15, .55);
+      col = Magic(8.0, col, uv + vec2(.2, -.25) * offset, baseDir, time, .05, .15, .35);
+      col = Magic(10.0, col, uv + vec2(-.15, -.35) * offset, baseDir, time, .04, .05, .75);
+      col = Magic(11.0, col, uv + vec2(-.3, -.15) * offset, baseDir, time, .04, .05, .75);
+      col = Magic(12.0, col, uv, baseDir, time, spread * .75, freq, 1.0);
+
+      fragColor = vec4(col,1.0);
+  }
+
+  void main() {
+    mainImage(gl_FragColor, tex_coords);
+  }
+`;
+const animeRadialShader = `\
+  uniform float iTime;
+  uniform int iFrame;
+  uniform sampler2D iChannel0;
+  uniform sampler2D iChannel1;
+  varying vec2 tex_coords;
+
+  const float fps = 30.;
+  const float intensityFactor = 0.5; // .8;
+  const float minRadius = 0.2; // 0.1;
+  const float maxRadius = 0.65;
+
+  float hash( vec2 p ) {return fract(sin(dot(p,vec2(127.1,311.7)))*43758.5453123);} //Pseudo-random
+  float smoothNoise( in vec2 p) { //Bilinearly interpolated noise (4 samples)
+      vec2 i = floor( p ); vec2 f = fract( p );	
+    vec2 u = f*f*(3.0-2.0*f);
+      float a = hash( i + vec2(0.0,0.0) );
+    float b = hash( i + vec2(1.0,0.0) );
+    float c = hash( i + vec2(0.0,1.0) );
+    float d = hash( i + vec2(1.0,1.0) );
+      return float(a+(b-a)*u.x+(c-a)*u.y+(a-b-c+d)*u.x*u.y)/4.;
+  }
+  //Funciton to make the noise continuous while wrapping around angle 
+  float rotatedMirror(float t, float r){
+      //t : 0->1
+      t = fract(t+r);
+      return 2.*abs(t-0.5);
+  }
+  //Some continous radial perlin noise
+  const mat2 m2 = mat2(0.90,0.44,-0.44,0.90);
+  float radialPerlinNoise(float t, float d){
+      const float BUMP_MAP_UV_SCALE = 44.2;
+      d = pow(d,0.01); //Impression of speed : stretch noise as the distance increases.
+      float dOffset = -floor(iTime*fps)/fps; //Time drift (animation)
+      vec2 p = vec2(rotatedMirror(t,0.1),d+dOffset);
+      float f1 = smoothNoise(p*BUMP_MAP_UV_SCALE);
+      p = 2.1*vec2(rotatedMirror(t,0.4),d+dOffset);
+      float f2 = smoothNoise(p*BUMP_MAP_UV_SCALE);
+      p = 3.7*vec2(rotatedMirror(t,0.8),d+dOffset);
+      float f3 = smoothNoise(p*BUMP_MAP_UV_SCALE);
+      p = 5.8*vec2(rotatedMirror(t,0.0),d+dOffset);
+      float f4 = smoothNoise(p*BUMP_MAP_UV_SCALE);
+      return (f1+0.5*f2+0.25*f3+0.125*f4)*3.;
+  }
+  //Colorize function (transforms BW Intensity to color)
+  vec3 colorize(float f){
+      f = clamp(f*.95,0.0,1.0);
+      vec3 c = mix(vec3(0,0,1.1), vec3(0,1,1), f); //Red-Yellow Gradient
+          c = mix(c, vec3(1,1,1), f*4.-3.0);      //While highlights
+      vec3 cAttenuated = mix(vec3(0), c, f+0.1);       //Intensity ramp
+      return cAttenuated;
+  }
+  /*vec3 colorize(float f){
+      f = clamp(f,0.0,1.0);
+      vec3 c = mix(vec3(1.1,0,0), vec3(1,1,0), f); //Red-Yellow Gradient
+          c = mix(c, vec3(1,1,1), f*10.-9.);      //While highlights
+      vec3 cAttenuated = mix(vec3(0), c, f);       //Intensity ramp
+      return cAttenuated;
+  }*/
+  //Main image.
+  void mainImage( out vec4 fragColor, in vec2 fragCoord ){
+      // vec2 uv = 2.2*(fragCoord-0.5*vec2(iResolution.xy))/iResolution.xx;
+      vec2 uv = 2.2 * ((fragCoord + vec2(0., 0.)) - 0.5);
+      float d = dot(uv,uv); //Squared distance
+      float t = 0.5+atan(uv.y,uv.x)/6.28; //Normalized Angle
+      float v = radialPerlinNoise(t,d);
+      //Saturate and offset values
+      v = -2.5+v*4.5;
+      //Intersity ramp from center
+      v = mix(0.,v,intensityFactor*smoothstep(minRadius, maxRadius,d));
+      //Colorize (palette remap )
+      fragColor.rgb = colorize(v);
+      fragColor.a = v;
+  }
+
+  void main() {
+    mainImage(gl_FragColor, tex_coords);
+  }
+`;
+
+const _makeMapRenderTarget = (w, h) => new THREE.WebGLRenderTarget(w, h, {
+  minFilter: THREE.LinearFilter,
+  magFilter: THREE.LinearFilter,
+  format: THREE.RGBAFormat,
+});
+
+const minimapWorldSize = 100;
+const pixelRatio = window.devicePixelRatio;
+
+const minimaps = [];
+class MiniMap {
+  constructor(width, height, worldWidth, worldHeight) {
+    this.width = width;
+    this.height = height;
+    this.worldWidth = worldWidth;
+    this.worldHeight = worldHeight;
+
+    this.mapRenderTarget = null;
+    this.topCamera = new THREE.OrthographicCamera(
+      -minimapWorldSize*0.5,
+      minimapWorldSize*0.5,
+      minimapWorldSize*0.5,
+      -minimapWorldSize*0.5,
+      0,
+      1000
+    );
+
+    this.canvases = [];
+  }
+  resetCanvases() {
+    this.canvases.length = 0;
+  }
+  addCanvas(canvas) {
+    const {width, height} = canvas;
+    this.width = Math.max(this.width, width);
+    this.height = Math.max(this.height, height);
+
+    const ctx = canvas.getContext('2d');
+    canvas.ctx = ctx;
+
+    this.canvases.push(canvas);
+  }
+  update(timestamp, timeDiff) {
+    // const timeOffset = timestamp - lastDisabledTime;
+
+    if (!this.mapRenderTarget || (this.mapRenderTarget.width !== this.width * pixelRatio) || (this.mapRenderTarget.height !== this.height * pixelRatio)) {
+      this.mapRenderTarget = _makeMapRenderTarget(this.width * pixelRatio, this.height * pixelRatio);
+    }
+
+    const localPlayer = metaversefileApi.useLocalPlayer();
+
+    const renderer = getRenderer();
+    const size = renderer.getSize(localVector2D);
+    // a Vector2 representing the largest power of two less than or equal to the current canvas size
+    const sizePowerOfTwo = localVector2D2.set(
+      Math.pow(2, Math.floor(Math.log(size.x) / Math.log(2))),
+      Math.pow(2, Math.floor(Math.log(size.y) / Math.log(2))),
+    );
+    if (sizePowerOfTwo.x < this.width || sizePowerOfTwo.y < this.height) {
+      console.warn('renderer is too small');
+      return;
+    }
+  
+    // push old state
+    // const oldParent = app.parent;
+    // const oldRenderTarget = renderer.getRenderTarget();
+    const oldViewport = renderer.getViewport(localVector4D);
+  
+    const _render = () => {
+      // set up top camera
+      this.topCamera.position.copy(localPlayer.position);
+      this.topCamera.quaternion.setFromRotationMatrix(
+        localMatrix.lookAt(
+          localVector.copy(localPlayer.position)
+            .add(localVector3.set(0, cameraHeight, 0)),
+          localPlayer.position,
+          localVector2.set(0, 0, -1)
+            .applyQuaternion(localPlayer.quaternion),
+        )
+      );
+      this.topCamera.updateMatrixWorld();
+      
+      // render side scene
+      // renderer.setRenderTarget(oldRenderTarget);
+      renderer.setViewport(0, 0, this.width, this.height);
+      renderer.clear();
+      for (const scene of regularScenes) {
+        renderer.render(scene, this.topCamera);
+      }
+  
+      for (const canvas of this.canvases) {
+        const {width, height, ctx} = canvas;
+        ctx.clearRect(0, 0, width, height);
+        ctx.drawImage(
+          renderer.domElement,
+          0,
+          size.y * pixelRatio - this.height * pixelRatio,
+          this.width * pixelRatio,
+          this.height * pixelRatio,
+          0,
+          0,
+          width,
+          height
+        );
+      }
+    };
+    _render();
+
+    // pop old state
+    // renderer.setRenderTarget(oldRenderTarget);
+    renderer.setViewport(oldViewport);
+  }
+  destroy() {
+    for (const canvas of canvases) {
+      canvas.parentNode.removeChild(canvas);
+    }
+    minimaps.splice(minimaps.indexOf(this), 1);
+  }
+}
+
+const minimapManager = {
+  createMiniMap(width, height) {
+    const minimap = new MiniMap(width, height);
+    minimaps.push(minimap);
+    return minimap;
+  },
+  update(timestamp, timeDiff) {
+    for (const minimap of minimaps) {
+      minimap.update(timestamp, timeDiff);
+    }
+  }
+};
+
+export default minimapManager;

--- a/minimap.js
+++ b/minimap.js
@@ -17,6 +17,7 @@ const localVector2D = new THREE.Vector2();
 const localVector2D2 = new THREE.Vector2();
 const localVector2D3 = new THREE.Vector2();
 const localVector4D = new THREE.Vector4();
+const localEuler = new THREE.Euler();
 const localMatrix = new THREE.Matrix4();
 
 const cameraHeight = 50;
@@ -254,7 +255,10 @@ class MiniMap {
 
     const _renderMiniMap = () => {
       this.scene.reticleMesh.position.set(localPlayer.position.x, cameraHeight - 1, localPlayer.position.z);
-      this.scene.reticleMesh.quaternion.copy(localPlayer.quaternion);
+      localEuler.setFromQuaternion(localPlayer.quaternion, 'YXZ');
+      localEuler.x = 0;
+      localEuler.z = 0;
+      this.scene.reticleMesh.quaternion.setFromEuler(localEuler);
       this.scene.reticleMesh.updateMatrixWorld();
 
       renderer.setRenderTarget(oldRenderTarget);

--- a/minimap.js
+++ b/minimap.js
@@ -1,6 +1,7 @@
 import * as THREE from 'three';
 import {
   getRenderer,
+  rootScene,
   sceneHighPriority,
   scene,
   sceneLowPriority,
@@ -21,10 +22,11 @@ const localVector2D4 = new THREE.Vector2();
 const localVector4D = new THREE.Vector4();
 const localMatrix = new THREE.Matrix4();
 
-const regularScenes = [
-  scene,
+/* const regularScenes = [
   sceneHighPriority,
-];
+  scene,
+  sceneLowPriority,
+]; */
 const cameraHeight = 50;
 
 const vertexShader = `\
@@ -168,9 +170,9 @@ class MiniMap {
       
       renderer.setViewport((dx+1) * this.width/3, (-dy+1) * this.height/3, this.width/3, this.height/3);
       // renderer.setViewport(0, 0, this.width, this.height);
-      for (const scene of regularScenes) {
-        renderer.render(scene, this.topCamera);
-      }
+      // for (const scene of regularScenes) {
+        renderer.render(rootScene, this.topCamera);
+      // }
     };
     const _updateTiles = () => {
       let first = true;

--- a/minimap.js
+++ b/minimap.js
@@ -185,6 +185,7 @@ class MiniMap {
     this.worldHeightD3 = Math.floor(worldHeight / 3);
     this.worldWidth = this.worldWidthD3 * 3;
     this.worldHeight = this.worldHeightD3 * 3;
+    this.enabled = true;
 
     this.topCamera = new THREE.OrthographicCamera(
       -this.worldWidth/3*0.5,
@@ -396,7 +397,7 @@ const minimapManager = {
   },
   update(timestamp, timeDiff) {
     for (const minimap of minimaps) {
-      minimap.update(timestamp, timeDiff);
+      minimap.enabled && minimap.update(timestamp, timeDiff);
     }
   }
 };

--- a/minimap.js
+++ b/minimap.js
@@ -16,6 +16,8 @@ const localVector2 = new THREE.Vector3();
 const localVector3 = new THREE.Vector3();
 const localVector2D = new THREE.Vector2();
 const localVector2D2 = new THREE.Vector2();
+const localVector2D3 = new THREE.Vector2();
+const localVector2D4 = new THREE.Vector2();
 const localVector4D = new THREE.Vector4();
 const localMatrix = new THREE.Matrix4();
 
@@ -25,329 +27,30 @@ const regularScenes = [
 ];
 const cameraHeight = 50;
 
-const bgVertexShader = `\
-  varying vec2 tex_coords;
+const vertexShader = `\
+  varying vec2 vUv;
 
   void main() {
-    tex_coords = uv;
+    vUv = uv;
     gl_Position = vec4(position.xy, 1., 1.);
   }
 `;
-const outlineShader = `\
-  varying vec4 v_colour;
-  varying vec2 tex_coords;
-
-  uniform sampler2D t0;
-  uniform float outline_thickness;
-  uniform vec3 uColor1;
-  uniform vec3 uColor2;
-  uniform float outline_threshold;
-
-  #define pixel gl_FragColor
-  #define PI 3.1415926535897932384626433832795
-
-  void main() {
-    /* float sum = 0.0;
-    int passes = 64;
-    float passesFloat = float(passes);
-    float step = outline_thickness / passesFloat;
-    // top
-    for (int i = 0; i < passes; ++i) {
-      float n = float(i);
-      vec2 uv = tex_coords + vec2(-outline_thickness*0.5 + step * n, outline_thickness);
-      sum += texture(t0, uv).a;
-    }
-    // bottom
-    for (int i = 0; i < passes; ++i) {
-      float n = float(i);
-      vec2 uv = tex_coords + vec2(-outline_thickness*0.5 + step * n, -outline_thickness);
-      sum += texture(t0, uv).a;
-    }
-    // left
-    for (int i = 0; i < passes; ++i) {
-      float n = float(i);
-      vec2 uv = tex_coords + vec2(-outline_thickness, -outline_thickness*0.5 + step * n);
-      sum += texture(t0, uv).a;
-    }
-    // right
-    for (int i = 0; i < passes; ++i) {
-      float n = float(i);
-      vec2 uv = tex_coords + vec2(outline_thickness, -outline_thickness*0.5 + step * n);
-      sum += texture(t0, uv).a;
-    } */
-
-    float sum = 0.0;
-    int passes = 32;
-    float passesFloat = float(passes);
-    float angleStep = 2.0 * PI / passesFloat;
-    for (int i = 0; i < passes; ++i) {
-        float n = float(i);
-        float angle = angleStep * n;
-
-        vec2 uv = tex_coords + vec2(cos(angle), sin(angle)) * outline_thickness;
-        sum += texture(t0, uv).a; // / passesFloat;
-    }
-
-    if (sum > 0.) {
-      vec3 c = mix(uColor1, uColor2, 1. - tex_coords.y) * 0.35;
-      pixel = vec4(c, 1);
-    } else {
-      discard;
-      // pixel = texture(t0, tex_coords);
-    }
-  }
-`;
-const animeLightningFragmentShader = `\
+const fragmentShader = `\
   uniform float iTime;
-  uniform int iFrame;
-  uniform vec3 uColor1;
-  uniform vec3 uColor2;
-  uniform sampler2D iChannel0;
-  uniform sampler2D iChannel1;
-  varying vec2 tex_coords;
+  // uniform int iFrame;
+  uniform sampler2D uTex;
+  varying vec2 vUv;
 
-  // Quick and dirty line experiment to generate electric bolts :)
-
-  // http://extremelearning.com.au/unreasonable-effectiveness-of-quasirandom-sequences/
-  float R1seq(int n)
-  {
-    return fract(float(n) * 0.618033988749894848204586834365641218413556121186522017520);
-  }
-
-  vec2 R2seq(int n)
-  {
-    return fract(vec2(n) * vec2(0.754877666246692760049508896358532874940835564978799543103, 0.569840290998053265911399958119574964216147658520394151385));
-  }
-
-  // modified iq's segment: https://www.shadertoy.com/view/ldj3Wh
-  vec2 Line(vec2 a, vec2 b, vec2 p, vec2 identity, float sa, float sb)
-  {
-      vec2 pa = p - a;
-      vec2 pb = p - b;
-      vec2 ba = b - a;
-      float t = clamp(dot(pa,ba)/dot(ba,ba), 0.0, 1.0);    
-      vec2 pp = a + ba * t;
-      vec2 y = vec2(-identity.y, identity.x);
-      float cutoff = max(dot(pb, identity), dot(pa, -identity));
-      float s = mix(sa, sb, t);
-      return vec2(max(cutoff - .005, abs(dot(y, p - pp)) - s), t);
-  }
-
-  float Rythm(float x)
-  {
-    x = x * 6.28318 * 10.0 / 60.0;
-    x = smoothstep(-1.0, 1.0, sin(x));
-    x = smoothstep(0.0, 1.0, x);
-    x = smoothstep(0.0, 1.0, x);
-    x = smoothstep(0.0, 1.0, x);
-    x = smoothstep(0.0, 1.0, x);
-    return x;
-  }
-
-  vec3 Background(vec2 uv, vec2 baseDir, float time)
-  {
-      uv = uv * vec2(.75, .75);
-      vec3 result = vec3(0.91, 0.56, 0.02);
-      
-      vec2 n = vec2(-baseDir.y, baseDir.x);
-      
-      result = mix(result, vec3(1.0) - result, Rythm(time));
-      
-      float lines = texture(iChannel0, vec2(uv.x * 0.1, uv.y * 2.) + vec2(time * 1.35, 0.0)).r;
-      result += lines * lines * .75 + lines * lines * lines * .35;    
-      // result *= smoothstep(.5, .0, abs(dot(uv, n)));
-      
-      return result;
-  }
-
-  vec3 Magic(float leadTime, vec3 baseColor, vec2 uv, vec2 baseDir, float time, float spread, float freq, float intensity)
-  {
-      int frame = iFrame / 12;
-      
-      float speed = -1.5 - ((Rythm(time)) * .5 + .5) * 2.0;
-      //speed *= .2;
-      vec2 dir = normalize(baseDir);
-      
-      
-      uv -= dir * mix(.1, .3, Rythm(time));
-      
-      vec2 normal = vec2(-dir.y, dir.x);
-      
-      vec2 baseOffset = dir * speed * floor(float(iFrame) / 24.0);
-      
-      vec2 p = uv;
-      p.y -= 0.4;
-      p += dir * speed * (float(iFrame) / 24.0);
-      p -= R2seq(int(floor(float(iFrame)/3.0))) * .05;
-      p += normal * sin(time * 12.0) * .05;
-              
-      float ray = 0.0;
-      float glow = 0.0;
-      
-      p += (texture(iChannel1, p * .015 + leadTime * .25).xy * 2.0 - 1.0) * .1;
-      
-      float leadIntro = mix(.3, .015, smoothstep(10.0, 14.0, time));
-      
-      float leadingTime = 1.0 - smoothstep(leadTime - .5, leadTime, time);
-      float distanceToLead = dot(uv - .5, dir) - leadingTime * 2.0 - leadIntro;
-      float leadingMask = smoothstep(-.85, -.0, distanceToLead);
-      
-      p += leadingMask * (texture(iChannel1, vec2(time * .01 + leadTime * .35)).xy * 2.0 - 1.0) * .35;
-      
-      float sizeIntro = smoothstep(13.85, 14.15, time);
-      spread *= leadingMask * (1.0 - Rythm(time) * .75) * sizeIntro;
-      
-      for(int i = -12; i < 10; i++)
-      {
-      float offsetA = R1seq(i+frame) * 2.0 - 1.0;
-          float offsetB = R1seq(i+frame+1) * 2.0 - 1.0;
-          
-          vec2 a = baseOffset + dir * float(i) * freq + normal * offsetA * spread;
-          vec2 b = baseOffset + dir * float(i+1) * freq + normal * offsetB * spread;
-          
-          float sa = mix(.05, 3.0 * intensity, R1seq(frame*7+i-1)) * .005;
-          float sb = mix(.05, 3.0 * intensity, R1seq(frame*7+i)) * .005;
-          
-          vec2 l = Line(a, b, p, dir, sa, sb);
-          float d = .025 * leadingMask;
-      
-          ray += smoothstep(d, d * .75 - .0001, l.x);
-          glow += .5 * leadingMask * smoothstep(d * 20.0, d, l.x);
-      }
-
-      ray = clamp(ray, 0.0, 1.0);
-      return baseColor * (1.0 + glow * (Rythm(time * 16.0) * .05 + .025)) + vec3(ray) * intensity;
-  }
-
-  vec3 Background2(vec2 uv, float time) {
-    // uv = uv * vec2(.75, .75);
-    vec3 result = mix(uColor1, uColor2, 1. - uv.y);
-    
-    // vec2 n = vec2(-baseDir.y, baseDir.x);
-    
-    // result = mix(result, vec3(1.0) - result, Rythm(time));
-    
-    float lines = texture(iChannel0, vec2(uv.x * 0.1, uv.y * 2.) + vec2(time * 1.35, 0.0)).r;
-    result += lines * lines * .75 + lines * lines * lines * .35;    
-    // result *= smoothstep(.5, .0, abs(dot(uv, n)));
-    
-    return result;
-  }
-
-  void mainImage( out vec4 fragColor, in vec2 fragCoord )
-  {
-      float time = -.25 + floor(iTime * 1.1 * 24.0) / 24.0;
-      // float intro = 1.; // smoothstep(12.85, 13.15, time);
-      // vec2 uv = fragCoord/iResolution.xy;
-      vec2 uv = fragCoord;
-      
-      uv.y -= .075;
-      uv.x -= sin(time*4.0) * .2;
-      
-      vec2 baseDir = vec2(1., 0.);
-      
-      // vec3 col = Background(uv, baseDir, time);
-      vec3 col = Background2(uv, time);
-      
-      float spread = .35 + (sin(time * 10.0) * .5 + .5);
-      float freq = .6 - (sin(time * 4.0) * .5 + .5) * .2;
-      
-      
-      float offset = 1.0 - (smoothstep(5.0, 7.0, time) * smoothstep( 14.0, 13.0, time));
-      
-      spread *= offset;
-      
-      col = Magic(.5, col, uv + vec2(.4, .1) * offset, baseDir, time, .2, .35, 1.0);
-      col = Magic(3.0, col, uv + vec2(.2, .0) * offset, baseDir, time, .05, .15, .55);
-      col = Magic(8.0, col, uv + vec2(.2, -.25) * offset, baseDir, time, .05, .15, .35);
-      col = Magic(10.0, col, uv + vec2(-.15, -.35) * offset, baseDir, time, .04, .05, .75);
-      col = Magic(11.0, col, uv + vec2(-.3, -.15) * offset, baseDir, time, .04, .05, .75);
-      col = Magic(12.0, col, uv, baseDir, time, spread * .75, freq, 1.0);
-
-      fragColor = vec4(col,1.0);
+  void mainImage( out vec4 fragColor, in vec2 fragCoord ) {
+    vec4 c = texture2D(uTex, fragCoord);
+    fragColor = c;
+    fragColor.a = 1.;
+    // fragColor.bg = vUv;
+    // fragColor.rgb = vec3(1., 0., 0.);
   }
 
   void main() {
-    mainImage(gl_FragColor, tex_coords);
-  }
-`;
-const animeRadialShader = `\
-  uniform float iTime;
-  uniform int iFrame;
-  uniform sampler2D iChannel0;
-  uniform sampler2D iChannel1;
-  varying vec2 tex_coords;
-
-  const float fps = 30.;
-  const float intensityFactor = 0.5; // .8;
-  const float minRadius = 0.2; // 0.1;
-  const float maxRadius = 0.65;
-
-  float hash( vec2 p ) {return fract(sin(dot(p,vec2(127.1,311.7)))*43758.5453123);} //Pseudo-random
-  float smoothNoise( in vec2 p) { //Bilinearly interpolated noise (4 samples)
-      vec2 i = floor( p ); vec2 f = fract( p );	
-    vec2 u = f*f*(3.0-2.0*f);
-      float a = hash( i + vec2(0.0,0.0) );
-    float b = hash( i + vec2(1.0,0.0) );
-    float c = hash( i + vec2(0.0,1.0) );
-    float d = hash( i + vec2(1.0,1.0) );
-      return float(a+(b-a)*u.x+(c-a)*u.y+(a-b-c+d)*u.x*u.y)/4.;
-  }
-  //Funciton to make the noise continuous while wrapping around angle 
-  float rotatedMirror(float t, float r){
-      //t : 0->1
-      t = fract(t+r);
-      return 2.*abs(t-0.5);
-  }
-  //Some continous radial perlin noise
-  const mat2 m2 = mat2(0.90,0.44,-0.44,0.90);
-  float radialPerlinNoise(float t, float d){
-      const float BUMP_MAP_UV_SCALE = 44.2;
-      d = pow(d,0.01); //Impression of speed : stretch noise as the distance increases.
-      float dOffset = -floor(iTime*fps)/fps; //Time drift (animation)
-      vec2 p = vec2(rotatedMirror(t,0.1),d+dOffset);
-      float f1 = smoothNoise(p*BUMP_MAP_UV_SCALE);
-      p = 2.1*vec2(rotatedMirror(t,0.4),d+dOffset);
-      float f2 = smoothNoise(p*BUMP_MAP_UV_SCALE);
-      p = 3.7*vec2(rotatedMirror(t,0.8),d+dOffset);
-      float f3 = smoothNoise(p*BUMP_MAP_UV_SCALE);
-      p = 5.8*vec2(rotatedMirror(t,0.0),d+dOffset);
-      float f4 = smoothNoise(p*BUMP_MAP_UV_SCALE);
-      return (f1+0.5*f2+0.25*f3+0.125*f4)*3.;
-  }
-  //Colorize function (transforms BW Intensity to color)
-  vec3 colorize(float f){
-      f = clamp(f*.95,0.0,1.0);
-      vec3 c = mix(vec3(0,0,1.1), vec3(0,1,1), f); //Red-Yellow Gradient
-          c = mix(c, vec3(1,1,1), f*4.-3.0);      //While highlights
-      vec3 cAttenuated = mix(vec3(0), c, f+0.1);       //Intensity ramp
-      return cAttenuated;
-  }
-  /*vec3 colorize(float f){
-      f = clamp(f,0.0,1.0);
-      vec3 c = mix(vec3(1.1,0,0), vec3(1,1,0), f); //Red-Yellow Gradient
-          c = mix(c, vec3(1,1,1), f*10.-9.);      //While highlights
-      vec3 cAttenuated = mix(vec3(0), c, f);       //Intensity ramp
-      return cAttenuated;
-  }*/
-  //Main image.
-  void mainImage( out vec4 fragColor, in vec2 fragCoord ){
-      // vec2 uv = 2.2*(fragCoord-0.5*vec2(iResolution.xy))/iResolution.xx;
-      vec2 uv = 2.2 * ((fragCoord + vec2(0., 0.)) - 0.5);
-      float d = dot(uv,uv); //Squared distance
-      float t = 0.5+atan(uv.y,uv.x)/6.28; //Normalized Angle
-      float v = radialPerlinNoise(t,d);
-      //Saturate and offset values
-      v = -2.5+v*4.5;
-      //Intersity ramp from center
-      v = mix(0.,v,intensityFactor*smoothstep(minRadius, maxRadius,d));
-      //Colorize (palette remap )
-      fragColor.rgb = colorize(v);
-      fragColor.a = v;
-  }
-
-  void main() {
-    mainImage(gl_FragColor, tex_coords);
+    mainImage(gl_FragColor, vUv);
   }
 `;
 
@@ -359,6 +62,33 @@ const _makeMapRenderTarget = (w, h) => new THREE.WebGLRenderTarget(w, h, {
 
 // const minimapWorldSize = 100;
 const pixelRatio = window.devicePixelRatio;
+
+const _makeScene = renderTarget => {
+  const scene = new THREE.Scene();
+  
+  // full screen quad mesh
+  const mesh = new THREE.Mesh(
+    new THREE.PlaneBufferGeometry(2, 2),
+    new THREE.ShaderMaterial({
+      // map: renderTarget.texture,
+      uniforms: {
+        uTex: {
+          value: renderTarget.texture,
+          // needsUpdate: true,
+        },
+      },
+      vertexShader,
+      fragmentShader,
+      transparent: true,
+      depthTest: false,
+      // depthWrite: false,
+    }),
+  );
+  mesh.frustumCulled = false;
+  scene.add(mesh);
+
+  return scene;
+};
 
 const minimaps = [];
 class MiniMap {
@@ -379,6 +109,8 @@ class MiniMap {
     this.mapRenderTarget = _makeMapRenderTarget(this.width * pixelRatio * 3, this.height * pixelRatio * 3);
     this.canvasIndices = new Int32Array(3 * 3 * 2);
     this.canvasIndices.fill(0xffff);
+    this.scene = _makeScene(this.mapRenderTarget);
+    this.camera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0, 1);
 
     this.canvases = [];
   }
@@ -396,12 +128,6 @@ class MiniMap {
     this.canvases.push(canvas);
   }
   update(timestamp, timeDiff) {
-    // const timeOffset = timestamp - lastDisabledTime;
-
-    /* if (!this.mapRenderTarget || (this.mapRenderTarget.width !== this.width * pixelRatio) || (this.mapRenderTarget.height !== this.height * pixelRatio)) {
-      
-    } */
-
     const localPlayer = metaversefileApi.useLocalPlayer();
 
     const renderer = getRenderer();
@@ -435,14 +161,45 @@ class MiniMap {
       );
       this.topCamera.updateMatrixWorld();
       
-      renderer.setViewport(0, 0, this.width, this.height);
+      renderer.setRenderTarget(this.mapRenderTarget);
+      renderer.setViewport((dx+1) * this.width/3, (dy+1) * this.height/3, this.width/3, this.height/3);
+      // renderer.setViewport(0, 0, this.width, this.height);
       renderer.clear();
       for (const scene of regularScenes) {
         renderer.render(scene, this.topCamera);
       }
-  
+    };
+    const _updateTiles = () => {
+      let index = 0;
+      for (let dy = -1; dy <= 1; dy++) {
+        for (let dx = -1; dx <= 1; dx++) {
+          const ix = Math.floor((localPlayer.position.x + dx * this.worldWidth/2) / this.worldWidth);
+          const iy = Math.floor((localPlayer.position.y + dy * this.worldHeight/2) / this.worldHeight);
+          const requiredIndex = localVector2D3.set(ix, iy);
+          const currentIndex = localVector2D4.fromArray(this.canvasIndices, index * 2);
+          if (!currentIndex.equals(requiredIndex)) {
+            _render(dx, dy, index);
+            requiredIndex.toArray(this.canvasIndices, index * 2);
+          }
+          index++;
+        }
+      }
+    };
+    _updateTiles();
+
+    const _renderMiniMap = () => {
+      renderer.setRenderTarget(oldRenderTarget);
+      renderer.setViewport(0, 0, this.width, this.height);
+      renderer.clear();
+      renderer.render(this.scene, this.camera);
+    };
+    _renderMiniMap();
+
+    const _copyToCanvases = () => {
       for (const canvas of this.canvases) {
         const {width, height, ctx} = canvas;
+        // ctx.fillStyle = '#F00';
+        // ctx.fillRect(0, 0, width, height);
         ctx.clearRect(0, 0, width, height);
         ctx.drawImage(
           renderer.domElement,
@@ -457,22 +214,7 @@ class MiniMap {
         );
       }
     };
-
-    let index = 0;
-    for (let dy = -1; dy <= 1; dy++) {
-      for (let dx = -1; dx <= 1; dx++) {
-        const ix = Math.floor((localPlayer.position.x + dx * this.worldWidth/2) / this.worldWidth);
-        const iy = Math.floor((localPlayer.position.y + dy * this.worldHeight/2) / this.worldHeight);
-        const requiredIndex = localVector2D.set(ix, iy);
-        const currentIndex = localVector2D2.fromArray(this.canvasIndices, index * 2);
-        if (!currentIndex.equals(requiredIndex)) {
-          // console.log('not equals', currentIndex.toArray(), requiredIndex.toArray());
-          _render(dx, dy, index);
-          requiredIndex.toArray(this.canvasIndices, index * 2);
-        }
-        index++;
-      }
-    }
+    _copyToCanvases();
 
     // pop old state
     renderer.setRenderTarget(oldRenderTarget);

--- a/minimap.js
+++ b/minimap.js
@@ -22,6 +22,9 @@ const localMatrix = new THREE.Matrix4();
 const cameraHeight = 50;
 
 // XXX TODO:
+// add center reticle
+// add compass border circle
+// add compass north
 // render at mose once per frame
 // do not render avatars
 // debug mirrors

--- a/minimap.js
+++ b/minimap.js
@@ -472,8 +472,8 @@ class MiniMap {
 }
 
 const minimapManager = {
-  createMiniMap(width, height) {
-    const minimap = new MiniMap(width, height);
+  createMiniMap(width, height, worldWidth, worldHeight) {
+    const minimap = new MiniMap(width, height, worldWidth, worldHeight);
     minimaps.push(minimap);
     return minimap;
   },

--- a/minimap.js
+++ b/minimap.js
@@ -2,16 +2,13 @@ import * as THREE from 'three';
 import {
   getRenderer,
   rootScene,
-  sceneHighPriority,
+  /* sceneHighPriority,
   scene,
-  sceneLowPriority,
+  sceneLowPriority, */
   camera,
 } from './renderer.js';
-// import * as BufferGeometryUtils from 'three/examples/jsm/utils/BufferGeometryUtils.js';
-// import {world} from './world.js';
 import universe from './universe.js';
 import metaversefileApi from 'metaversefile';
-// import {fitCameraToBoundingBox} from './util.js';
 
 const localVector = new THREE.Vector3();
 const localVector2 = new THREE.Vector3();
@@ -19,15 +16,9 @@ const localVector3 = new THREE.Vector3();
 const localVector2D = new THREE.Vector2();
 const localVector2D2 = new THREE.Vector2();
 const localVector2D3 = new THREE.Vector2();
-// const localVector2D4 = new THREE.Vector2();
 const localVector4D = new THREE.Vector4();
 const localMatrix = new THREE.Matrix4();
 
-/* const regularScenes = [
-  sceneHighPriority,
-  scene,
-  sceneLowPriority,
-]; */
 const cameraHeight = 50;
 
 const vertexShader = `\
@@ -63,7 +54,6 @@ const _makeMapRenderTarget = (w, h) => new THREE.WebGLRenderTarget(w, h, {
   format: THREE.RGBAFormat,
 });
 
-// const minimapWorldSize = 100;
 const pixelRatio = window.devicePixelRatio;
 
 const _makeScene = (renderTarget, worldWidth, worldHeight) => {
@@ -72,21 +62,17 @@ const _makeScene = (renderTarget, worldWidth, worldHeight) => {
   // full screen quad mesh
   const mesh = new THREE.Mesh(
     new THREE.PlaneBufferGeometry(worldWidth, worldHeight)
-      // .applyMatrix4(new THREE.Matrix4().makeTranslation(0, 0, -1)),
       .applyMatrix4(new THREE.Matrix4().makeRotationX(-Math.PI / 2)),
     new THREE.ShaderMaterial({
-      // map: renderTarget.texture,
       uniforms: {
         uTex: {
           value: renderTarget.texture,
-          // needsUpdate: true,
+          needsUpdate: true,
         },
       },
       vertexShader,
       fragmentShader,
-      // transparent: true,
       depthTest: false,
-      // depthWrite: false,
     }),
   );
   mesh.frustumCulled = false;
@@ -163,7 +149,6 @@ class MiniMap {
     }
 
     // push old state
-    // const oldParent = app.parent;
     const oldRenderTarget = renderer.getRenderTarget();
     const oldViewport = renderer.getViewport(localVector4D);
   
@@ -207,7 +192,6 @@ class MiniMap {
         }
 
         this.scene.mesh.position.set(baseX * this.worldWidthD3, 0, baseY * this.worldHeightD3);
-        // this.scene.mesh.scale.set(this.worldWidth, 1, this.worldHeight);
         this.scene.mesh.updateMatrixWorld();
 
         this.lastBase.set(baseX, baseY);

--- a/minimap.js
+++ b/minimap.js
@@ -196,8 +196,6 @@ class MiniMap {
     );
     this.mapRenderTarget = _makeMapRenderTarget(this.width * pixelRatio, this.height * pixelRatio);
     this.mapRenderTarget2 = _makeMapRenderTarget(this.width * pixelRatio, this.height * pixelRatio);
-    this.canvasIndices = new Int32Array(3 * 3 * 2);
-    this.canvasIndices.fill(0xffff);
     this.scene = _makeScene(this.mapRenderTarget, this.worldWidth, this.worldHeight);
     this.camera = new THREE.OrthographicCamera(-this.worldWidth/2, this.worldWidth/2, this.worldHeight/2, -this.worldHeight/2, 0, 1000);
 
@@ -304,7 +302,6 @@ class MiniMap {
           for (let dx = -1; dx <= 1; dx++) {
             const ix = baseX + dx;
             const iy = baseY + dy;
-            // const requiredIndex = localVector2D3.set(ix, iy);
 
             const previousOffset = _getPreviousOffset(ix, iy);
             if (previousOffset) {
@@ -312,7 +309,6 @@ class MiniMap {
             } else {
               _render(baseX, baseY, dx, dy);
             }
-            // requiredIndex.toArray(this.canvasIndices, index * 2);
             index++;
           }
         }

--- a/src/Header.jsx
+++ b/src/Header.jsx
@@ -10,7 +10,7 @@ import * as Z from 'zjs';
 // import {Color} from './Color.js';
 import {world} from '../world.js'
 import game from '../game.js'
-import * as universe from '../universe.js'
+import universe from '../universe.js'
 import * as hacks from '../hacks.js'
 import cameraManager from '../camera-manager.js'
 import metaversefile from '../metaversefile-api.js'

--- a/src/components/app/App.jsx
+++ b/src/components/app/App.jsx
@@ -6,7 +6,7 @@ import { defaultAvatarUrl } from '../../../constants';
 import dropManager from '../../../drop-manager.js';
 
 import Webaverse from '../../../webaverse.js';
-import * as universe from '../../../universe.js';
+import universe from '../../../universe.js';
 import metaversefileApi from '../../../metaversefile-api';
 
 import { ActionMenu } from '../general/action-menu';

--- a/src/components/play-mode/minimap/Minimap.jsx
+++ b/src/components/play-mode/minimap/Minimap.jsx
@@ -1,18 +1,34 @@
 
-import React from 'react';
+import React, {useState, useRef, useEffect} from 'react';
+import minimapManager from '../../../../minimap.js';
 
 import styles from './minimap.module.css';
 
 //
 
+let minimap = null;
+const minimapSize = 128;
+const minimapWorldSize = 50;
+
 export const Minimap = () => {
+    const canvasRef = useRef();
+
+    useEffect(() => {
+        if (canvasRef.current) {
+          const canvas = canvasRef.current;
+
+          if (!minimap) {
+            minimap = minimapManager.createMiniMap(minimapSize, minimapSize, minimapWorldSize, minimapWorldSize);
+          }
+          minimap.resetCanvases();
+          minimap.addCanvas(canvas);
+        }
+      }, [canvasRef.current]);
 
     return (
         <div className={ styles.locationMenu } >
 
-            <div className={ styles.map } >
-
-            </div>
+            <canvas width={minimapSize} height={minimapSize} className={ styles.map } ref={canvasRef} />
 
         </div>
     );

--- a/src/components/play-mode/minimap/Minimap.jsx
+++ b/src/components/play-mode/minimap/Minimap.jsx
@@ -7,7 +7,7 @@ import styles from './minimap.module.css';
 //
 
 let minimap = null;
-const minimapSize = 128;
+const minimapSize = 300;
 const minimapWorldSize = 50;
 
 export const Minimap = () => {

--- a/src/components/play-mode/minimap/minimap.module.css
+++ b/src/components/play-mode/minimap/minimap.module.css
@@ -15,5 +15,5 @@
     height: 180px;
     /* border-radius: 50%; */
     background-color: #000;
-    image-rendering: pixelated;
+    /* image-rendering: pixelated; */
 }

--- a/src/components/play-mode/minimap/minimap.module.css
+++ b/src/components/play-mode/minimap/minimap.module.css
@@ -15,5 +15,5 @@
     height: 180px;
     border-radius: 50%;
     background-color: #000;
-    opacity: 0.5;
+    image-rendering: pixelated;
 }

--- a/src/components/play-mode/minimap/minimap.module.css
+++ b/src/components/play-mode/minimap/minimap.module.css
@@ -13,7 +13,7 @@
     margin-bottom: 20px;
     width: 180px;
     height: 180px;
-    border-radius: 50%;
+    /* border-radius: 50%; */
     background-color: #000;
     image-rendering: pixelated;
 }

--- a/universe.js
+++ b/universe.js
@@ -1,5 +1,6 @@
 /*
-this file contains the multiplayer code.
+this file contains the universe/meta-world/scenes/multiplayer code.
+responsibilities include loading the world on url change.
 */
 
 import * as THREE from 'three';
@@ -11,88 +12,93 @@ import {parseQuery, parseCoord} from './util.js';
 import metaversefile from 'metaversefile';
 import sceneNames from './scenes/scenes.json';
 
-let currentWorld = null;
-const getWorldsHost = () => window.location.protocol + '//' + window.location.hostname + ':' +
-  ((window.location.port ? parseInt(window.location.port, 10) : (window.location.protocol === 'https:' ? 443 : 80)) + 1) + '/worlds/';
-const enterWorld = async worldSpec => {
-  world.disconnectRoom();
-  
-  const localPlayer = metaversefile.useLocalPlayer();
-  /* localPlayer.teleportTo(new THREE.Vector3(0, 1.5, 0), camera.quaternion, {
-    relation: 'float',
-  }); */
-  localPlayer.position.set(0, initialPosY, 0);
-  localPlayer.resetPhysics();
-  localPlayer.updateMatrixWorld();
-  physicsManager.setPhysicsEnabled(true);
-  localPlayer.updatePhysics(0, 0);
-  physicsManager.setPhysicsEnabled(false);
+class Universe extends EventTarget {
+  constructor() {
+    super();
 
-  const _doLoad = async () => {
-    // world.clear();
-
-    const promises = [];
-    const {src, room} = worldSpec;
-    if (!room) {
-      const state = new Z.Doc();
-      world.connectState(state);
-      
-      if (src === undefined) {
-        promises.push(metaversefile.load('./scenes/' + sceneNames[0]));
-      } else if (src === '') {
-        // nothing
-      } else {
-        promises.push(metaversefile.load(src));
-      }
-    } else {
-      const p = (async () => {
-        const roomUrl = getWorldsHost() + room;
-        await world.connectRoom(roomUrl);
-      })();
-      promises.push(p);
-    }
-    
-    sceneLoadedPromise = Promise.all(promises).then(() => {});
-    await sceneLoadedPromise;
-    sceneLoadedPromise = null;
-  };
-  await _doLoad().catch(err => {
-    console.warn(err);
-  });
-
-  localPlayer.resetPhysics();
-  physicsManager.setPhysicsEnabled(true);
-  localPlayer.updatePhysics(0, 0);
-
-  currentWorld = worldSpec;
-};
-const reload = async () => {
-  await enterWorld(currentWorld);
-};
-const pushUrl = async u => {
-  history.pushState({}, '', u);
-  window.dispatchEvent(new MessageEvent('pushstate'));
-  await handleUrlUpdate();
-};
-const handleUrlUpdate = async () => {
-  const q = parseQuery(location.search);
-  await enterWorld(q);
-};
-
-let sceneLoadedPromise = null;
-const isSceneLoaded = () => !sceneLoadedPromise;
-const waitForSceneLoaded = async () => {
-  if (sceneLoadedPromise) {
-    await sceneLoadedPromise;
+    this.currentWorld = null;
+    this.sceneLoadedPromise = null;
   }
-};
+  getWorldsHost() {
+    return window.location.protocol + '//' + window.location.hostname + ':' +
+      ((window.location.port ? parseInt(window.location.port, 10) : (window.location.protocol === 'https:' ? 443 : 80)) + 1) + '/worlds/';
+  }
+  async enterWorld(worldSpec) {
+    world.disconnectRoom();
+    
+    const localPlayer = metaversefile.useLocalPlayer();
+    /* localPlayer.teleportTo(new THREE.Vector3(0, 1.5, 0), camera.quaternion, {
+      relation: 'float',
+    }); */
+    localPlayer.position.set(0, initialPosY, 0);
+    localPlayer.resetPhysics();
+    localPlayer.updateMatrixWorld();
+    physicsManager.setPhysicsEnabled(true);
+    localPlayer.updatePhysics(0, 0);
+    physicsManager.setPhysicsEnabled(false);
 
-export {
-  enterWorld,
-  reload,
-  getWorldsHost,
-  pushUrl,
-  handleUrlUpdate,
-  isSceneLoaded,
-  waitForSceneLoaded,
-};
+    const _doLoad = async () => {
+      // world.clear();
+
+      const promises = [];
+      const {src, room} = worldSpec;
+      if (!room) {
+        const state = new Z.Doc();
+        world.connectState(state);
+        
+        if (src === undefined) {
+          promises.push(metaversefile.load('./scenes/' + sceneNames[0]));
+        } else if (src === '') {
+          // nothing
+        } else {
+          promises.push(metaversefile.load(src));
+        }
+      } else {
+        const p = (async () => {
+          const roomUrl = getWorldsHost() + room;
+          await world.connectRoom(roomUrl);
+        })();
+        promises.push(p);
+      }
+      
+      this.sceneLoadedPromise = Promise.all(promises)
+        .then(() => {});
+      await this.sceneLoadedPromise;
+      this.sceneLoadedPromise = null;
+    };
+    await _doLoad().catch(err => {
+      console.warn(err);
+    });
+
+    localPlayer.resetPhysics();
+    physicsManager.setPhysicsEnabled(true);
+    localPlayer.updatePhysics(0, 0);
+
+    this.currentWorld = worldSpec;
+
+    this.dispatchEvent(new MessageEvent('worldload'));
+  }
+  async reload() {
+    await this.enterWorld(this.currentWorld);
+  }
+  async pushUrl(u) {
+    history.pushState({}, '', u);
+    window.dispatchEvent(new MessageEvent('pushstate'));
+    await this.handleUrlUpdate();
+  }
+  async handleUrlUpdate() {
+    const q = parseQuery(location.search);
+    await this.enterWorld(q);
+  }
+  isSceneLoaded() {
+    return !this.sceneLoadedPromise;
+  }
+  async waitForSceneLoaded() {
+    if (this.sceneLoadedPromise) {
+      await this.sceneLoadedPromise;
+    }
+  }
+}
+const universe = new Universe();
+
+export default universe;

--- a/webaverse.js
+++ b/webaverse.js
@@ -20,6 +20,7 @@ import hpManager from './hp-manager.js';
 // import equipmentRender from './equipment-render.js';
 // import * as characterController from './character-controller.js';
 import {playersManager} from './players-manager.js';
+import minimapManager from './minimap.js';
 import postProcessing from './post-processing.js';
 import {Stats} from './stats.js';
 import {
@@ -404,6 +405,7 @@ export default class Webaverse extends EventTarget {
 
       // render scenes
       dioramaManager.update(timestamp, timeDiffCapped);
+      minimapManager.update(timestamp, timeDiffCapped);
       this.render(timestamp, timeDiffCapped);
     }
     renderer.setAnimationLoop(animate);


### PR DESCRIPTION
Adds an efficiently-rendered minimap to the UI; it caches chunks for 100% reprojection, re-uses old chunks when possible using double-buffering, and only re-draws one chunk per frame to prevent frame rate impact in fast movement situations.

The plan is to circularize, clip, add a compass, and perform GTA-style speed zoom optimization.