### PR TITLE
Chat diorama destroy

### DIFF
--- a/game.js
+++ b/game.js
@@ -1292,25 +1292,6 @@ const _bindPointerLock = () => {
 };
 _bindPointerLock();
 
-/* let lastLocalPlayerPosition;
-let lastLocalPlayerQuaternion;
-const _bindLocalPlayerTeleport = () => {
-  const localPlayer = metaversefileApi.useLocalPlayer();
-  lastLocalPlayerPosition = localPlayer.position.clone();
-  lastLocalPlayerQuaternion = localPlayer.quaternion.clone();
-  world.appManager.addEventListener('preframe', e => {
-    if (
-      !localPlayer.position.equals(lastLocalPlayerPosition) ||
-      !localPlayer.quaternion.equals(lastLocalPlayerQuaternion)
-    ) {
-      localPlayer.teleportTo(localPlayer.position, localPlayer.quaternion, {
-        relation: 'head',
-      });
-    }
-  });
-};
-_bindLocalPlayerTeleport(); */
-
 const _setFirstPersonAction = firstPerson => {
   const localPlayer = metaversefileApi.useLocalPlayer();
   if (firstPerson) {

--- a/src/CharacterHups.jsx
+++ b/src/CharacterHups.jsx
@@ -51,7 +51,6 @@ const CharacterHup = function(props) {
       }
 
       return () => {
-        chatDioramas.delete(player);
         diorama.destroy();
       };
     }
@@ -88,6 +87,9 @@ const CharacterHup = function(props) {
     }
     hup.addEventListener('voicestart', voicestart);
     function destroy(e) {
+      const player = hup.parent.player;
+      chatDioramas.delete(player);
+
       setLocalOpen(false);
     }
     hup.addEventListener('destroy', destroy);


### PR DESCRIPTION
Fixes a diorama race condition where character dioramas would be destroyed even if the character had more lines to say, due to the doomed diorama being re-used from the cache.

This PR makes it so the diorama cache is cleared the instance a diorama is for doom, allowing a new diorama to take its place if needed, fixing the race condition.