### PR TITLE
Elide physics update

### DIFF
--- a/universe.js
+++ b/universe.js
@@ -33,8 +33,8 @@ class Universe extends EventTarget {
     localPlayer.position.set(0, initialPosY, 0);
     localPlayer.resetPhysics();
     localPlayer.updateMatrixWorld();
-    physicsManager.setPhysicsEnabled(true);
-    localPlayer.updatePhysics(0, 0);
+    // physicsManager.setPhysicsEnabled(true);
+    // localPlayer.updatePhysics(0, 0);
     physicsManager.setPhysicsEnabled(false);
 
     const _doLoad = async () => {


### PR DESCRIPTION
There is a `physicsManager.setPhysicsEnabled` twiddling in  `universe.js`.

It used to fix a bug but now it seemlingly doesn't, so commenting out these lines since they no longer seem useful, and just waste runtime.