### PR TITLE
Disable diorama scene auto update

### DIFF
--- a/diorama.js
+++ b/diorama.js
@@ -1536,10 +1536,12 @@ const skinnedRedMaterial = (() => {
 
 const outlineRenderScene = new THREE.Scene();
 outlineRenderScene.name = 'outlineRenderScene';
+outlineRenderScene.autoUpdate = false;
 outlineRenderScene.overrideMaterial = skinnedRedMaterial;
 
 const sideScene = new THREE.Scene();
 sideScene.name = 'sideScene';
+sideScene.autoUpdate = false;
 sideScene.add(lightningMesh);
 sideScene.add(radialMesh);
 sideScene.add(grassMesh);


### PR DESCRIPTION
The diorama scenes had scene update enabled, possibly causing expensive updates.

Since the diorama objects should already be being set up before being rendered in the diorama, this should have no effect other than a slight performance boost.

Note that `autoUpdate` is already disabled in our root scene, so the dioramas render case was strictly worse.