### PR TITLE
Remove springbone time step

### DIFF
--- a/avatars/avatars.js
+++ b/avatars/avatars.js
@@ -17,13 +17,12 @@ import {zbdecode} from 'zjs/encoding.mjs';
 import Simplex from '../simplex-noise.js';
 import {
   crouchMaxTime,
-  useMaxTime,
+  // useMaxTime,
   aimMaxTime,
-  avatarInterpolationFrameRate,
-  avatarInterpolationTimeDelay,
-  avatarInterpolationNumFrames,
+  // avatarInterpolationFrameRate,
+  // avatarInterpolationTimeDelay,
+  // avatarInterpolationNumFrames,
 } from '../constants.js';
-import {FixedTimeStep} from '../interpolants.js';
 import * as avatarCruncher from '../avatar-cruncher.js';
 import * as avatarSpriter from '../avatar-spriter.js';
 import {

--- a/avatars/avatars.js
+++ b/avatars/avatars.js
@@ -1278,11 +1278,6 @@ class Avatar {
     if (options.hair) {
       this.springBoneManager = new VRMSpringBoneImporter().import(object);
     }
-    /* this.springBoneTimeStep = new FixedTimeStep(timeDiff => {
-      // console.log('update hairs', new Error().stack);
-      const timeDiffS = timeDiff / 1000;
-      this.springBoneManager && this.springBoneManager.lateUpdate(timeDiffS);
-    }, avatarInterpolationFrameRate); */
 
     const _getOffset = (bone, parent = bone?.parent) => bone && bone.getWorldPosition(new THREE.Vector3()).sub(parent.getWorldPosition(new THREE.Vector3()));
 
@@ -3171,7 +3166,6 @@ class Avatar {
     );
     // this.modelBones.Root.updateMatrixWorld();
 
-    // this.springBoneTimeStep.update(timeDiff);
     this.springBoneManager && this.springBoneManager.lateUpdate(timeDiffS);
 
     // XXX hook these up

--- a/avatars/avatars.js
+++ b/avatars/avatars.js
@@ -1278,11 +1278,11 @@ class Avatar {
     if (options.hair) {
       this.springBoneManager = new VRMSpringBoneImporter().import(object);
     }
-    this.springBoneTimeStep = new FixedTimeStep(timeDiff => {
+    /* this.springBoneTimeStep = new FixedTimeStep(timeDiff => {
       // console.log('update hairs', new Error().stack);
       const timeDiffS = timeDiff / 1000;
       this.springBoneManager && this.springBoneManager.lateUpdate(timeDiffS);
-    }, avatarInterpolationFrameRate);
+    }, avatarInterpolationFrameRate); */
 
     const _getOffset = (bone, parent = bone?.parent) => bone && bone.getWorldPosition(new THREE.Vector3()).sub(parent.getWorldPosition(new THREE.Vector3()));
 
@@ -3171,7 +3171,8 @@ class Avatar {
     );
     // this.modelBones.Root.updateMatrixWorld();
 
-    this.springBoneTimeStep.update(timeDiff);
+    // this.springBoneTimeStep.update(timeDiff);
+    this.springBoneManager && this.springBoneManager.lateUpdate(timeDiffS);
 
     // XXX hook these up
     this.nodder.update(now);

--- a/avatars/avatars.js
+++ b/avatars/avatars.js
@@ -23,6 +23,7 @@ import {
   // avatarInterpolationTimeDelay,
   // avatarInterpolationNumFrames,
 } from '../constants.js';
+import {FixedTimeStep} from '../interpolants.js';
 import * as avatarCruncher from '../avatar-cruncher.js';
 import * as avatarSpriter from '../avatar-spriter.js';
 import {
@@ -1277,6 +1278,11 @@ class Avatar {
     if (options.hair) {
       this.springBoneManager = new VRMSpringBoneImporter().import(object);
     }
+    /* this.springBoneTimeStep = new FixedTimeStep(timeDiff => {
+      // console.log('update hairs', new Error().stack);
+      const timeDiffS = timeDiff / 1000;
+      this.springBoneManager && this.springBoneManager.lateUpdate(timeDiffS);
+    }, 10); */
 
     const _getOffset = (bone, parent = bone?.parent) => bone && bone.getWorldPosition(new THREE.Vector3()).sub(parent.getWorldPosition(new THREE.Vector3()));
 
@@ -3165,6 +3171,7 @@ class Avatar {
     );
     // this.modelBones.Root.updateMatrixWorld();
 
+    // this.springBoneTimeStep.update(timeDiff);
     this.springBoneManager && this.springBoneManager.lateUpdate(timeDiffS);
 
     // XXX hook these up

--- a/avatars/avatars.js
+++ b/avatars/avatars.js
@@ -23,7 +23,7 @@ import {
   // avatarInterpolationTimeDelay,
   // avatarInterpolationNumFrames,
 } from '../constants.js';
-import {FixedTimeStep} from '../interpolants.js';
+// import {FixedTimeStep} from '../interpolants.js';
 import * as avatarCruncher from '../avatar-cruncher.js';
 import * as avatarSpriter from '../avatar-spriter.js';
 import {
@@ -1277,6 +1277,8 @@ class Avatar {
 
     if (options.hair) {
       this.springBoneManager = new VRMSpringBoneImporter().import(object);
+    } else {
+      this.springBoneManager = null;
     }
     /* this.springBoneTimeStep = new FixedTimeStep(timeDiff => {
       // console.log('update hairs', new Error().stack);


### PR DESCRIPTION
Under low FPS conditions, there is a hair glitch in which some frames do not get a hair time step in. This is due to the high resolution of the hair update.

However, it looks like this isn't needed and simply updating the hair every frame with the correct time offset gets rid of this problem.

This might even result in more consistent performance, since we now always do a hair update on every frame regardless of how long it took.