### PR TITLE
Npc compatible appManager

### DIFF
--- a/app-manager.js
+++ b/app-manager.js
@@ -236,15 +236,7 @@ class AppManager extends EventTarget {
         const m = await metaversefile.import(contentId);
         if (!live) return _bailout(null);
         const app = metaversefile.createApp({
-          name: contentId,
-          /* type: (() => {
-            const match = contentId.match(/\.([a-z0-9]+)$/i);
-            if (match) {
-              return match[1];
-            } else {
-              return '';
-            }
-          })(), */
+          // name: contentId,
         });
         
         app.position.fromArray(position);

--- a/app-manager.js
+++ b/app-manager.js
@@ -245,19 +245,12 @@ class AppManager extends EventTarget {
         app.updateMatrixWorld();
         app.lastMatrix.copy(app.matrixWorld);
 
-        app.name = m.name ?? contentId.match(/([^\/\.]*)$/)[1];
-        app.description = m.description ?? '';
-        app.contentId = contentId;
         app.instanceId = instanceId;
         app.setComponent('physics', true);
-        if (Array.isArray(m.components)) {
-          for (const {key, value} of m.components) {
-            app.setComponent(key, value);
-          }
-        }
         for (const {key, value} of components) {
           app.setComponent(key, value);
         }
+        // console.log('add module', m);
         const mesh = await app.addModule(m);
         if (!live) return _bailout(app);
         if (!mesh) {

--- a/character-controller.js
+++ b/character-controller.js
@@ -942,7 +942,7 @@ class LocalPlayer extends UninterpolatedPlayer {
       }
     }
   }
-  lookAt(p) {
+  /* lookAt(p) {
     const cameraOffset = cameraManager.getCameraOffset();
     camera.position.add(localVector.copy(cameraOffset).applyQuaternion(camera.quaternion));
     camera.quaternion.setFromRotationMatrix(
@@ -954,14 +954,7 @@ class LocalPlayer extends UninterpolatedPlayer {
     );
     camera.position.sub(localVector.copy(cameraOffset).applyQuaternion(camera.quaternion));
     camera.updateMatrixWorld();
-    
-    /* this.quaternion.setFromRotationMatrix(
-      localMatrix.lookAt(this.position, p, upVector)
-    );
-    teleportTo(this.position, this.quaternion, {
-      relation: 'head',
-    }); */
-  }
+  } */
   pushPlayerUpdates() {
     this.playersArray.doc.transact(() => {
       /* if (isNaN(this.position.x) || isNaN(this.position.y) || isNaN(this.position.z)) {

--- a/character-controller.js
+++ b/character-controller.js
@@ -136,7 +136,21 @@ class PlayerBase extends THREE.Object3D {
       this.leftHand,
       this.rightHand,
     ];
+    
     this.avatar = null;
+    
+    this.appManager = new AppManager({
+      appsMap: null,
+    });
+    this.appManager.addEventListener('appadd', e => {
+      const app = e.data;
+      scene.add(app);
+    });
+    this.appManager.addEventListener('appremove', e => {
+      const app = e.data;
+      app.parent && app.parent.remove(app);
+    });
+
     this.eyeballTarget = new THREE.Vector3();
     this.eyeballTargetEnabled = false;
     this.voicePack = null;
@@ -257,18 +271,6 @@ class StatePlayer extends PlayerBase {
     this.playersArray = null;
     this.playerMap = null;
     this.microphoneMediaStream = null;
-
-    this.appManager = new AppManager({
-      appsMap: null,
-    });
-    this.appManager.addEventListener('appadd', e => {
-      const app = e.data;
-      scene.add(app);
-    });
-    this.appManager.addEventListener('appremove', e => {
-      const app = e.data;
-      app.parent && app.parent.remove(app);
-    });
     
     this.avatarEpoch = 0;
     this.syncAvatarCancelFn = null;

--- a/metaverse-components.js
+++ b/metaverse-components.js
@@ -22,15 +22,11 @@ const componentTemplates = {
     let modelBones = null;
     let appAimAnimationMixers = null;
 
-    // console.log('wear component add', app.contentId);
-
     const initialScale = app.scale.clone();
 
     const localPlayer = metaversefile.useLocalPlayer();
 
     const wearupdate = e => {
-      // console.log('wear update', e);
-      
       if (e.wear) {
         wearSpec = app.getComponent('wear');
         initialScale.copy(app.scale);

--- a/metaverse-components.js
+++ b/metaverse-components.js
@@ -5,6 +5,7 @@ import {world} from './world.js';
 import physicsManager from './physics-manager.js';
 import {glowMaterial} from './shaders.js';
 import easing from './easing.js';
+import npcManager from './npc-manager.js';
 import {rarityColors} from './constants.js';
 
 const localVector = new THREE.Vector3();
@@ -154,6 +155,22 @@ const componentTemplates = {
       }
     };
     app.addEventListener('wearupdate', wearupdate);
+    app.addEventListener('destroy', () => {
+      const localPlayer = metaversefile.useLocalPlayer();
+      const remotePlayers = metaversefile.useRemotePlayers();
+      const {npcs} = npcManager;
+      const players = [localPlayer]
+        .concat(remotePlayers)
+        .concat(npcs);
+      for (const player of players) {
+        const wearActionIndex = player.findActionIndex(action => {
+          return action.type === 'wear' && action.instanceId === app.instanceId;
+        });
+        if (wearActionIndex !== -1) {
+          player.removeActionIndex(wearActionIndex);
+        }
+      }
+    });
 
     const _unwear = () => {
       if (wearSpec) {

--- a/metaverse_modules/ki/index.js
+++ b/metaverse_modules/ki/index.js
@@ -12,7 +12,9 @@ const identityQuaternion = new THREE.Quaternion();
 
 let kiGlbApp = null;
 const loadPromise = (async () => {
-  kiGlbApp = await metaversefile.load(baseUrl + 'ki.glb');
+  kiGlbApp = await metaversefile.createAppAsync({
+    start_url: baseUrl + 'ki.glb',
+  });
 })();
 
 const color1 = new THREE.Color(0x59C173);

--- a/metaversefile-api.js
+++ b/metaversefile-api.js
@@ -925,7 +925,7 @@ export default () => {
             },
           });
         } else {
-          console.warn('module is not a function', m);
+          console.warn('module default export is not a function', m);
           return null;
         }
       } catch(err) {

--- a/metaversefile-api.js
+++ b/metaversefile-api.js
@@ -282,12 +282,12 @@ metaversefile.setApi({
       return null;
     }
   },
-  async load(u) {
+  /* async load(u) {
     const m = await metaversefile.import(u);
     const app = metaversefile.createApp();
     await metaversefile.addModule(app, m);
     return app;
-  },
+  }, */
   useApp() {
     const app = currentAppRender;
     if (app) {

--- a/metaversefile-api.js
+++ b/metaversefile-api.js
@@ -72,6 +72,9 @@ class App extends THREE.Object3D {
       value,
     });
   }
+  hasComponent(key) {
+    return this.components.some(component => component.key === key);
+  }
   removeComponent(key) {
     const index = this.components.findIndex(component => component.type === key);
     if (index !== -1) {

--- a/metaversefile-api.js
+++ b/metaversefile-api.js
@@ -900,6 +900,17 @@ export default () => {
     await universe.waitForSceneLoaded();
   },
   async addModule(app, m) {
+    app.name = m.name ?? (m.contentId ? m.contentId.match(/([^\/\.]*)$/)[1] : '');
+    app.description = m.description ?? '';
+    app.contentId = m.contentId ?? '';
+    if (Array.isArray(m.components)) {
+      for (const {key, value} of m.components) {
+        if (!app.hasComponent(key)) {
+          app.setComponent(key, value);
+        }
+      }
+    }
+
     currentAppRender = app;
 
     let renderSpec = null;

--- a/universe.js
+++ b/universe.js
@@ -47,11 +47,15 @@ class Universe extends EventTarget {
         world.connectState(state);
         
         if (src === undefined) {
-          promises.push(metaversefile.load('./scenes/' + sceneNames[0]));
+          promises.push(metaversefile.createAppAsync({
+            start_url: './scenes/' + sceneNames[0],
+          }));
         } else if (src === '') {
           // nothing
         } else {
-          promises.push(metaversefile.load(src));
+          promises.push(metaversefile.createAppAsync({
+            start_url: src,
+          }));
         }
       } else {
         const p = (async () => {


### PR DESCRIPTION
Refactoring to support wearables for NPCs. Previously wearables were only for local and remote players.

NPCs now get their own `appManager` which means they can transact with the world like any other player.

Also cleans up the `app` creation APIs, such as making `.addModule` self-initializing in its app metadata. Previously the metadata decorations was a bunch of hacks that happened only in certain places, like the app manager, but not others, like a manual userspace metaversefile load.

The end result of these changes is that we support NPC JSON wearable definition, since it now runs the same code as putting an object in the world and manually wearing it.

Depends on https://github.com/webaverse/totum/pull/69/files