### PR TITLE
Hotbar action controls

### DIFF
--- a/game.js
+++ b/game.js
@@ -1393,11 +1393,10 @@ const gameManager = {
   menuAim() {
     const localPlayer = metaversefileApi.useLocalPlayer();
     if (!localPlayer.hasAction('aim')) {
+      const localPlayer = metaversefileApi.useLocalPlayer();
+      const wearApp = loadoutManager.getSelectedApp();
       const wearAimApp = (() => {
-        const wearApps = Array.from(localPlayer.getActionsState())
-          .filter(action => action.type === 'wear')
-          .map(({instanceId}) => metaversefileApi.getAppByInstanceId(instanceId));
-        for (const wearApp of wearApps) {
+        if (wearApp) {
           const aimComponent = wearApp.getComponent('aim');
           if (aimComponent) {
             return wearApp;

--- a/game.js
+++ b/game.js
@@ -326,10 +326,8 @@ const _getNextUseIndex = animationCombo => {
 }
 const _startUse = () => {
   const localPlayer = metaversefileApi.useLocalPlayer();
-  const wearApps = Array.from(localPlayer.getActionsState())
-    .filter(action => action.type === 'wear')
-    .map(({instanceId}) => metaversefileApi.getAppByInstanceId(instanceId));
-  for (const wearApp of wearApps) {
+  const wearApp = loadoutManager.getSelectedApp();
+  if (wearApp) {
     const useComponent = wearApp.getComponent('use');
     if (useComponent) {
       const useAction = localPlayer.getAction('use');
@@ -356,7 +354,6 @@ const _startUse = () => {
 
         wearApp.use();
       }
-      break;
     }
   }
 };

--- a/game.js
+++ b/game.js
@@ -1496,10 +1496,8 @@ const gameManager = {
   },
   drop() {
     const localPlayer = metaversefileApi.useLocalPlayer();
-    const wearActions = localPlayer.getActionsArray().filter(action => action.type === 'wear');
-    if (wearActions.length > 0) {
-      const wearAction = wearActions[0];
-      const app = metaversefileApi.getAppByInstanceId(wearAction.instanceId);
+    const app = loadoutManager.getSelectedApp();
+    if (app) {
       localPlayer.unwear(app);
     }
   },

--- a/loadout-manager.js
+++ b/loadout-manager.js
@@ -17,7 +17,7 @@ class LoadoutManager extends EventTarget {
 
       this.ensureHotbarRenderers();
       if (wear) {
-        const nextIndex = this.getNextIndex();
+        const nextIndex = this.getNextFreeIndex();
         if (nextIndex !== -1) {
           const hotbarRenderer = this.hotbarRenderers[nextIndex];
           hotbarRenderer.setApp(app);
@@ -29,7 +29,9 @@ class LoadoutManager extends EventTarget {
           const hotbarRenderer = this.hotbarRenderers[i];
           if (hotbarRenderer.app === app) {
             hotbarRenderer.setApp(null);
-            this.setSelectedIndex(-1);
+
+            const nextIndex = this.getNextUsedIndex();
+            this.setSelectedIndex(nextIndex);
             break;
           }
         }
@@ -76,10 +78,19 @@ class LoadoutManager extends EventTarget {
       this.selectedIndex = index;
     }
   }
-  getNextIndex() {
+  getNextFreeIndex() {
     this.ensureHotbarRenderers();
     for (let i = 0; i < this.hotbarRenderers.length; i++) {
       if (!this.hotbarRenderers[i].app) {
+        return i;
+      }
+    }
+    return -1;
+  }
+  getNextUsedIndex() {
+    this.ensureHotbarRenderers();
+    for (let i = 0; i < this.hotbarRenderers.length; i++) {
+      if (this.hotbarRenderers[i].app) {
         return i;
       }
     }

--- a/loadout-manager.js
+++ b/loadout-manager.js
@@ -53,6 +53,15 @@ class LoadoutManager extends EventTarget {
     this.ensureHotbarRenderers();
     return this.hotbarRenderers[index];
   }
+  getSelectedApp() {
+    this.ensureHotbarRenderers();
+    
+    if (this.selectedIndex !== -1) {
+      return this.hotbarRenderers[this.selectedIndex].app;
+    } else {
+      return null;
+    }
+  }
   setSelectedIndex(index) {
     this.ensureHotbarRenderers();
 

--- a/loadout-manager.js
+++ b/loadout-manager.js
@@ -1,5 +1,4 @@
-import {/*HotbarRenderer, */createHotbarRenderer} from './hotbar.js';
-// import {getRenderer} from './renderer.js';
+import {createHotbarRenderer} from './hotbar.js';
 import {localPlayer} from './players.js';
 import {hotbarSize} from './constants.js';
 
@@ -12,7 +11,6 @@ class LoadoutManager extends EventTarget {
     this.selectedIndex = -1;
   
     localPlayer.addEventListener('wearupdate', e => {
-      // console.log('wear update', e);
       const {app, wear} = e;
 
       this.ensureHotbarRenderers();


### PR DESCRIPTION
This PR makes the current hotbar selection be honored when pressing buttons like `use` (mouse click) or `drop` (`R`).

This allows convenient dual wielding and hotswap during gameplay.