### PR TITLE
<KeyHandlers />

### DIFF
--- a/src/KeyHandlers.jsx
+++ b/src/KeyHandlers.jsx
@@ -1,0 +1,81 @@
+import React, {useState, useEffect, useRef} from 'react'
+// import classes from './MagicMenu.module.css'
+import ioManager from '../io-manager.js';
+// import * as codeAi from '../ai/code/code-ai.js';
+// import metaversefile from 'metaversefile';
+
+const types = ['keyup', 'click', 'mousedown', 'mouseup', 'mousemove', 'mouseenter', 'mouseleave', 'paste'];
+const keyHandlers = {};
+for (const type of types.concat([''])) {
+  keyHandlers[type] = [];
+}
+function registerKeyHandler(type, fn) {
+  keyHandlers[type].push(fn);
+}
+function unregisterKeyHandler(type, fn) {
+  const khs = keyHandlers[type];
+  const index = khs.indexOf(fn);
+  if (index !== -1) {
+    khs.splice(index, 1);
+  }
+}
+
+function KeyHandlers() {
+  useEffect(() => {
+    const cleanups = types.map(type => {
+      const fn = e => {
+        // console.log('got event', type, e);
+
+        let broke = false;
+        
+        // type
+        for (let i = 0; i < keyHandlers[type].length; i++) {
+          const result = keyHandlers[type][i](e);
+          if (result === false) {
+            // console.log('handled 1', type);
+            broke = true;
+            break;
+          }
+        }
+
+        // all
+        if (!broke) {
+          const type = '';
+          for (let i = 0; i < keyHandlers[type].length; i++) {
+            const result = keyHandlers[type][i](e);
+            if (result === false) {
+              // console.log('handled 2', type);
+              broke = true;
+              break;
+            }
+          }
+        }
+        
+        // default
+        if (!broke) {
+          // console.log('default handle e', type);
+          ioManager[type](e);
+        }
+      };
+      window.addEventListener(type, fn);
+      return () => {
+        // console.log('clear event');
+        window.removeEventListener(type, fn);
+      };
+    });
+    return () => {
+      for (const fn of cleanups) {
+        fn();
+      }
+    };
+  }, []);
+  
+  return (
+    <></>
+  );
+}
+export {
+  KeyHandlers,
+  registerKeyHandler,
+  unregisterKeyHandler,
+};

--- a/src/MagicMenu.jsx
+++ b/src/MagicMenu.jsx
@@ -1,4 +1,5 @@
 import React, {useState, useEffect, useRef} from 'react'
+import {registerKeyHandler, unregisterKeyHandler} from './KeyHandlers.jsx'
 import classes from './MagicMenu.module.css'
 import ioManager from '../io-manager.js';
 import * as codeAi from '../ai/code/code-ai.js';
@@ -72,27 +73,6 @@ function MagicMenu({open, setOpen}) {
     })();
   };
   useEffect(() => {
-    const types = ['keyup', 'click', 'mousedown', 'mouseup', 'mousemove', 'mouseenter', 'mouseleave', 'paste'];
-    const cleanups = types.map(type => {
-      const fn = e => {
-        if (window.document.activeElement === inputTextarea.current || e.target === inputTextarea.current) {
-          // nothing
-        } else {
-          ioManager[type](e);
-        }
-      };
-      window.addEventListener(type, fn);
-      return () => {
-        window.removeEventListener(type, fn);
-      };
-    });
-    return () => {
-      for (const fn of cleanups) {
-        fn();
-      }
-    };
-  }, []);
-  useEffect(() => {
     if (magicMenuOpen) {
       if (page === 'input') {
         inputTextarea.current.focus();
@@ -104,6 +84,19 @@ function MagicMenu({open, setOpen}) {
       setNeedsFocus(false);
     }
   }, [magicMenuOpen, inputTextarea.current, needsFocus]);
+  useEffect(() => {
+    function all(e) {
+      if (window.document.activeElement === inputTextarea.current || e.target === inputTextarea.current) {
+        return false;
+      } else {
+        return true;
+      }
+    };
+    registerKeyHandler('', all);
+    return () => {
+      unregisterKeyHandler('', all);
+    };
+  }, []);
 
   const click = e => {
     ioManager.click(new MouseEvent('click'));

--- a/src/components/app/App.jsx
+++ b/src/components/app/App.jsx
@@ -4,7 +4,8 @@ import React, { useState, useEffect, useRef } from 'react';
 // import MagicMenu from '../../MagicMenu.jsx';
 import { defaultAvatarUrl } from '../../../constants';
 // import dropManager from '../../../drop-manager.js';
-import {ZoneTitleCard} from '../general/zone-title-card/ZoneTitleCard.jsx';
+import { ZoneTitleCard } from '../general/zone-title-card/ZoneTitleCard.jsx';
+import { KeyHandlers } from '../../KeyHandlers.jsx';
 
 import sceneNames from '../../../scenes/scenes.json';
 import { parseQuery } from '../../../util.js'
@@ -135,6 +136,7 @@ export const App = () => {
             <WorldObjectsList opened={ worldObjectsListOpened } setOpened={ setWorldObjectsListOpened } />
             <PlayMode />
             <EditorMode selectedScene={ selectedScene } setSelectedScene={ setSelectedScene } selectedRoom={ selectedRoom } setSelectedRoom={ setSelectedRoom } />
+            <KeyHandlers />
             <ZoneTitleCard app={ app } />
         </div>
     );


### PR DESCRIPTION
It turns out `MagicMenu.jsx` was handling _all_ keys in the app, passing off to `ioManager`. That made sense when it was the only other menu and it required a default intercept, but now there are many other menus.

This PR adds a `KeyHandlers` component which routes all key events. There is a local intercept mechanism (now used by `MagicMenu.jsx`): `registerKeyHandler`/`unregisterKeyHandler`, and the default is to pass off to the code engine `ioManager` as usual.

There should be no functionality change, but this enables more menu hotkeys, such as the mega map.

