### PR TITLE
Unuse animations clear

### DIFF
--- a/avatars/avatars.js
+++ b/avatars/avatars.js
@@ -1667,7 +1667,6 @@ class Avatar {
     this.useAnimationEnvelope = [];
     this.unuseAnimation = null;
     this.unuseTime = -1;
-    this.used = false;
     
     this.sitState = false;
     this.sitAnimation = null;
@@ -2753,7 +2752,7 @@ class Avatar {
                 .add(localVector2.fromArray(v2));
             }
           };
-        } else if (this.unuseAnimation && this.unuseTime >= 0 && this.used) {
+        } else if (this.unuseAnimation && this.unuseTime >= 0) {
           return spec => {
             const {
               animationTrackName: k,
@@ -2813,7 +2812,7 @@ class Avatar {
             }
 
             if (f >= 1) {
-              this.used = false;
+              this.useAnimation = '';
             }
           };
         }

--- a/player-avatar-binding.js
+++ b/player-avatar-binding.js
@@ -115,7 +115,6 @@ export function applyPlayerActionsToAvatar(player, rig) {
   }
   if (useAction?.animationEnvelope) {
     rig.useAnimationEnvelope = useAction.animationEnvelope;
-    rig.unuseAnimation = rig.useAnimationEnvelope[2]; // the last animation in the triplet is the unuse animation
   } else {
     if (rig.useAnimationEnvelope.length > 0) {
       rig.useAnimationEnvelope = [];
@@ -124,8 +123,10 @@ export function applyPlayerActionsToAvatar(player, rig) {
   rig.useAnimationIndex = useAction?.index;
   rig.useTime = player.actionInterpolants.use.get();
   rig.unuseTime = player.actionInterpolants.unuse.get();
-  if (useAction) {
-    rig.used = true;
+  if (rig.unuseTime === 0) {
+    if (useAction?.animationEnvelope) {
+      rig.unuseAnimation = rig.useAnimationEnvelope[2]; // the last animation in the triplet is the unuse animation
+    }
   }
 
   rig.narutoRunState = !!narutoRunAction && !crouchAction;

--- a/player-avatar-binding.js
+++ b/player-avatar-binding.js
@@ -123,7 +123,7 @@ export function applyPlayerActionsToAvatar(player, rig) {
   rig.useAnimationIndex = useAction?.index;
   rig.useTime = player.actionInterpolants.use.get();
   rig.unuseTime = player.actionInterpolants.unuse.get();
-  if (rig.unuseTime === 0) {
+  if (rig.unuseTime === 0) { // this means use is active
     if (useAction?.animationEnvelope) {
       rig.unuseAnimation = rig.useAnimationEnvelope[2]; // the last animation in the triplet is the unuse animation
     }


### PR DESCRIPTION
This fixes a bug where using a bow followed by another usable item (like pistol) would cause the lingering "unuse" animation to be triggered.

This PR changes how the use animations are reset to make sure a use action resets the unuse animation, including if it is not present.