### PR TITLE
Refactor player update loop (updatePhysics+updateAvatar)

### DIFF
--- a/character-controller.js
+++ b/character-controller.js
@@ -946,11 +946,7 @@ class LocalPlayer extends UninterpolatedPlayer {
     camera.position.sub(localVector.copy(cameraOffset).applyQuaternion(camera.quaternion));
     camera.updateMatrixWorld();
   } */
-  getSession() {
-    const renderer = getRenderer();
-    const session = renderer.xr.getSession();
-    return session;
-  }
+  
   pushPlayerUpdates() {
     this.playersArray.doc.transact(() => {
       /* if (isNaN(this.position.x) || isNaN(this.position.y) || isNaN(this.position.z)) {
@@ -963,7 +959,9 @@ class LocalPlayer extends UninterpolatedPlayer {
     this.appManager.updatePhysics();
   }
   getSession() {
-    return null;
+    const renderer = getRenderer();
+    const session = renderer.xr.getSession();
+    return session;
   }
   updatePhysics(timestamp, timeDiff) {
     if (this.avatar) {
@@ -1148,6 +1146,9 @@ class NpcPlayer extends StaticUninterpolatedPlayer {
     
     loadPhysxCharacterController.call(this);
     // loadPhysxAuxCharacterCapsule.call(this);
+  }
+  getSession() {
+    return null;
   }
   updatePhysics = LocalPlayer.prototype.updatePhysics;
   updateAvatar = LocalPlayer.prototype.updateAvatar;


### PR DESCRIPTION
- Make `updatePhysics` responsible for only physics-related updates in the player; previously this included sounds and special effects, and these are now moved to `updateAvatar`
- Merge the update methods for all player objects into a single set, so NPCs and local/remote players are treated the same for update purposes (this was already logically true)