### PR TITLE
2350 naruto run animation has scale transforms

### DIFF
--- a/animations-baker.js
+++ b/animations-baker.js
@@ -359,9 +359,10 @@ const {CharsetEncoder} = require('three/examples/js/libs/mmdparser.js');
         }
       }
       // remove scale transform tracks as they won't be used;
-      tracksToRemove.forEach(i => {
-        tracks.splice(i, 1);
-      });
+      let i = tracksToRemove.length;
+      while (i--) {
+        tracks.splice(tracksToRemove[i], 1);
+      }
 
       const walkBufferSize = 256;
       const leftFootYDeltas = new Float32Array(walkBufferSize);

--- a/animations-baker.js
+++ b/animations-baker.js
@@ -329,7 +329,7 @@ const {CharsetEncoder} = require('three/examples/js/libs/mmdparser.js');
       const rootBone = object; // not really a bone
       const leftFootBone = bones.find(b => b.name === 'mixamorigLeftFoot');
       const rightFootBone = bones.find(b => b.name === 'mixamorigRightFoot');
-      const allOnes = arr => arr[0] === 1 && arr.every(v => v === arr[0]);
+      const allOnes = arr => arr.every(v => v === 1);
 
       const bonePositionInterpolants = {};
       const boneQuaternionInterpolants = {};
