### PR TITLE
Patch fix multiplayer

### DIFF
--- a/avatars/avatars.js
+++ b/avatars/avatars.js
@@ -1407,7 +1407,7 @@ class Avatar {
 
     let currentSpeed = this.lastSpeed;
     const moveFactors = {...this.lastMoveFactors};
-    currentSpeed = (localVector.set(this.velocity.x, 0, this.velocity.z)).length() / timeDiffS;
+    currentSpeed = (localVector.set(this.velocity.x, 0, this.velocity.z)).length();
 
     moveFactors.idleWalkFactor = Math.min(Math.max((currentSpeed - idleFactorSpeed) / (walkFactorSpeed - idleFactorSpeed), 0), 1);
     moveFactors.walkRunFactor = Math.min(Math.max((currentSpeed - walkFactorSpeed) / (runFactorSpeed - walkFactorSpeed), 0), 1);
@@ -1420,7 +1420,9 @@ class Avatar {
       .divideScalar(timeDiffS)
       .multiplyScalar(0.1);
 
-    if(positionDiff.length() < 0.0000001 && currentSpeed > 0.00000001)
+    if((positionDiff.length() < 0.0000001 && currentSpeed > 0.00000001) || 
+      (positionDiff.length() > 10 && currentSpeed < 10)
+    )
       return // Skip this frame
       
     localEuler.setFromQuaternion(this.inputs.hmd.quaternion, 'YXZ');

--- a/world.js
+++ b/world.js
@@ -95,9 +95,9 @@ world.connectRoom = async u => {
       wsrtc.removeEventListener('init', init);
       
       localPlayer.bindState(state.getArray(playersMapName));
-      if (mediaStream) {
-        wsrtc.enableMic(mediaStream);
-      }
+      // if (mediaStream) {
+      //   wsrtc.enableMic(mediaStream);
+      // }
     };
     wsrtc.addEventListener('init', init);
   };


### PR DESCRIPTION
Right now, multiplayer is broken. This *mostly* fixes it.

Occasionally, remote players will have a velocity of 0. The position.hmd doesn't change from one frame to the next, probably because the Z store hasn't propagated in time. So the problem seems to be that the position.hmd from remote player and remote player avatar update are not syncing exactly on the same frames durations, so the remote player ends up updating more than once on the same hmd position on different timestamped frames.

The symptom is that the velocity is dependent on the network data updating consistently, and when these timings are mismatched the velocity drops to 0 and the animation blinks from run back to idle pose.

This PR looks at the velocity from last speed (as calculated by currentSpeed in avatars), then looks at the new velocity, and if they aren't congruent then a glitch is detected, the function returns and lets the animation from last frame play. Seems to work well enough for now, but there is definitely a more elegant way to do this.

One other note -- interpolation is still broken, and probably for the exact same reason. The HMD and character frames are not lining up, and it causes interpolation to wig tf out. So I switched to the Uninterpolated base class for the RemotePlayer, which should be fine for a few players demoing, but we'll need to solve the underlying cause.