### PR TITLE
Avatar async loading

### DIFF
--- a/avatar-spriter.js
+++ b/avatar-spriter.js
@@ -1498,7 +1498,7 @@ const _renderSpriteImages = skinnedVrm => {
     visemes: true,
     debug: false,
   });
-  await localRig.waitForLoad();
+  // await localRig.waitForLoad();
   for (let h = 0; h < 2; h++) {
     localRig.setHandEnabled(h, false);
   }

--- a/avatar-spriter.js
+++ b/avatar-spriter.js
@@ -1498,6 +1498,7 @@ const _renderSpriteImages = skinnedVrm => {
     visemes: true,
     debug: false,
   });
+  await localRig.waitForLoad();
   for (let h = 0; h < 2; h++) {
     localRig.setHandEnabled(h, false);
   }

--- a/avatar-spriter.js
+++ b/avatar-spriter.js
@@ -1498,7 +1498,6 @@ const _renderSpriteImages = skinnedVrm => {
     visemes: true,
     debug: false,
   });
-  // await localRig.waitForLoad();
   for (let h = 0; h < 2; h++) {
     localRig.setHandEnabled(h, false);
   }

--- a/avatars/avatars.js
+++ b/avatars/avatars.js
@@ -26,7 +26,7 @@ import {
 import {FixedTimeStep} from '../interpolants.js';
 import * as avatarCruncher from '../avatar-cruncher.js';
 import * as avatarSpriter from '../avatar-spriter.js';
-import game from '../game.js';
+// import game from '../game.js';
 import {
   idleFactorSpeed,
   walkFactorSpeed,

--- a/avatars/avatars.js
+++ b/avatars/avatars.js
@@ -3318,10 +3318,6 @@ class Avatar {
     }
 	}
 
-  async waitForLoad() {
-    await this.springBoneManager.waitForLoad();
-  }
-
   isAudioEnabled() {
     return !!this.microphoneWorker;
   }

--- a/avatars/avatars.js
+++ b/avatars/avatars.js
@@ -26,7 +26,7 @@ import {
 import {FixedTimeStep} from '../interpolants.js';
 import * as avatarCruncher from '../avatar-cruncher.js';
 import * as avatarSpriter from '../avatar-spriter.js';
-// import game from '../game.js';
+import game from '../game.js';
 import {
   idleFactorSpeed,
   walkFactorSpeed,

--- a/character-controller.js
+++ b/character-controller.js
@@ -1123,7 +1123,6 @@ class NpcPlayer extends StaticUninterpolatedPlayer {
       visemes: true,
       debug: false,
     });
-    await avatar.waitForLoad();
 
     unFrustumCull(app);
     enableShadows(app);

--- a/character-controller.js
+++ b/character-controller.js
@@ -1123,7 +1123,8 @@ class NpcPlayer extends StaticUninterpolatedPlayer {
       visemes: true,
       debug: false,
     });
-  
+    await avatar.waitForLoad();
+
     unFrustumCull(app);
     enableShadows(app);
   

--- a/metaversefile-api.js
+++ b/metaversefile-api.js
@@ -347,9 +347,9 @@ metaversefile.setApi({
   usePostProcessing() {
     return postProcessing;
   },
-  createAvatar(o, options) {
+  /* createAvatar(o, options) {
     return new Avatar(o, options);
-  },
+  }, */
   useAvatarAnimations() {
     return Avatar.getAnimations();
   },
@@ -864,9 +864,9 @@ export default () => {
   /* useRigManagerInternal() {
     return rigManager;
   }, */
-  useAvatar() {
+  /* useAvatar() {
     return Avatar;
-  },
+  }, */
   useText() {
     return Text;
   },

--- a/player-avatar-binding.js
+++ b/player-avatar-binding.js
@@ -285,9 +285,6 @@ export async function switchAvatar(oldAvatar, newApp) {
       
       if (!newApp[avatarSymbol]) {
         newApp[avatarSymbol] = makeAvatar(newApp);
-        if (newApp[avatarSymbol]) {
-          await newApp[avatarSymbol].waitForLoad();
-        }
       }
       result = newApp[avatarSymbol];
     })());

--- a/player-avatar-binding.js
+++ b/player-avatar-binding.js
@@ -283,10 +283,11 @@ export async function switchAvatar(oldAvatar, newApp) {
     promises.push((async () => {
       await newApp.setSkinning(true);
       
-      // unwear old rig
-      
       if (!newApp[avatarSymbol]) {
         newApp[avatarSymbol] = makeAvatar(newApp);
+        if (newApp[avatarSymbol]) {
+          await newApp[avatarSymbol].waitForLoad();
+        }
       }
       result = newApp[avatarSymbol];
     })());

--- a/screenshot.js
+++ b/screenshot.js
@@ -273,6 +273,7 @@ const _getType = id => {
         visemes: true,
         debug: false,
       });
+      await avatar.waitForLoad();
       app.avatar = avatar;
     }
     o = app;

--- a/screenshot.js
+++ b/screenshot.js
@@ -273,7 +273,6 @@ const _getType = id => {
         visemes: true,
         debug: false,
       });
-      await avatar.waitForLoad();
       app.avatar = avatar;
     }
     o = app;


### PR DESCRIPTION
Part of avatar loading involves running the VRM springbones importer, which is implemented asynchronously upstream (that doesn't make sense to me, since you already have 100% of the data by that point, but that is the upstream `three-vrm` implementation).

That means we cannot truly set up avatars synchronously, though we had handling in place to ignore spring bones until they snap into existence, usually within frames of the load.

This is usually perfectly fine, but it fails in the case where accurate, reproducible control of hair is required as the avatar loads in (such as motion video). This PR attempts to address that by adding async waiters to all cases where we use avatar -- which it turns out were already `async`, so it's not a big change.

This PR successfully fixes the bug, even improving the initial avatar load experience to be less janky, though it adds more `async` complexity just to enable this upstream corner case, which really makes no sense to me in the first place.

IMO the best path would be to either:
1) Figure out [VRMSpringBoneImporter](https://github.com/pixiv/three-vrm/blob/5ab93c5640ea3b7594e2072b0e0b5615ae3f0ee4/packages/three-vrm/src/springbone/VRMSpringBoneImporter.ts#L22) in the upstream, possibly rewriting it to be synchronous
2) failing that, make avatars loading completely async in `async createAvatar()` instead of being a two-step process (`a = new Avatar(); await a.waitForLoad();`)