@@ -348,9 +348,7 @@ const {CharsetEncoder} = require('three/examples/js/libs/mmdparser.js');
         } else if (/\.scale$/.test(track.name)) {
           if (allOnes(track.values)) {
             const index = tracks.indexOf(track);
-            if (index !== -1) {
               tracksToRemove.push(index);
-            }
           } else {
             throw new Error(`Error with the following track.  All scale transforms must be set to 1. Aborting.\n Animation: ${animation.name}, Track: ${track.name}, values: \n ${track.values}`);
           }

--- a/animations-baker.js
+++ b/animations-baker.js
@@ -348,9 +348,9 @@ const {CharsetEncoder} = require('three/examples/js/libs/mmdparser.js');
         } else if (/\.scale$/.test(track.name)) {
           if (allOnes(track.values)) {
             const index = tracks.indexOf(track);
-              tracksToRemove.push(index);
+            tracksToRemove.push(index);
           } else {
-            throw new Error(`Error with the following track.  All scale transforms must be set to 1. Aborting.\n Animation: ${animation.name}, Track: ${track.name}, values: \n ${track.values}`);
+            throw new Error(`This track has invalid values.  All scale transforms must be set to 1. Aborting.\n Animation: ${animation.name}, Track: ${track.name}, values: \n ${track.values}`);
           }
         } else {
           console.warn('unknown track name', animation.name, track);

--- a/animations-baker.js
+++ b/animations-baker.js
@@ -16,135 +16,134 @@ global.MMDLoader = MMDLoader;
 const {CharsetEncoder} = require('three/examples/js/libs/mmdparser.js');
 
 (async () => {
+  const nodeFetch = await import('node-fetch');
+  globalThis.fetch = nodeFetch.default;
+  const {Request, Response, Headers} = nodeFetch;
+  globalThis.Request = Request;
+  globalThis.Response = Response;
+  globalThis.Headers = Headers;
+  const {getHeight, animationBoneToModelBone, modelBoneToAnimationBone} = await import('./avatars/util.mjs');
+  const {zbencode, zbdecode} = await import('zjs/encoding.mjs');
 
-const nodeFetch = await import('node-fetch');
-globalThis.fetch = nodeFetch.default;
-const {Request, Response, Headers} = nodeFetch;
-globalThis.Request = Request;
-globalThis.Response = Response;
-globalThis.Headers = Headers;
-const {getHeight, animationBoneToModelBone, modelBoneToAnimationBone} = await import('./avatars/util.mjs');
-const {zbencode, zbdecode} = await import('zjs/encoding.mjs');
-
-const idleAnimationName = 'idle.fbx';
-const reversibleAnimationNames = [
-  `left strafe walking.fbx`,
-  `left strafe.fbx`,
-  `right strafe walking.fbx`,
-  `right strafe.fbx`,
-  `Sneaking Forward.fbx`,
-  `Crouched Sneaking Left.fbx`,
-  `Crouched Sneaking Right.fbx`,
-];
-const findFilesWithExtension = (baseDir, subDir, ext) => {
-  const files = [];
-  const dotExt = `.${ext}`;
-  const _recurse = p => {
-    const entries = fs.readdirSync(p);
-    for (const entry of entries) {
-      const fullPath = `${p}/${entry}`;
-      if (fs.statSync(fullPath).isDirectory()) {
-        _recurse(fullPath);
-      } else if (entry.endsWith(dotExt)) {
-        files.push(fullPath.slice(baseDir.length + 1));
+  const idleAnimationName = 'idle.fbx';
+  const reversibleAnimationNames = [
+    'left strafe walking.fbx',
+    'left strafe.fbx',
+    'right strafe walking.fbx',
+    'right strafe.fbx',
+    'Sneaking Forward.fbx',
+    'Crouched Sneaking Left.fbx',
+    'Crouched Sneaking Right.fbx',
+  ];
+  const findFilesWithExtension = (baseDir, subDir, ext) => {
+    const files = [];
+    const dotExt = `.${ext}`;
+    const _recurse = p => {
+      const entries = fs.readdirSync(p);
+      for (const entry of entries) {
+        const fullPath = `${p}/${entry}`;
+        if (fs.statSync(fullPath).isDirectory()) {
+          _recurse(fullPath);
+        } else if (entry.endsWith(dotExt)) {
+          files.push(fullPath.slice(baseDir.length + 1));
+        }
       }
-    }
-  }
-  _recurse(path.join(baseDir, subDir));
-  return files;
-};
-// let mmdAnimation = null;
-// const charsetEncoder = new CharsetEncoder();
-const _makeFakeBone = name => {
-  return {
+    };
+    _recurse(path.join(baseDir, subDir));
+    return files;
+  };
+  // let mmdAnimation = null;
+  // const charsetEncoder = new CharsetEncoder();
+  const _makeFakeBone = name => {
+    return {
     // name,
-    translation: [0, 0, 0],
-    quaternion: [0, 0, 0, 1],
+      translation: [0, 0, 0],
+      quaternion: [0, 0, 0, 1],
+    };
   };
-};
-const _parseVpd = o => {
-  const _getBone = name => {
-    return o.bones.find(b => b.name === name) ?? _makeFakeBone();
-  };
-  const mmdModelBones = {
+  const _parseVpd = o => {
+    const _getBone = name => {
+      return o.bones.find(b => b.name === name) ?? _makeFakeBone();
+    };
+    const mmdModelBones = {
     // Root: _getBone('センター'), // deliberately excluded
 
-    Hips: _getBone('下半身'),
-    Spine: _makeFakeBone(), // not present in mmd
-    Chest: _getBone('上半身'),
-    UpperChest: _makeFakeBone(), // not present in mmd
-    Neck: _getBone('首'),
-    Head: _getBone('頭'),
-    // Eye_L: _getBone('左目'), // deliberately excluded
-    // Eye_R: _getBone('右目'), // deliberately excluded
+      Hips: _getBone('下半身'),
+      Spine: _makeFakeBone(), // not present in mmd
+      Chest: _getBone('上半身'),
+      UpperChest: _makeFakeBone(), // not present in mmd
+      Neck: _getBone('首'),
+      Head: _getBone('頭'),
+      // Eye_L: _getBone('左目'), // deliberately excluded
+      // Eye_R: _getBone('右目'), // deliberately excluded
 
-    Left_shoulder: _getBone('左肩'),
-    Left_arm: _getBone('左腕'),
-    Left_elbow: _getBone('左ひじ'),
-    Left_wrist: _getBone('左手首'),
-    Left_thumb2: _getBone('左親指２'),
-    Left_thumb1: _getBone('左親指１'),
-    Left_thumb0: _makeFakeBone(), // not present in mmd
-    Left_indexFinger3: _getBone('左人指３'),
-    Left_indexFinger2: _getBone('左人指２'),
-    Left_indexFinger1: _getBone('左人指１'),
-    Left_middleFinger3: _getBone('左中指３'),
-    Left_middleFinger2: _getBone('左中指２'),
-    Left_middleFinger1: _getBone('左中指１'),
-    Left_ringFinger3: _getBone('左薬指３'),
-    Left_ringFinger2: _getBone('左薬指２'),
-    Left_ringFinger1: _getBone('左薬指１'),
-    Left_littleFinger3: _getBone('左小指３'),
-    Left_littleFinger2: _getBone('左小指２'),
-    Left_littleFinger1: _getBone('左小指１'),
-    Left_leg: _getBone('左足'),
-    Left_knee: _getBone('左ひざ'),
-    Left_ankle: _getBone('左足首'),
+      Left_shoulder: _getBone('左肩'),
+      Left_arm: _getBone('左腕'),
+      Left_elbow: _getBone('左ひじ'),
+      Left_wrist: _getBone('左手首'),
+      Left_thumb2: _getBone('左親指２'),
+      Left_thumb1: _getBone('左親指１'),
+      Left_thumb0: _makeFakeBone(), // not present in mmd
+      Left_indexFinger3: _getBone('左人指３'),
+      Left_indexFinger2: _getBone('左人指２'),
+      Left_indexFinger1: _getBone('左人指１'),
+      Left_middleFinger3: _getBone('左中指３'),
+      Left_middleFinger2: _getBone('左中指２'),
+      Left_middleFinger1: _getBone('左中指１'),
+      Left_ringFinger3: _getBone('左薬指３'),
+      Left_ringFinger2: _getBone('左薬指２'),
+      Left_ringFinger1: _getBone('左薬指１'),
+      Left_littleFinger3: _getBone('左小指３'),
+      Left_littleFinger2: _getBone('左小指２'),
+      Left_littleFinger1: _getBone('左小指１'),
+      Left_leg: _getBone('左足'),
+      Left_knee: _getBone('左ひざ'),
+      Left_ankle: _getBone('左足首'),
 
-    Right_shoulder: _getBone('右肩'),
-    Right_arm: _getBone('右腕'),
-    Right_elbow: _getBone('右ひじ'),
-    Right_wrist: _getBone('右手首'),
-    Right_thumb2: _getBone('右親指２'),
-    Right_thumb1: _getBone('右親指１'),
-    Right_thumb0: _makeFakeBone(), // not present in mmd
-    Right_indexFinger3: _getBone('右人指３'),
-    Right_indexFinger2: _getBone('右人指２'),
-    Right_indexFinger1: _getBone('右人指１'),
-    Right_middleFinger3: _getBone('右中指３'),
-    Right_middleFinger2: _getBone('右中指２'),
-    Right_middleFinger1: _getBone('右中指１'),
-    Right_ringFinger3: _getBone('右薬指３'),
-    Right_ringFinger2: _getBone('右薬指２'),
-    Right_ringFinger1: _getBone('右薬指１'),
-    Right_littleFinger3: _getBone('右小指３'),
-    Right_littleFinger2: _getBone('右小指２'),
-    Right_littleFinger1: _getBone('右小指１'),
-    Right_leg: _getBone('右足'),
-    Right_knee: _getBone('右ひざ'),
-    Right_ankle: _getBone('右足首'),
-    Left_toe: _getBone('左つま先'),
-    Right_toe: _getBone('右つま先'),
-  };
-  /* for (const k in mmdModelBones) {
+      Right_shoulder: _getBone('右肩'),
+      Right_arm: _getBone('右腕'),
+      Right_elbow: _getBone('右ひじ'),
+      Right_wrist: _getBone('右手首'),
+      Right_thumb2: _getBone('右親指２'),
+      Right_thumb1: _getBone('右親指１'),
+      Right_thumb0: _makeFakeBone(), // not present in mmd
+      Right_indexFinger3: _getBone('右人指３'),
+      Right_indexFinger2: _getBone('右人指２'),
+      Right_indexFinger1: _getBone('右人指１'),
+      Right_middleFinger3: _getBone('右中指３'),
+      Right_middleFinger2: _getBone('右中指２'),
+      Right_middleFinger1: _getBone('右中指１'),
+      Right_ringFinger3: _getBone('右薬指３'),
+      Right_ringFinger2: _getBone('右薬指２'),
+      Right_ringFinger1: _getBone('右薬指１'),
+      Right_littleFinger3: _getBone('右小指３'),
+      Right_littleFinger2: _getBone('右小指２'),
+      Right_littleFinger1: _getBone('右小指１'),
+      Right_leg: _getBone('右足'),
+      Right_knee: _getBone('右ひざ'),
+      Right_ankle: _getBone('右足首'),
+      Left_toe: _getBone('左つま先'),
+      Right_toe: _getBone('右つま先'),
+    };
+    /* for (const k in mmdModelBones) {
     if (!mmdModelBones[k]) {
       console.warn('no bone', k);
     }
   } */
 
-  const mmdAnimation = {};
-  for (const key in mmdModelBones) {
-    const key2 = modelBoneToAnimationBone[key];
-    /* if (key2 === undefined) {
+    const mmdAnimation = {};
+    for (const key in mmdModelBones) {
+      const key2 = modelBoneToAnimationBone[key];
+      /* if (key2 === undefined) {
       throw new Error('fail: ' + key);
     } */
-    mmdAnimation[key2] = mmdModelBones[key];
-  }
-  return mmdAnimation;
-};
+      mmdAnimation[key2] = mmdModelBones[key];
+    }
+    return mmdAnimation;
+  };
 
-const baker = async (uriPath = '', fbxFileNames, vpdFileNames, outFile) => {
-    let animations = [];
+  const baker = async (uriPath = '', fbxFileNames, vpdFileNames, outFile) => {
+    const animations = [];
 
     // mmd
     const mmdLoader = new MMDLoader();
@@ -152,9 +151,9 @@ const baker = async (uriPath = '', fbxFileNames, vpdFileNames, outFile) => {
     const mmdPoses = [];
     for (const name of vpdFileNames) {
       // console.log('try', name);
-      
+
       let o;
-      
+
       /* const content = fs.readFileSync('public/' + name);
       const text = charsetEncoder.s2u(content);
       // console.log('got text', text);
@@ -211,17 +210,17 @@ const baker = async (uriPath = '', fbxFileNames, vpdFileNames, outFile) => {
       };
       mmdAnimationsJson.push(mmdAnimation);
     }
-    
+
     // fbx
     const fbxLoader = new FBXLoader();
     const height = await (async () => {
       let o;
       const u = uriPath + 'animations/' + idleAnimationName;
       o = await new Promise((accept, reject) => {
-          fbxLoader.load(u, o => {
-            o.scene = o;
-            accept(o);
-          }, function progress() { }, reject);
+        fbxLoader.load(u, o => {
+          o.scene = o;
+          accept(o);
+        }, function progress() { }, reject);
       });
       // console.log('got height', height);
       // const animation = o.animations[0];
@@ -229,67 +228,67 @@ const baker = async (uriPath = '', fbxFileNames, vpdFileNames, outFile) => {
     })();
     // console.log('got height', height);
     for (const name of fbxFileNames) {
-        const u = uriPath + name;
-        console.log('processing', name);
-        let o;
-        o = await new Promise((accept, reject) => {
-            fbxLoader.load(u, o => {
-              o.scene = o;
-              accept(o);
-            }, function progress() { }, reject);
-        });
-        // console.log('got height', height);
-        const animation = o.animations[0];
-        animation.name = name.slice('animations/'.length);
-        animation.object = o;
-        
-        // scale position tracks by height
-        for (const track of animation.tracks) {
-          if (/\.position/.test(track.name)) {
-            const values2 = new track.values.constructor(track.values.length);
-            const valueSize = track.getValueSize();
-            const numValues = track.values.length / valueSize;
-            for (let i = 0; i < numValues; i++) {
-                const index = i;
-                for (let j = 0; j < valueSize; j++) {
-                  values2[index * valueSize + j] = track.values[index * valueSize + j] / height;
-                }
-            }
-            track.values = values2;
-          }
-        }
+      const u = uriPath + name;
+      console.log('processing', name);
+      let o;
+      o = await new Promise((accept, reject) => {
+        fbxLoader.load(u, o => {
+          o.scene = o;
+          accept(o);
+        }, function progress() { }, reject);
+      });
+      // console.log('got height', height);
+      const animation = o.animations[0];
+      animation.name = name.slice('animations/'.length);
+      animation.object = o;
 
-        animations.push(animation);
+      // scale position tracks by height
+      for (const track of animation.tracks) {
+        if (/\.position/.test(track.name)) {
+          const values2 = new track.values.constructor(track.values.length);
+          const valueSize = track.getValueSize();
+          const numValues = track.values.length / valueSize;
+          for (let i = 0; i < numValues; i++) {
+            const index = i;
+            for (let j = 0; j < valueSize; j++) {
+              values2[index * valueSize + j] = track.values[index * valueSize + j] / height;
+            }
+          }
+          track.values = values2;
+        }
+      }
+
+      animations.push(animation);
     }
     const _reverseAnimation = animation => {
-        animation = animation.clone();
-        for (const track of animation.tracks) {
-            const times2 = new track.times.constructor(track.times.length);
-            for (let i = 0; i < track.times.length; i++) {
-                times2[i] = animation.duration - track.times[track.times.length - 1 - i];
-            }
-            track.times = times2;
-
-            const values2 = new track.values.constructor(track.values.length);
-            const valueSize = track.getValueSize();
-            const numValues = track.values.length / valueSize;
-            for (let i = 0; i < numValues; i++) {
-                const aIndex = i;
-                const bIndex = numValues - 1 - i;
-                for (let j = 0; j < valueSize; j++) {
-                    values2[aIndex * valueSize + j] = track.values[bIndex * valueSize + j];
-                }
-            }
-            track.values = values2;
+      animation = animation.clone();
+      for (const track of animation.tracks) {
+        const times2 = new track.times.constructor(track.times.length);
+        for (let i = 0; i < track.times.length; i++) {
+          times2[i] = animation.duration - track.times[track.times.length - 1 - i];
         }
-        return animation;
+        track.times = times2;
+
+        const values2 = new track.values.constructor(track.values.length);
+        const valueSize = track.getValueSize();
+        const numValues = track.values.length / valueSize;
+        for (let i = 0; i < numValues; i++) {
+          const aIndex = i;
+          const bIndex = numValues - 1 - i;
+          for (let j = 0; j < valueSize; j++) {
+            values2[aIndex * valueSize + j] = track.values[bIndex * valueSize + j];
+          }
+        }
+        track.values = values2;
+      }
+      return animation;
     };
     for (const name of reversibleAnimationNames) {
-        const animation = animations.find(a => a.name === name);
-        const reverseAnimation = _reverseAnimation(animation);
-        reverseAnimation.name = animation.name.replace(/\.fbx$/, ' reverse.fbx');
-        reverseAnimation.object = animation.object;
-        animations.push(reverseAnimation);
+      const animation = animations.find(a => a.name === name);
+      const reverseAnimation = _reverseAnimation(animation);
+      reverseAnimation.name = animation.name.replace(/\.fbx$/, ' reverse.fbx');
+      reverseAnimation.object = animation.object;
+      animations.push(reverseAnimation);
     }
 
     const walkAnimationNames = [
@@ -363,7 +362,7 @@ const baker = async (uriPath = '', fbxFileNames, vpdFileNames, outFile) => {
       tracksToRemove.forEach(i => {
         tracks.splice(i, 1);
       });
-      
+
       const walkBufferSize = 256;
       const leftFootYDeltas = new Float32Array(walkBufferSize);
       const rightFootYDeltas = new Float32Array(walkBufferSize);
@@ -390,7 +389,7 @@ const baker = async (uriPath = '', fbxFileNames, vpdFileNames, outFile) => {
         const fbxScale = 100;
         const rootY = new THREE.Vector3().setFromMatrixPosition(rootBone.matrixWorld).divideScalar(fbxScale).y;
         const leftFootY = new THREE.Vector3().setFromMatrixPosition(leftFootBone.matrixWorld).divideScalar(fbxScale).y;
-        const rightFootY = new THREE.Vector3().setFromMatrixPosition(rightFootBone.matrixWorld).divideScalar(fbxScale).y
+        const rightFootY = new THREE.Vector3().setFromMatrixPosition(rightFootBone.matrixWorld).divideScalar(fbxScale).y;
 
         const leftFootYDelta = leftFootY - rootY;
         const rightFootYDelta = rightFootY - rootY;
@@ -417,7 +416,7 @@ const baker = async (uriPath = '', fbxFileNames, vpdFileNames, outFile) => {
         rightMax = Math.max(rightMax, rightFootYDelta);
       }
       const rightYLimit = rightMin + range * (rightMax - rightMin);
-      
+
       const leftStepIndices = new Uint8Array(walkBufferSize);
       const rightStepIndices = new Uint8Array(walkBufferSize);
       let numLeft = 0;
@@ -450,7 +449,7 @@ const baker = async (uriPath = '', fbxFileNames, vpdFileNames, outFile) => {
       );
       /* if (numLeft === 2) {
         for (let i = leftStepIndices.length - 1; i >= 0; i--) {
-          if (leftStepIndices[i]) { 
+          if (leftStepIndices[i]) {
             leftStepIndices[i] = 0;
             break;
           }
@@ -458,7 +457,7 @@ const baker = async (uriPath = '', fbxFileNames, vpdFileNames, outFile) => {
       }
       if (numRight === 2) {
         for (let i = rightStepIndices.length - 1; i >= 0; i--) {
-          if (rightStepIndices[i]) { 
+          if (rightStepIndices[i]) {
             rightStepIndices[i] = 0;
             break;
           }
@@ -553,9 +552,9 @@ const baker = async (uriPath = '', fbxFileNames, vpdFileNames, outFile) => {
     console.log('exporting animations');
     fs.writeFileSync(outFile, Buffer.from(animationsUint8Array));
     console.log('exported animations at', outFile);
-}
+  };
 
-(async () => {
+  (async () => {
     const app = express();
     /* app.all('*', (req, res, next) => {
       // console.log('got url 1', req.url);
@@ -564,16 +563,15 @@ const baker = async (uriPath = '', fbxFileNames, vpdFileNames, outFile) => {
       // console.log('got url 2', req.url);
       next();
     }); */
-    app.use(express.static('public'))
+    app.use(express.static('public'));
     app.listen(9999);
     const animationFileNames = fs.readdirSync('public/animations');
     const fbxFileNames = animationFileNames.filter(name => /\.fbx$/.test(name)).map(name => 'animations/' + name);
     const vpdFileNames = findFilesWithExtension('public', 'poses', 'vpd');
     const animationsResultFileName = 'public/animations/animations.z';
-    await baker('http://localhost:9999/', fbxFileNames, vpdFileNames, animationsResultFileName).catch((e) => {
-        console.warn('bake error', e);
-    })
+    await baker('http://localhost:9999/', fbxFileNames, vpdFileNames, animationsResultFileName).catch(e => {
+      console.warn('bake error', e);
+    });
     process.exit();
-})();
-
+  })();
 })();


### PR DESCRIPTION
This PR ensures that any animations with animation tracks applying scaling throw an error.  Animation tracks with scales all set to 1 are just removed.  Closes #2350.  Disable white space when reviewing.

as per https://github.com/webaverse/app/issues/2350#issuecomment-1074449065

> Failing that I'm ok with just adding to our code a loop that checks that if there is a scale, it must be all = 1, and then it can be thrown away (if that requirement is violated we should crash because there is currently no way we can render such an animation).