### PR TITLE
Loadout select limit

### DIFF
--- a/src/components/play-mode/hotbar/Hotbar.jsx
+++ b/src/components/play-mode/hotbar/Hotbar.jsx
@@ -23,10 +23,10 @@ const HotbarItem = props => {
     }, [canvasRef]);
     useEffect(() => {
       function selectedchange(e) {
-        // console.log('selectedchange hotbar 1', e.data);
-        const {index} = e.data;
-        setSelected(index === props.index);
-        // console.log('selectedchange hotbar 2', e.data);
+        const {index, app} = e.data;
+        if (index === -1 || app) {
+          setSelected(index === props.index);
+        }
       }
 
       loadoutManager.addEventListener('selectedchange', selectedchange);

--- a/src/components/play-mode/infobox/Infobox.jsx
+++ b/src/components/play-mode/infobox/Infobox.jsx
@@ -36,8 +36,10 @@ export const Infobox = () => {
     }, [canvasRef]);
     useEffect(() => {
         function selectedchange(e) {
-            const {app} = e.data;
-            setSelectedApp(app);
+            const {index, app} = e.data;
+            if (index === -1 || app) {
+                setSelectedApp(app);
+            }
         }
         loadoutManager.addEventListener('selectedchange', selectedchange);
         return () => {


### PR DESCRIPTION
Fixes a bug where you could select empty slots in the avatar's loadout.