### PR TITLE
remove unneeded localPlayer updateds

### DIFF
--- a/players-manager.js
+++ b/players-manager.js
@@ -80,11 +80,13 @@ class PlayersManager {
       this.unbindStateFn = this.playersArray.unobserve.bind(this.playersArray, playersObserveFn);
     }
   }
-  update(timestamp, timeDiff) {
-    for (const remotePlayer of this.remotePlayers.values()) {
-      remotePlayer.updateAvatar(timestamp, timeDiff);
-    }
-  }
+  
+  // updates now handled by vrm template, will likely remove
+  // update(timestamp, timeDiff) {
+  //   for (const remotePlayer of this.remotePlayers.values()) {
+  //     remotePlayer.updateAvatar(timestamp, timeDiff);
+  //   }
+  // }
 }
 const playersManager = new PlayersManager();
 

--- a/webaverse.js
+++ b/webaverse.js
@@ -8,13 +8,11 @@ import Avatar from './avatars/avatars.js';
 import * as sounds from './sounds.js';
 import physx from './physx.js';
 import ioManager from './io-manager.js';
-import physicsManager from './physics-manager.js';
 import {world} from './world.js';
 import * as blockchain from './blockchain.js';
 import cameraManager from './camera-manager.js';
 import game from './game.js';
 import hpManager from './hp-manager.js';
-import {playersManager} from './players-manager.js';
 import minimapManager from './minimap.js';
 import postProcessing from './post-processing.js';
 import loadoutManager from './loadout-manager.js';
@@ -305,8 +303,6 @@ export default class Webaverse extends EventTarget {
 
           transformControls.update();
           game.update(timestamp, timeDiffCapped);
-
-          playersManager.update(timestamp, timeDiffCapped);
 
           world.appManager.tick(timestamp, timeDiffCapped, frame);
 

--- a/webaverse.js
+++ b/webaverse.js
@@ -302,19 +302,12 @@ export default class Webaverse extends EventTarget {
         const _pre = () => {
           ioManager.update(timeDiffCapped);
           // this.injectRigInput();
-          
-          const localPlayer = metaversefileApi.useLocalPlayer();
-          if (this.contentLoaded && physicsManager.getPhysicsEnabled()) {
-            physicsManager.simulatePhysics(timeDiffCapped);
-            localPlayer.updatePhysics(timestamp, timeDiffCapped);
-          }
 
           transformControls.update();
           game.update(timestamp, timeDiffCapped);
-          
-          localPlayer.updateAvatar(timestamp, timeDiffCapped);
+
           playersManager.update(timestamp, timeDiffCapped);
-          
+
           world.appManager.tick(timestamp, timeDiffCapped, frame);
 
           hpManager.update(timestamp, timeDiffCapped);


### PR DESCRIPTION
closes #2621 

this PR removes the update code which will not be needed once the vrm templates handle that via useFrame.  Currently requires https://github.com/webaverse/totum/pull/97 before it can be merged