### PR TITLE
2507 references to app.setskinning should be removed

### DIFF
--- a/character-controller.js
+++ b/character-controller.js
@@ -480,7 +480,7 @@ class StatePlayer extends PlayerBase {
     
     const _setNextAvatarApp = app => {
       (async () => {
-        const avatar = await switchAvatar(this.avatar, app);
+        const avatar = switchAvatar(this.avatar, app);
         if (!cancelFn.isLive()) return;
         this.avatar = avatar;
 
@@ -1132,9 +1132,8 @@ class NpcPlayer extends StaticUninterpolatedPlayer {
   
     this.isNpcPlayer = true;
   }
-  async setAvatarAppAsync(app) {
-    await app.setSkinning(true);
-    
+  setAvatarApp(app) {
+    app.toggleBoneUpdates(true);
     const {skinnedVrm} = app;
     const avatar = new Avatar(skinnedVrm, {
       fingers: true,

--- a/character-controller.js
+++ b/character-controller.js
@@ -479,7 +479,7 @@ class StatePlayer extends PlayerBase {
     }
     
     const _setNextAvatarApp = app => {
-      (async () => {
+      (() => {
         const avatar = switchAvatar(this.avatar, app);
         if (!cancelFn.isLive()) return;
         this.avatar = avatar;

--- a/npc-manager.js
+++ b/npc-manager.js
@@ -6,7 +6,8 @@ class NpcManager extends EventTarget {
 
     this.npcs = [];
   }
-  async createNpc({
+
+  createNpc({
     name,
     avatarApp,
     position,
@@ -33,7 +34,7 @@ class NpcManager extends EventTarget {
       npcPlayer.updateMatrixWorld();
     }
 
-    await npcPlayer.setAvatarAppAsync(avatarApp);
+    npcPlayer.setAvatarApp(avatarApp);
     this.npcs.push(npcPlayer);
 
     this.dispatchEvent(new MessageEvent('npcadd', {
@@ -41,15 +42,16 @@ class NpcManager extends EventTarget {
         player: npcPlayer,
       },
     }));
-    
+
     return npcPlayer;
   }
+
   destroyNpc(npcPlayer) {
     npcPlayer.destroy();
 
     const removeIndex = this.npcs.indexOf(npcPlayer);
     this.npcs.splice(removeIndex, 1);
-  
+
     this.dispatchEvent(new MessageEvent('npcremove', {
       data: {
         player: npcPlayer,

--- a/pic.js
+++ b/pic.js
@@ -117,7 +117,7 @@ export const genPic = async ({
   const position = new THREE.Vector3(0, 1.5, 0);
   const quaternion = new THREE.Quaternion();
   const scale = new THREE.Vector3(1, 1, 1);
-  const player = await npcManager.createNpc({
+  const player = npcManager.createNpc({
     name: 'npc',
     avatarApp: app,
     position,

--- a/player-avatar-binding.js
+++ b/player-avatar-binding.js
@@ -37,7 +37,7 @@ export function applyPlayerModesToAvatar(player, session, rig) {
     rig.setHandEnabled(i, player.hands[i].enabled);
   }
   rig.setTopEnabled(
-    (!!session && (rig.inputs.leftGamepad.enabled || rig.inputs.rightGamepad.enabled))
+    (!!session && (rig.inputs.leftGamepad.enabled || rig.inputs.rightGamepad.enabled)),
   );
   rig.setBottomEnabled(
     (
@@ -191,7 +191,7 @@ export function applyMirrorsToAvatar(player, rig, mirrors) {
         .setFromNormalAndCoplanarPoint(
           localVector.set(0, 0, 1)
             .applyQuaternion(localQuaternion.setFromRotationMatrix(closestMirror.matrixWorld)),
-          mirrorPosition
+          mirrorPosition,
         )
         .projectPoint(eyePosition, rig.eyeballTarget);
       rig.eyeballTargetEnabled = true;
@@ -223,7 +223,24 @@ export function applyPlayerToAvatar(player, session, rig, mirrors) {
   applyPlayerEmotesToAvatar(player, rig);
   applyPlayerPoseToAvatar(player, rig);
 }
-export async function switchAvatar(oldAvatar, newApp) {
+
+export function switchAvatar(oldAvatar, newApp) {
+  let result;
+
+  oldAvatar && oldAvatar[appSymbol].toggleBoneUpdates(true);
+
+  if (newApp) {
+    newApp.toggleBoneUpdates(true);
+    if (!newApp[avatarSymbol]) {
+      newApp[avatarSymbol] = makeAvatar(newApp);
+    }
+    result = newApp[avatarSymbol];
+  } else {
+    result = null;
+  }
+  return result;
+}
+/* export async function switchAvatar(oldAvatar, newApp) {
   let result;
   const promises = [];
   if (oldAvatar) {
@@ -232,17 +249,16 @@ export async function switchAvatar(oldAvatar, newApp) {
     })());
   }
   if (newApp) {
-    promises.push((async () => {
-      await newApp.setSkinning(true);
-      
+    // promises.push((async () => {
+    newApp.toggleBoneUpdates(true);
       if (!newApp[avatarSymbol]) {
         newApp[avatarSymbol] = makeAvatar(newApp);
       }
       result = newApp[avatarSymbol];
-    })());
+    // })());
   } else {
     result = null;
   }
   await Promise.all(promises);
   return result;
-}
+} */


### PR DESCRIPTION
Updated PR to replace setSkinning references in app to toggleBoneUpdates. Currently set as a draft and pointing to fork of totum until related https://github.com/webaverse/totum/pull/72 is merged.  This also removes some async/awaits that were previously needed because of the cloneVrm class in the vrm template, which was removed in webaverse/totum#72. 