### PR TITLE
Pointer lock API abstraction

### DIFF
--- a/camera-manager.js
+++ b/camera-manager.js
@@ -87,6 +87,21 @@ class CameraManager extends EventTarget {
     this.pointerLockElement = null;
     this.pointerLockEpoch = 0;
     this.shakes = [];
+
+    document.addEventListener('pointerlockchange', e => {
+      let pointerLockElement = document.pointerLockElement;
+      const renderer = getRenderer();
+      if (pointerLockElement !== null && pointerLockElement !== renderer.domElement) {
+        pointerLockElement = null;
+      }
+      
+      this.pointerLockElement = pointerLockElement;
+      this.dispatchEvent(new MessageEvent('pointerlockchange', {
+        data: {
+          pointerLockElement,
+        },
+      }));
+    });
   }
   wasActivated() {
     return wasActivated;
@@ -109,42 +124,7 @@ class CameraManager extends EventTarget {
           if (document.pointerLockElement !== renderer.domElement) {
             const _pointerlockchange = e => {
               if (localPointerLockEpoch === this.pointerLockEpoch) {
-                if (document.pointerLockElement === renderer.domElement) {
-                  accept();
-
-                  this.pointerLockElement = document.pointerLockElement;
-                  this.dispatchEvent(new MessageEvent('pointerlockchange', {
-                    data: {
-                      pointerLockElement: this.pointerLockElement,
-                    },
-                  }));
-
-                  const _setUpUnlockNotification = () => {
-                    const _pointerlockchange2 = e => {
-                      if (localPointerLockEpoch === this.pointerLockEpoch) {
-                        if (document.pointerLockElement === null) {
-                          this.pointerLockElement = document.pointerLockElement;
-
-                          this.dispatchEvent(new MessageEvent('pointerlockchange', {
-                            data: {
-                              pointerLockElement: null,
-                            },
-                          }));
-                        } else {
-                          console.warn('unexpected pointer lock change 1', document.pointerLockElement);
-                        }
-                      }
-                      _cleanup2();
-                    };
-                    document.addEventListener('pointerlockchange', _pointerlockchange2);
-                    const _cleanup2 = () => {
-                      document.removeEventListener('pointerlockchange', _pointerlockchange2);
-                    };
-                  };
-                  _setUpUnlockNotification();
-                } else {
-                  console.warn('unexpected pointer lock change 2', document.pointerLockElement);
-                }
+                accept();
               }
               _cleanup();
             };

--- a/camera-manager.js
+++ b/camera-manager.js
@@ -153,7 +153,7 @@ class CameraManager extends EventTarget {
               reject(err);
               _cleanup();
               
-              notifications.addNotification(`\
+              /* notifications.addNotification(`\
                 <i class="icon fa fa-mouse-pointer"></i>
                 <div class=wrap>
                   <div class=label>Whoa there!</div>
@@ -164,7 +164,7 @@ class CameraManager extends EventTarget {
                 </div>
               `, {
                 timeout: 3000,
-              });
+              }); */
             };
             document.addEventListener('pointerlockerror', _pointerlockerror);
             const _cleanup = () => {

--- a/camera-manager.js
+++ b/camera-manager.js
@@ -185,7 +185,6 @@ class CameraManager extends EventTarget {
     }
   }
   exitPointerLock() {
-    // this.pointerLockEpoch++;
     document.exitPointerLock();
   }
   getMode() {

--- a/game.js
+++ b/game.js
@@ -1159,7 +1159,7 @@ const _gameUpdate = (timestamp, timeDiff) => {
         localPlayer.avatar.eyeTarget.copy(mouseSelectedPosition);
         localPlayer.avatar.eyeTargetInverted = true;
         localPlayer.avatar.eyeTargetEnabled = true;
-      } else if (!document.pointerLockElement && lastMouseEvent) {
+      } else if (!cameraManager.pointerLockElement && lastMouseEvent) {
         const renderer = getRenderer();
         const size = renderer.getSize(localVector);
         
@@ -1199,7 +1199,7 @@ const _gameUpdate = (timestamp, timeDiff) => {
 
   const crosshairEl = document.getElementById('crosshair');
   if (crosshairEl) {
-    const visible = !!document.pointerLockElement &&
+    const visible = !!cameraManager.pointerLockElement &&
       (['camera', 'firstperson', 'thirdperson'].includes(cameraManager.getMode()) || metaversefileApi.useLocalPlayer().hasAction('aim')) &&
       !_getGrabbedObject(0);
     crosshairEl.style.visibility = visible ? null : 'hidden';
@@ -1283,9 +1283,11 @@ window.addEventListener('drop', async e => {
 });
 
 const _bindPointerLock = () => {
-  document.addEventListener('pointerlockchange', () => {
+  cameraManager.addEventListener('pointerlockchange', e => {
+    const {pointerLockElement} = e.data;
+
     gameManager.setMouseHoverObject(null);
-    if (!document.pointerLockElement) {
+    if (!pointerLockElement) {
       gameManager.editMode = false;
     }
   });
@@ -1629,7 +1631,7 @@ const gameManager = {
     this.editMode = !this.editMode;
     // console.log('got edit mode', this.editMode);
     if (this.editMode) {
-      if (!document.pointerLockElement) {
+      if (!cameraManager.pointerLockElement) {
         await cameraManager.requestPointerLock();
       }
       if (this.mouseSelectedObject) {

--- a/io-manager.js
+++ b/io-manager.js
@@ -78,7 +78,7 @@ const resetKeys = () => {
   }
 };
 
-document.addEventListener('pointerlockchange', () => {
+cameraManager.addEventListener('pointerlockchange', () => {
   resetKeys();
 });
 
@@ -315,7 +315,7 @@ ioManager.keydown = e => {
     }
     case 87: { // W
       ioManager.keys.up = true;
-      if (!document.pointerLockElement) {
+      if (!cameraManager.pointerLockElement) {
         game.menuVertical(-1);
       }
 
@@ -331,7 +331,7 @@ ioManager.keydown = e => {
     }
     case 65: { // A
       ioManager.keys.left = true;
-      if (!document.pointerLockElement) {
+      if (!cameraManager.pointerLockElement) {
         game.menuHorizontal(-1);
       }
 
@@ -347,7 +347,7 @@ ioManager.keydown = e => {
     }
     case 83: { // S
       ioManager.keys.down = true;
-      if (!document.pointerLockElement) {
+      if (!cameraManager.pointerLockElement) {
         if (game.menuOpen) {
           game.menuVertical(1);
         } else {
@@ -369,7 +369,7 @@ ioManager.keydown = e => {
     }
     case 68: { // D
       ioManager.keys.right = true;
-      if (!document.pointerLockElement) {
+      if (!cameraManager.pointerLockElement) {
         game.menuHorizontal(1);
       }
 
@@ -384,7 +384,7 @@ ioManager.keydown = e => {
       break;
     }
     case 82: { // R
-      if (document.pointerLockElement) {
+      if (cameraManager.pointerLockElement) {
         if (game.canRotate()) {
           game.menuRotate(1);
         } else {
@@ -411,7 +411,7 @@ ioManager.keydown = e => {
       break;
     }
     case 71: { // G
-      if (document.pointerLockElement) {
+      if (cameraManager.pointerLockElement) {
         /* if (game.canTry()) {
           game.menuTry();
         } */
@@ -540,7 +540,7 @@ ioManager.keydown = e => {
       break;
     }
     case 69: { // E
-      // if (document.pointerLockElement) {
+      // if (cameraManager.pointerLockElement) {
         if (game.canRotate()) {
           game.menuRotate(-1);
         } else {
@@ -609,19 +609,19 @@ ioManager.keyup = e => {
       break;
     } */
     case 69: { // E
-      if (document.pointerLockElement) {
+      if (cameraManager.pointerLockElement) {
         game.menuActivateUp();
       }
       break;
     }
     case 70: { // F
-      // if (document.pointerLockElement) {
+      // if (cameraManager.pointerLockElement) {
         ioManager.keys.forward = false;
       // }
       break;
     }
     case 67: { // C
-      // if (document.pointerLockElement) {
+      // if (cameraManager.pointerLockElement) {
         ioManager.keys.backward = false;
         ioManager.keys.ctrl = false;
       // }
@@ -754,7 +754,7 @@ ioManager.mousemove = e => {
   /* if (game.weaponWheel) {
     game.updateWeaponWheel(e);
   } else { */
-    if (document.pointerLockElement) {
+    if (cameraManager.pointerLockElement) {
       _updateMouseMovement(e);
     } else {
       if (game.dragging) {
@@ -772,7 +772,7 @@ ioManager.mouseleave = e => {
   renderer.domElement.classList.remove('hover');
 };
 ioManager.click = e => {
-  if (document.pointerLockElement) {
+  if (cameraManager.pointerLockElement) {
     game.menuClick();
   } else {
     // game.setContextMenu(false);
@@ -802,7 +802,7 @@ ioManager.click = e => {
 let lastMouseButtons = 0;
 ioManager.mousedown = e => {
   const changedButtons = lastMouseButtons ^ e.buttons;
-  if (document.pointerLockElement) {
+  if (cameraManager.pointerLockElement) {
     if ((changedButtons & 1) && (e.buttons & 1)) { // left
       game.menuMouseDown();
     }
@@ -832,7 +832,7 @@ ioManager.mousedown = e => {
 ioManager.mouseup = e => {
   const changedButtons = lastMouseButtons ^ e.buttons;
   // if (mouseDown) {
-    if (document.pointerLockElement) {
+    if (cameraManager.pointerLockElement) {
       if ((changedButtons & 1) && !(e.buttons & 1)) { // left
         game.menuMouseUp();
       }

--- a/src/Header.jsx
+++ b/src/Header.jsx
@@ -69,18 +69,19 @@ export default function Header({
   }, []);
   useEffect(() => {
     const pointerlockchange = e => {
-      if (document.pointerLockElement && open !== null) {
+      const {pointerLockElement} = e.data;
+      if (pointerLockElement && open !== null) {
         setOpen(null);
       }
     };
-    window.document.addEventListener('pointerlockchange', pointerlockchange);
+    cameraManager.addEventListener('pointerlockchange', pointerlockchange);
     return () => {
-      window.document.removeEventListener('pointerlockchange', pointerlockchange);
+      cameraManager.removeEventListener('pointerlockchange', pointerlockchange);
     };
   }, [open]);
   useEffect(() => {
-    if (open && document.pointerLockElement && open !== 'chat') {
-      document.exitPointerLock();
+    if (open && open !== 'chat') {
+      cameraManager.exitPointerLock();
     }
     if (game.playerDiorama) {
       game.playerDiorama.enabled = characterOpen;

--- a/src/components/general/world-objects-list/WorldObjectsList.jsx
+++ b/src/components/general/world-objects-list/WorldObjectsList.jsx
@@ -168,7 +168,7 @@ export const WorldObjectsList = ({ opened, setOpened }) => {
 
         if ( opened ) {
 
-            document.exitPointerLock();
+            cameraManager.exitPointerLock();
             closeOtherWindows();
 
         }


### PR DESCRIPTION
Adds an abstraction in the camera manager for managing pointer locks.

This is for supporting other UIs besides the canvas which might want to request the pointer lock; we do not want the canvas UI code to be confused by that, so we abstract the pointer lock API and provide a set of virtual methods to access it.