### PR TITLE
disable hair spring bones for sprite rig

### DIFF
--- a/avatar-spriter.js
+++ b/avatar-spriter.js
@@ -1494,7 +1494,7 @@ class AvatarSpriteDepthMaterial extends THREE.MeshNormalMaterial {
 const _renderSpriteImages = skinnedVrm => {
   const localRig = new Avatar(skinnedVrm, {
     fingers: true,
-    hair: true,
+    hair: false,
     visemes: true,
     debug: false,
   });


### PR DESCRIPTION
this prevents the sprite hair from going up during rendering.  the hair doesn't animate, but seems like it hasn't been doing so in a while.  so animation will be addressed in another PR