### PR TITLE
Voice endpoint settings

### DIFF
--- a/character-controller.js
+++ b/character-controller.js
@@ -228,7 +228,6 @@ class PlayerBase extends THREE.Object3D {
     this.updateVoice();
   }
   updateVoice() {
-    console.log('set voice', this.voiceEndpoint || this.voicePack || null, this.voiceEndpoint, this.voicePack, null, new Error().stack);
     this.characterHups.setVoice(this.voiceEndpoint || this.voicePack || null);
   }
   getCrouchFactor() {

--- a/character-controller.js
+++ b/character-controller.js
@@ -139,6 +139,8 @@ class PlayerBase extends THREE.Object3D {
     this.avatar = null;
     this.eyeballTarget = new THREE.Vector3();
     this.eyeballTargetEnabled = false;
+    this.voicePack = null;
+    this.voiceEndpoint = null;
   }
   findAction(fn) {
     const actions = this.getActionsState();
@@ -210,16 +212,24 @@ class PlayerBase extends THREE.Object3D {
     return false;
   }
   async loadVoicePack({audioUrl, indexUrl}) {
-    const voicePack = await VoicePack.load({
+    this.voicePack = await VoicePack.load({
       audioUrl,
       indexUrl,
     });
-    this.characterHups.setVoice(voicePack);
+    this.updateVoice();
   }
-  setVoice(voiceId) {
-    const url = `${voiceEndpoint}?voice=${encodeURIComponent(voiceId)}`;
-    const voice = new VoiceEndpoint(url);
-    this.characterHups.setVoice(voice);
+  setVoiceEndpoint(voiceId) {
+    if (voiceId) {
+      const url = `${voiceEndpoint}?voice=${encodeURIComponent(voiceId)}`;
+      this.voiceEndpoint = new VoiceEndpoint(url);
+    } else {
+      this.voiceEndpoint = null;
+    }
+    this.updateVoice();
+  }
+  updateVoice() {
+    console.log('set voice', this.voiceEndpoint || this.voicePack || null, this.voiceEndpoint, this.voicePack, null, new Error().stack);
+    this.characterHups.setVoice(this.voiceEndpoint || this.voicePack || null);
   }
   getCrouchFactor() {
     return 1 - 0.4 * this.actionInterpolants.crouch.getNormalized();

--- a/character-hups.js
+++ b/character-hups.js
@@ -180,6 +180,8 @@ class CharacterHups extends EventTarget {
       this.voicer = new VoicePackVoicer(syllableFiles, audioBuffer, this.player);
     } else if (voice instanceof VoiceEndpoint) {
       this.voicer = new VoiceEndpointVoicer(voice, this.player);
+    } else if (voice === null) {
+      this.voicer = null;
     } else {
       throw new Error('invalid voice');
     }

--- a/constants.js
+++ b/constants.js
@@ -90,9 +90,12 @@ export const defaultVoicePack = {
   indexUrl: `https://webaverse.github.io/shishi-voicepack/syllables/syllable-files.json`,
 };
 export const voiceEndpoint = `https://voice.webaverse.com/tts`;
-export const defaultVoice = `1jLX0Py6j8uY93Fjf2l0HOZQYXiShfWUO`; // Sweetie Belle
-// export const defaultVoice = 'Sweetie Belle';
-// export const defaultVoice = 'Trixie';
+/* export const defaultVoice = {
+  name: 'Sweetie Belle',
+}; */
+export const defaultVoiceEndpoint = {
+  name: 'Trixie',
+};
 
 export const loreAiEndpoint = `https://ai.webaverse.com/lore`;
 export const chatTextSpeed = 20;

--- a/game.js
+++ b/game.js
@@ -1912,9 +1912,9 @@ const gameManager = {
     const localPlayer = metaversefileApi.useLocalPlayer();
     return localPlayer.loadVoicePack(voicePack);
   },
-  setVoice(voiceId) {
+  setVoiceEndpoint(voiceId) {
     const localPlayer = metaversefileApi.useLocalPlayer();
-    return localPlayer.setVoice(voiceId);
+    return localPlayer.setVoiceEndpoint(voiceId);
   },
   update: _gameUpdate,
   pushAppUpdates: _pushAppUpdates,

--- a/src/components/general/settings/TabAudio.jsx
+++ b/src/components/general/settings/TabAudio.jsx
@@ -2,7 +2,7 @@
 import React, { useEffect, useState } from 'react';
 import classNames from 'classnames';
 
-import { defaultVoicePack, defaultVoice } from '../../../../constants.js';
+import { defaultVoicePack, defaultVoiceEndpoint } from '../../../../constants.js';
 import game from '../../../../game';
 import { Slider } from './slider';
 
@@ -10,13 +10,17 @@ import styles from './settings.module.css';
 
 //
 
+const noneVoiceEndpoint = {
+    name: 'None',
+    drive_id: null,
+};
 const DefaultSettings = {
     general:        100,
     music:          100,
     voice:          100,
     effects:        100,
     voicePack:      defaultVoicePack.name,
-    // voicePack:      defaultVoice.name
+    voiceEndpoint:  noneVoiceEndpoint.name,
 };
 
 export const TabAudio = ({ active }) => {
@@ -26,12 +30,14 @@ export const TabAudio = ({ active }) => {
     const [ settingsLoaded, setSettingsLoaded ] = useState( null );
 
     const [ voicePacks, setVoicePacks ] = useState([]);
+    const [ voiceEndpoints, setVoiceEndpoints ] = useState([]);
 
     const [ generalVolume, setGeneralVolume ] = useState( null );
     const [ musicVolume, setMusicVolume ] = useState( null );
     const [ voiceVolume, setVoiceVolume ] = useState( null );
     const [ effectsVolume, setEffectsVolume ] = useState( null );
     const [ voicePack, setVoicePack ] = useState( '' );
+    const [ voiceEndpoint, setVoiceEndpoint ] = useState( '' );
 
     //
 
@@ -42,7 +48,8 @@ export const TabAudio = ({ active }) => {
             music:          musicVolume,
             voice:          voiceVolume,
             effects:        effectsVolume,
-            voicePack:      voicePack
+            voicePack:      voicePack,
+            voiceEndpoint:  voiceEndpoint,
         };
 
         localStorage.setItem( 'AudioSettings', JSON.stringify( settings ) );
@@ -71,6 +78,7 @@ export const TabAudio = ({ active }) => {
         setVoiceVolume( settings.voice ?? DefaultSettings.voice );
         setEffectsVolume( settings.effects ?? DefaultSettings.effects );
         setVoicePack( settings.voicePack ?? DefaultSettings.voicePack );
+        setVoiceEndpoint( settings.voiceEndpoint ?? DefaultSettings.voiceEndpoint );
 
         setSettingsLoaded( true );
 
@@ -80,13 +88,8 @@ export const TabAudio = ({ active }) => {
 
         // set voice pack
 
-        const vp = voicePacks[ voicePacks.map( ( vp ) => { return vp.name; } ).indexOf( voicePack ).toString() ];
-
-        if ( typeof vp.drive_id === 'string' ) {
-
-            game.setVoice( vp.drive_id );
-
-        } else if ( typeof vp.audioUrl === 'string' || typeof vp.indexUrl === 'string' ) {
+        const vp = voicePacks[ voicePacks.map( ( vp ) => { return vp.name; } ).indexOf( voicePack ) ];
+        if ( vp ) {
 
             (async () => {
 
@@ -101,9 +104,14 @@ export const TabAudio = ({ active }) => {
 
             });
 
-        } else {
+        }
 
-            console.warn( 'no such voice pack', voicePack );
+        // set voice endpoint
+
+        const ve = voiceEndpoints[ voiceEndpoints.map( ( vp ) => { return vp.name; } ).indexOf( voiceEndpoint ) ];
+        if ( ve ) {
+
+            game.setVoiceEndpoint( ve.drive_id );
 
         }
 
@@ -117,9 +125,15 @@ export const TabAudio = ({ active }) => {
 
     async function loadVoicePack () {
 
+        setVoicePacks( [ defaultVoicePack ] );
+
+    };
+
+    async function loadVoiceEndpoint () {
+
         const res = await fetch( `https://raw.githubusercontent.com/webaverse/tiktalknet/main/model_lists/all_models.json` );
-        const voicePacks = await res.json();
-        setVoicePacks( [ defaultVoicePack ].concat( voicePacks ) );
+        const voiceEndpoints = await res.json();
+        setVoiceEndpoints( [ noneVoiceEndpoint ].concat(voiceEndpoints) );
 
     };
 
@@ -134,7 +148,7 @@ export const TabAudio = ({ active }) => {
 
     useEffect( () => {
 
-        if ( generalVolume && musicVolume && voiceVolume && effectsVolume && voicePack ) {
+        if ( generalVolume && musicVolume && voiceVolume && effectsVolume && voicePack && voiceEndpoint ) {
 
             if ( settingsLoaded ) {
 
@@ -149,11 +163,14 @@ export const TabAudio = ({ active }) => {
 
         }
 
-    }, [ generalVolume, musicVolume, voiceVolume, effectsVolume, voicePack ] );
+    }, [ generalVolume, musicVolume, voiceVolume, effectsVolume, voicePack, voiceEndpoint ] );
 
     useEffect( async () => {
 
-        await loadVoicePack();
+        await Promise.all([
+            loadVoicePack(),
+            loadVoiceEndpoint(),
+        ]);
         loadSettings();
 
     }, [] );
@@ -189,6 +206,18 @@ export const TabAudio = ({ active }) => {
                         voicePacks.map( ( voicePack, i ) => {
                             return (
                                 <option value={ voicePack.name } key={ i }>{ voicePack.name }</option>
+                            );
+                        })
+                    }
+                </select>
+            </div>
+            <div className={ styles.row } >
+                <div className={ styles.paramName }>Voice endpoint</div>
+                <select className={ styles.select } value={ voiceEndpoint } onChange={ e => { setVoiceEndpoint( e.target.value ); } } >
+                    {
+                        voiceEndpoints.map( ( voiceEndpoint, i ) => {
+                            return (
+                                <option value={ voiceEndpoint.name } key={ i }>{ voiceEndpoint.name }</option>
                             );
                         })
                     }

--- a/webaverse.js
+++ b/webaverse.js
@@ -40,7 +40,7 @@ import * as metaverseModules from './metaverse-modules.js';
 import dioramaManager from './diorama.js';
 import metaversefileApi from 'metaversefile';
 import WebaWallet from './src/components/wallet.js';
-import {defaultVoice, defaultVoicePack} from './constants.js';
+// import {defaultVoiceEndpoint, defaultVoicePack} from './constants.js';
 
 // const leftHandOffset = new THREE.Vector3(0.2, -0.2, -0.4);
 // const rightHandOffset = new THREE.Vector3(-0.2, -0.2, -0.4);
@@ -159,8 +159,8 @@ export default class Webaverse extends EventTarget {
         transformControls.waitForLoad(),
         metaverseModules.waitForLoad(),
         WebaWallet.waitForLoad(),
-        game.loadVoicePack(defaultVoicePack),
-        // game.setVoice(defaultVoice),
+        // game.loadVoicePack(defaultVoicePack),
+        // game.setVoiceEndpoint(defaultVoice),
       ]);
     })();
     this.contentLoaded = false;


### PR DESCRIPTION
This PR adds splits voice packs and voice endpoints into two separate options in the settings panel. The voice pack provides basic static synthesis and action vocals, and the voice endpoint, if enabled, provides neural synthesis. They can be selected independently, and the voice endpoint is disabled by default, triggering voice pack fallback.

APIs are adjusted accordingly, unlocking the same configurability with NPCs.

A nice side effect of this PR is that it optimizes a double-loading of voice packs, since we were already doing another voice load in `webaverse.js`.