### PR TITLE
Adds an empty scene to make drag and drop of .scn files easy in app.webaverse.com

### DIFF
--- a/scenes/custom.scn
+++ b/scenes/custom.scn
@@ -1,0 +1,14 @@
+{
+  "objects": [
+{
+      "position": [
+        0,
+        0,
+        0
+      ],
+      "physics": true,
+      "start_url": "https://github.com/amnaarshed4224/assets/raw/main/floor.glb",
+      "dynamic": false
+    }
+]
+}

--- a/scenes/custom.scn
+++ b/scenes/custom.scn
@@ -7,7 +7,7 @@
         0
       ],
       "physics": true,
-      "start_url": "https://github.com/amnaarshed4224/assets/raw/main/floor.glb",
+      "start_url": "https://github.com/webaverse/Invisible-grid/raw/main/floor.glb",
       "dynamic": false
     }
 ]

--- a/scenes/scenes.json
+++ b/scenes/scenes.json
@@ -10,5 +10,6 @@
   "canyon.scn",
   "prototype.scn",
   "silk-fountains.scn",
-  "moon.scn"
+  "moon.scn",
+  "custom.scn"
 ]


### PR DESCRIPTION
This PR adds an empty scene to master. The purpose of the scene is to make it easy for end user to drag and drop any .scn file into the custom scene, without having to clone the app on local.
The "Custom" .scn contains an invisible grid to make sure avatar doesn't falls down.

https://user-images.githubusercontent.com/35926530/155554747-ad78c4fe-5378-41eb-acae-ea3969c09ad4.mp4


