### PR TITLE
Procgen expose alea

### DIFF
--- a/metaverse_modules/infinistreet/index.js
+++ b/metaverse_modules/infinistreet/index.js
@@ -4,7 +4,6 @@ const {MToonMaterial} = ThreeVrm;
 // window.ThreeVrm = ThreeVrm;
 // import easing from './easing.js';
 import {StreetGeometry} from './StreetGeometry.js';
-import alea from 'alea';
 import metaversefile from 'metaversefile';
 const {useApp, useFrame, useActivate, useLoaders, usePhysics, useProcGen, addTrackedApp, useDefaultModules, useCleanup} = metaversefile;
 
@@ -60,7 +59,7 @@ export default () => {
   const app = useApp();
   const physics = usePhysics();
   const procGen = useProcGen();
-  const {chunkWorldSize} = procGen;
+  const {alea, chunkWorldSize} = procGen;
 
   app.name = 'infinistreet';
 

--- a/procgen/procgen.js
+++ b/procgen/procgen.js
@@ -1,3 +1,4 @@
+import alea from './alea.js';
 import {
   makeRng,
   createMisc,
@@ -17,6 +18,7 @@ import {
 } from './map-render.js'
 
 export {
+  alea,
   makeRng,
   createMisc,
   numBlocksPerChunk,


### PR DESCRIPTION
`alea` is the a common seeded RNG we use. It is needed for street apps.

This exposes it in the `useProcGen` api, and switches street apps to use it from there.