### PR TITLE
Player appManager physics update

### DIFF
--- a/character-controller.js
+++ b/character-controller.js
@@ -958,6 +958,8 @@ class LocalPlayer extends UninterpolatedPlayer {
       this.playerMap.set('position', this.position.toArray(localArray3));
       this.playerMap.set('quaternion', this.quaternion.toArray(localArray4));
     }, 'push');
+
+    this.appManager.updatePhysics();
   }
   updatePhysics(timestamp, timeDiff) {
     const timeDiffS = timeDiff / 1000;


### PR DESCRIPTION
The world appManager tracks all of the apps in the scene. It is also responsible for synchronizing the app's matrix back to the physics object.

However, wearable physics objects would not update while worn, because those apps live in the player's appManager, not the world's.

This PR breaks out the physics update part of the appManager into a separate method and ensures that players call it during the update loop.

This fixes bugs in dioramas, as well as physics highlight shading for currently worn apps.