### PR TITLE
add watch to dev deps, restart node on packages change

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -10,7 +10,9 @@ import wsrtc from 'wsrtc/wsrtc-server.mjs';
 Error.stackTraceLimit = 300;
 const cwd = process.cwd();
 
-const isProduction = process.argv[2] === '-p';
+process.title = process.argv.find(e => e.split("=")[0] == '--name');
+process.title &&= process.title.split("=")[1];
+const isProduction = process.argv.find(e => e == '-p') === '-p';
 
 const _isMediaType = p => /\.(?:png|jpe?g|gif|svg|glb|mp3|wav|webm|mp4|mov)$/.test(p);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,8 @@
         "eslint-plugin-promise": "^4.2.1",
         "eslint-plugin-standard": "^4.0.1",
         "spectorjs": "^0.9.27",
-        "vite": "^2.5.1"
+        "vite": "^2.5.1",
+        "watch": "^1.0.2"
       }
     },
     "node_modules/@3id/common": {
@@ -5578,6 +5579,15 @@
       "version": "6.4.4",
       "license": "MIT"
     },
+    "node_modules/exec-sh": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.2.tgz",
+      "integrity": "sha512-FIUCJz1RbuS0FKTdaAafAByGS0CPvU3R0MeHxgtl+djzCc//F8HakL8GzmVNZanasTbTAY/3DRFA0KpVqj/eAw==",
+      "dev": true,
+      "dependencies": {
+        "merge": "^1.2.0"
+      }
+    },
     "node_modules/execa": {
       "version": "4.1.0",
       "dev": true,
@@ -8184,6 +8194,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/merge": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.1.tgz",
+      "integrity": "sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==",
+      "dev": true
     },
     "node_modules/merge-descriptors": {
       "version": "1.0.1",
@@ -12586,6 +12602,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/watch": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/watch/-/watch-1.0.2.tgz",
+      "integrity": "sha1-NApxe952Vyb6CqB9ch4BR6VR3ww=",
+      "dev": true,
+      "dependencies": {
+        "exec-sh": "^0.2.0",
+        "minimist": "^1.2.0"
+      },
+      "bin": {
+        "watch": "cli.js"
+      },
+      "engines": {
+        "node": ">=0.1.95"
+      }
+    },
     "node_modules/web-streams-polyfill": {
       "version": "3.2.0",
       "license": "MIT",
@@ -16706,6 +16738,15 @@
     "eventemitter2": {
       "version": "6.4.4"
     },
+    "exec-sh": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.2.tgz",
+      "integrity": "sha512-FIUCJz1RbuS0FKTdaAafAByGS0CPvU3R0MeHxgtl+djzCc//F8HakL8GzmVNZanasTbTAY/3DRFA0KpVqj/eAw==",
+      "dev": true,
+      "requires": {
+        "merge": "^1.2.0"
+      }
+    },
     "execa": {
       "version": "4.1.0",
       "dev": true,
@@ -18371,6 +18412,12 @@
         "mimic-fn": "^2.0.0",
         "p-is-promise": "^2.0.0"
       }
+    },
+    "merge": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.1.tgz",
+      "integrity": "sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==",
+      "dev": true
     },
     "merge-descriptors": {
       "version": "1.0.1"
@@ -21382,6 +21429,16 @@
     "vlq": {
       "version": "0.2.3",
       "dev": true
+    },
+    "watch": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/watch/-/watch-1.0.2.tgz",
+      "integrity": "sha1-NApxe952Vyb6CqB9ch4BR6VR3ww=",
+      "dev": true,
+      "requires": {
+        "exec-sh": "^0.2.0",
+        "minimist": "^1.2.0"
+      }
     },
     "web-streams-polyfill": {
       "version": "3.2.0"

--- a/package.json
+++ b/package.json
@@ -5,13 +5,17 @@
   "main": "index.mjs",
   "scripts": {
     "start": "forever start index.mjs -p",
-    "dev": "node index.mjs",
+    "stop": "killall -SIGINT webaverse || true",    
+    "dev": "node index.mjs --name=webaverse",
+    "prerestart": "npm run stop",
+    "restart": "npm run dev",    
     "prod": "sudo $(which node) index.mjs -p",
     "build": "vite build",
     "serve": "vite preview",
     "setup:test": "cd test && npm i",
     "test": "cd test && npm run test",
-    "start-pm2": "pm2-runtime index.mjs -p --secret $PM2_SECRET_KEY --public $PM2_PUBLIC_KEY --no-auto-exit --instances 1 --restart-delay 60000"
+    "start-pm2": "pm2-runtime index.mjs -p --secret $PM2_SECRET_KEY --public $PM2_PUBLIC_KEY --no-auto-exit --instances 1 --restart-delay 60000",
+    "watch": "watch 'npm run restart' ./packages"    
   },
   "dependencies": {
     "@3id/connect": "^0.2.5",
@@ -70,6 +74,7 @@
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-standard": "^4.0.1",
     "spectorjs": "^0.9.27",
-    "vite": "^2.5.1"
+    "vite": "^2.5.1",
+    "watch": "^1.0.2"
   }
 }


### PR DESCRIPTION
package.json changes to reload node when submodules get edited.
- run `npm insatll` to get watch module
- run `npm run watch` to watch submodules directory

`npm run dev` still works as before if you don't want to watch submodules dir.
closes #2509