### PR TITLE
2550 app detect users gpu settings to define default performance settings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@react-three/fiber": "^7.0.6",
         "@shaderfrog/glsl-parser": "^0.1.20",
         "classnames": "^2.3.1",
+        "detect-gpu": "^4.0.14",
         "dids": "^2.4.0",
         "encoding-japanese": "^1.0.30",
         "express": "^4.17.1",
@@ -4506,6 +4507,14 @@
     "node_modules/destroy": {
       "version": "1.0.4",
       "license": "MIT"
+    },
+    "node_modules/detect-gpu": {
+      "version": "4.0.14",
+      "resolved": "https://registry.npmjs.org/detect-gpu/-/detect-gpu-4.0.14.tgz",
+      "integrity": "sha512-4F3p9NHoP7zAQXI0tzl1BwMaufgJ62DqE8QUuiX6Oo2c732tGnHqLdmjl8klT50x+6M4lSJxKt/mQvGhDf4k8A==",
+      "dependencies": {
+        "webgl-constants": "^1.1.1"
+      }
     },
     "node_modules/did-jwt": {
       "version": "5.8.0",
@@ -12593,6 +12602,11 @@
         "node": ">= 8"
       }
     },
+    "node_modules/webgl-constants": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/webgl-constants/-/webgl-constants-1.1.1.tgz",
+      "integrity": "sha512-LkBXKjU5r9vAW7Gcu3T5u+5cvSvh5WwINdr0C+9jpzVB41cjQAP5ePArDtk/WHYdVj0GefCgM73BA7FlIiNtdg=="
+    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "license": "BSD-2-Clause"
@@ -15984,6 +15998,14 @@
     },
     "destroy": {
       "version": "1.0.4"
+    },
+    "detect-gpu": {
+      "version": "4.0.14",
+      "resolved": "https://registry.npmjs.org/detect-gpu/-/detect-gpu-4.0.14.tgz",
+      "integrity": "sha512-4F3p9NHoP7zAQXI0tzl1BwMaufgJ62DqE8QUuiX6Oo2c732tGnHqLdmjl8klT50x+6M4lSJxKt/mQvGhDf4k8A==",
+      "requires": {
+        "webgl-constants": "^1.1.1"
+      }
     },
     "did-jwt": {
       "version": "5.8.0",
@@ -21385,6 +21407,11 @@
     },
     "web-streams-polyfill": {
       "version": "3.2.0"
+    },
+    "webgl-constants": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/webgl-constants/-/webgl-constants-1.1.1.tgz",
+      "integrity": "sha512-LkBXKjU5r9vAW7Gcu3T5u+5cvSvh5WwINdr0C+9jpzVB41cjQAP5ePArDtk/WHYdVj0GefCgM73BA7FlIiNtdg=="
     },
     "webidl-conversions": {
       "version": "3.0.1"

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@react-three/fiber": "^7.0.6",
     "@shaderfrog/glsl-parser": "^0.1.20",
     "classnames": "^2.3.1",
+    "detect-gpu": "^4.0.14",
     "dids": "^2.4.0",
     "encoding-japanese": "^1.0.30",
     "express": "^4.17.1",

--- a/src/components/general/settings/TabGraphics.jsx
+++ b/src/components/general/settings/TabGraphics.jsx
@@ -9,8 +9,7 @@ import { Switch } from './switch';
 
 import styles from './settings.module.css';
 
-//
-
+// defaults get modified depending on the users detected GPU tier
 const DefaultSettings = {
     resolution:         'HIGH',
     antialias:          'NONE',
@@ -85,7 +84,20 @@ export const TabGraphics = ({ active }) => {
     async function setDefault() {
       const gpuTier = await getGPUTier();
       console.log('GPU INFO', gpuTier);
-      DefaultSettings.character.details = Object.keys(detailsMap).find(key => detailsMap[key] === gpuTier.tier);
+      const defaultDetail = Object.keys(detailsMap).find(key => detailsMap[key] === gpuTier.tier);
+      const defaultEnabled = detailsMap[defaultDetail] > 2 ? 'ON' : 'Off';
+
+      DefaultSettings.resolution = defaultDetail;
+      DefaultSettings.antialias = defaultDetail;
+      DefaultSettings.viewRange = defaultDetail;
+      DefaultSettings.shadowQuality = defaultDetail;
+      DefaultSettings.postprocessing.enabled = defaultEnabled;
+      DefaultSettings.postprocessing.depthOfField = defaultEnabled;
+      DefaultSettings.postprocessing.hdr = defaultEnabled;
+      DefaultSettings.postprocessing.bloom = defaultEnabled;
+      DefaultSettings.character.details = defaultDetail;
+      DefaultSettings.character.hairPhysics = defaultEnabled;
+
       console.log('set default character details to', DefaultSettings.character.details);
     }
     (async () => { await setDefault(); })();

--- a/src/components/general/settings/TabGraphics.jsx
+++ b/src/components/general/settings/TabGraphics.jsx
@@ -80,7 +80,7 @@ export const TabGraphics = ({active}) => {
     async function setDefault() {
       const gpuTier = await getGPUTier();
       console.log('GPU INFO', gpuTier);
-      const defaultDetail = Object.keys(detailsMap).find(key => detailsMap[key] === gpuTier.tier);
+      const defaultDetail = Object.keys(detailsMap).find(key => detailsMap[key] === gpuTier.tier + 1);
       const defaultEnabled = detailsMap[defaultDetail] > 2 ? 'ON' : 'Off';
 
       DefaultSettings.resolution = defaultDetail;

--- a/src/components/general/settings/TabGraphics.jsx
+++ b/src/components/general/settings/TabGraphics.jsx
@@ -1,5 +1,6 @@
 
 import React, { useEffect, useState } from 'react';
+import { getGPUTier } from 'detect-gpu';
 import classNames from 'classnames';
 
 import game from '../../../../game.js';
@@ -46,6 +47,13 @@ export const TabGraphics = ({ active }) => {
 
     //
 
+    const detailsMap = {
+        ULTRA: 4,
+        HIGH: 3,
+        MEDIUM: 2,
+        LOW: 1,
+    };
+
     function saveSettings () {
 
         const settings = {
@@ -74,12 +82,21 @@ export const TabGraphics = ({ active }) => {
         const settingsString = localStorage.getItem( 'GfxSettings' );
         let settings;
 
+    async function setDefault() {
+      const gpuTier = await getGPUTier();
+      console.log('GPU INFO', gpuTier);
+      DefaultSettings.character.details = Object.keys(detailsMap).find(key => detailsMap[key] === gpuTier.tier);
+      console.log('set default character details to', DefaultSettings.character.details);
+    }
+    (async () => { await setDefault(); })();
+        
+
         try {
 
             settings = JSON.parse( settingsString );
-
+            
         } catch ( err ) {
-
+            
             settings = DefaultSettings;
 
         }
@@ -103,10 +120,7 @@ export const TabGraphics = ({ active }) => {
 
         // set avatar style
 
-        let avatarStyle = 4;
-        if ( characterDetails === 'HIGH' ) avatarStyle = 3;
-        if ( characterDetails === 'MEDIUM' ) avatarStyle = 2;
-        if ( characterDetails === 'LOW' ) avatarStyle = 1;
+        const avatarStyle = detailsMap[characterDetails];
 
         const localPlayer = metaversefileApi.useLocalPlayer();
 

--- a/src/components/general/settings/TabGraphics.jsx
+++ b/src/components/general/settings/TabGraphics.jsx
@@ -1,85 +1,81 @@
 
-import React, { useEffect, useState } from 'react';
-import { getGPUTier } from 'detect-gpu';
+import React, {useEffect, useState} from 'react';
+import {getGPUTier} from 'detect-gpu';
 import classNames from 'classnames';
 
 import game from '../../../../game.js';
-import metaversefileApi from '../../../../metaversefile-api'
-import { Switch } from './switch';
+import metaversefileApi from '../../../../metaversefile-api';
+import {Switch} from './switch';
 
 import styles from './settings.module.css';
 
 // defaults get modified depending on the users detected GPU tier
 const DefaultSettings = {
-    resolution:         'HIGH',
-    antialias:          'NONE',
-    viewRange:          'HIGH',
-    shadowQuality:      'HIGH',
-    postprocessing: {
-        enabled:        'ON',
-        depthOfField:   'ON',
-        hdr:            'ON',
-        bloom:          'ON'
-    },
-    character: {
-        details:        'HIGH',
-        hairPhysics:    'ON'
-    }
+  resolution: 'HIGH',
+  antialias: 'NONE',
+  viewRange: 'HIGH',
+  shadowQuality: 'HIGH',
+  postprocessing: {
+    enabled: 'ON',
+    depthOfField: 'ON',
+    hdr: 'ON',
+    bloom: 'ON',
+  },
+  character: {
+    details: 'HIGH',
+    hairPhysics: 'ON',
+  },
 };
 
-export const TabGraphics = ({ active }) => {
+export const TabGraphics = ({active}) => {
+  const [appyingChanges, setAppyingChanges] = useState(false);
+  const [changesNotSaved, setChangesNotSaved] = useState(false);
+  const [settingsLoaded, setSettingsLoaded] = useState(false);
 
-    const [ appyingChanges, setAppyingChanges ] = useState( false );
-    const [ changesNotSaved, setChangesNotSaved ] = useState( false );
-    const [ settingsLoaded, setSettingsLoaded ] = useState( false );
+  const [resolution, setResolution] = useState(null);
+  const [antialias, setAntialias] = useState(null);
+  const [viewRange, setViewRange] = useState(null);
+  const [shadowQuality, setShadowQuality] = useState(null);
+  const [postprocessing, setPostprocessing] = useState(null);
+  const [depthOfField, setDepthOfField] = useState(null);
+  const [hdr, setHdr] = useState(null);
+  const [bloom, setBloom] = useState(null);
+  const [characterDetails, setCharacterDetails] = useState(null);
+  const [hairPhysics, setHairPhysics] = useState(null);
 
-    const [ resolution, setResolution ] = useState( null );
-    const [ antialias, setAntialias ] = useState( null );
-    const [ viewRange, setViewRange ] = useState( null );
-    const [ shadowQuality, setShadowQuality ] = useState( null );
-    const [ postprocessing, setPostprocessing ] = useState( null );
-    const [ depthOfField, setDepthOfField ] = useState( null );
-    const [ hdr, setHdr ] = useState( null );
-    const [ bloom, setBloom ] = useState( null );
-    const [ characterDetails, setCharacterDetails ] = useState( null );
-    const [ hairPhysics, setHairPhysics ] = useState( null );
+  //
 
-    //
+  const detailsMap = {
+    ULTRA: 4,
+    HIGH: 3,
+    MEDIUM: 2,
+    LOW: 1,
+  };
 
-    const detailsMap = {
-        ULTRA: 4,
-        HIGH: 3,
-        MEDIUM: 2,
-        LOW: 1,
+  function saveSettings() {
+    const settings = {
+      resolution: resolution,
+      antialias: antialias,
+      viewRange: viewRange,
+      shadowQuality: shadowQuality,
+      postprocessing: {
+        enabled: postprocessing,
+        depthOfField: depthOfField,
+        hdr: hdr,
+        bloom: bloom,
+      },
+      character: {
+        details: characterDetails,
+        hairPhysics: hairPhysics,
+      },
     };
 
-    function saveSettings () {
+    localStorage.setItem('GfxSettings', JSON.stringify(settings));
+  }
 
-        const settings = {
-            resolution:         resolution,
-            antialias:          antialias,
-            viewRange:          viewRange,
-            shadowQuality:      shadowQuality,
-            postprocessing: {
-                enabled:        postprocessing,
-                depthOfField:   depthOfField,
-                hdr:            hdr,
-                bloom:          bloom
-            },
-            character: {
-                details:        characterDetails,
-                hairPhysics:    hairPhysics
-            }
-        };
-
-        localStorage.setItem( 'GfxSettings', JSON.stringify( settings ) );
-
-    };
-
-    function loadSettings () {
-
-        const settingsString = localStorage.getItem( 'GfxSettings' );
-        let settings;
+  function loadSettings() {
+    const settingsString = localStorage.getItem('GfxSettings');
+    let settings;
 
     async function setDefault() {
       const gpuTier = await getGPUTier();
@@ -101,168 +97,141 @@ export const TabGraphics = ({ active }) => {
       console.log('set default character details to', DefaultSettings.character.details);
     }
     (async () => { await setDefault(); })();
-        
 
-        try {
+    try {
+      settings = JSON.parse(settingsString);
+    } catch (err) {
+      settings = DefaultSettings;
+    }
 
-            settings = JSON.parse( settingsString );
-            
-        } catch ( err ) {
-            
-            settings = DefaultSettings;
+    settings = settings ?? DefaultSettings;
 
-        }
+    setResolution(settings.resolution ?? DefaultSettings.resolution);
+    setAntialias(settings.antialias ?? DefaultSettings.antialias);
+    setViewRange(settings.viewRange ?? DefaultSettings.viewRange);
+    setShadowQuality(settings.shadowQuality ?? DefaultSettings.shadowQuality);
+    setPostprocessing(settings.postprocessing.enabled ?? DefaultSettings.postprocessing.enabled);
+    setDepthOfField(settings.postprocessing.depthOfField ?? DefaultSettings.postprocessing.depthOfField);
+    setHdr(settings.postprocessing.hdr ?? DefaultSettings.postprocessing.hdr);
+    setBloom(settings.postprocessing.bloom ?? DefaultSettings.postprocessing.bloom);
+    setCharacterDetails(settings.character.details ?? DefaultSettings.character.details);
+    setHairPhysics(settings.character.hairPhysics ?? DefaultSettings.character.hairPhysics);
+  }
 
-        settings = settings ?? DefaultSettings;
+  function applySettings() {
+    // set avatar style
 
-        setResolution( settings.resolution ?? DefaultSettings.resolution );
-        setAntialias( settings.antialias ?? DefaultSettings.antialias );
-        setViewRange( settings.viewRange ?? DefaultSettings.viewRange );
-        setShadowQuality( settings.shadowQuality ?? DefaultSettings.shadowQuality );
-        setPostprocessing( settings.postprocessing.enabled ?? DefaultSettings.postprocessing.enabled );
-        setDepthOfField( settings.postprocessing.depthOfField ?? DefaultSettings.postprocessing.depthOfField );
-        setHdr( settings.postprocessing.hdr ?? DefaultSettings.postprocessing.hdr );
-        setBloom( settings.postprocessing.bloom ?? DefaultSettings.postprocessing.bloom );
-        setCharacterDetails( settings.character.details ?? DefaultSettings.character.details );
-        setHairPhysics( settings.character.hairPhysics ?? DefaultSettings.character.hairPhysics );
+    const avatarStyle = detailsMap[characterDetails];
 
-    };
+    const localPlayer = metaversefileApi.useLocalPlayer();
 
-    function applySettings () {
+    function setAvatarQuality() {
+      game.setAvatarQuality(avatarStyle);
+      localPlayer.removeEventListener('avatarchange', setAvatarQuality);
+    }
 
-        // set avatar style
-
-        const avatarStyle = detailsMap[characterDetails];
-
-        const localPlayer = metaversefileApi.useLocalPlayer();
-
-        function setAvatarQuality () {
-
-            game.setAvatarQuality( avatarStyle );
-            localPlayer.removeEventListener( 'avatarchange', setAvatarQuality );
-
-        };
-
-        if ( ! localPlayer.avatar ) {
-
-            localPlayer.addEventListener( 'avatarchange', setAvatarQuality );
-
-        } else {
-
-            setAvatarQuality();
-
-        }
-
-        //
-
-        saveSettings();
-        setChangesNotSaved( false );
-        setTimeout( () => { setAppyingChanges( false ) }, 1000 );
-
-    };
-
-    function handleApplySettingsBtnClick () {
-
-        setAppyingChanges( true );
-        setTimeout( applySettings, 100 );
-
-    };
+    if (!localPlayer.avatar) {
+      localPlayer.addEventListener('avatarchange', setAvatarQuality);
+    } else {
+      setAvatarQuality();
+    }
 
     //
 
-    useEffect( () => {
+    saveSettings();
+    setChangesNotSaved(false);
+    setTimeout(() => { setAppyingChanges(false); }, 1000);
+  }
 
-        if ( resolution && antialias && viewRange && shadowQuality && postprocessing && depthOfField && hdr && bloom && characterDetails && hairPhysics ) {
+  function handleApplySettingsBtnClick() {
+    setAppyingChanges(true);
+    setTimeout(applySettings, 100);
+  }
 
-            if ( settingsLoaded ) {
+  //
 
-                setChangesNotSaved( true );
+  useEffect(() => {
+    if (resolution && antialias && viewRange && shadowQuality && postprocessing && depthOfField && hdr && bloom && characterDetails && hairPhysics) {
+      if (settingsLoaded) {
+        setChangesNotSaved(true);
+      } else {
+        setSettingsLoaded(true);
+        applySettings();
+      }
+    }
+  }, [resolution, antialias, viewRange, shadowQuality, postprocessing, depthOfField, hdr, bloom, characterDetails, hairPhysics]);
 
-            } else {
+  useEffect(() => {
+    loadSettings();
+  }, []);
 
-                setSettingsLoaded( true );
-                applySettings();
+  //
 
-            }
+  return (
+    <div className={ classNames(styles.tabContent, active ? styles.active : null) }>
+      <div className={ styles.blockTitle }>Display</div>
+      <div className={ styles.row }>
+        <div className={ styles.paramName }>Resolution</div>
+        <Switch className={ styles.switch } value={ resolution } setValue={ setResolution } values={ ['LOW', 'MEDIUM', 'HIGH'] } />
+        <div className={ styles.clearfix } />
+      </div>
+      <div className={ styles.row }>
+        <div className={ styles.paramName }>Antialias</div>
+        <Switch className={ styles.switch } value={ antialias } setValue={ setAntialias } values={ ['MSAA', 'FXAA', 'NONE'] } />
+        <div className={ styles.clearfix } />
+      </div>
+      <div className={ styles.row }>
+        <div className={ styles.paramName }>View range</div>
+        <Switch className={ styles.switch } value={ viewRange } setValue={ setViewRange } values={ ['LOW', 'MEDIUM', 'HIGH'] } />
+        <div className={ styles.clearfix } />
+      </div>
+      <div className={ styles.row }>
+        <div className={ styles.paramName }>Shadows quality</div>
+        <Switch className={ styles.switch } value={ shadowQuality } setValue={ setShadowQuality } values={ ['OFF', 'LOW', 'MEDIUM', 'HIGH'] } />
+        <div className={ styles.clearfix } />
+      </div>
+      <div className={ styles.row }>
+        <div className={ styles.blockTitle }>Postprocessing</div>
+        <div className={ styles.clearfix } />
+      </div>
+      <div className={ styles.row }>
+        <div className={ styles.paramName }>Enabled</div>
+        <Switch className={ styles.switch } value={ postprocessing } setValue={ setPostprocessing } values={ ['OFF', 'ON'] } />
+        <div className={ styles.clearfix } />
+      </div>
+      <div className={ styles.row }>
+        <div className={ styles.paramName }>Depth of field</div>
+        <Switch className={ styles.switch } value={ depthOfField } setValue={ setDepthOfField } values={ ['OFF', 'ON'] } />
+        <div className={ styles.clearfix } />
+      </div>
+      <div className={ styles.row }>
+        <div className={ styles.paramName }>HDR</div>
+        <Switch className={ styles.switch } value={ hdr } setValue={ setHdr } values={ ['OFF', 'ON'] } />
+        <div className={ styles.clearfix } />
+      </div>
+      <div className={ styles.row }>
+        <div className={ styles.paramName }>Bloom</div>
+        <Switch className={ styles.switch } value={ bloom } setValue={ setBloom } values={ ['OFF', 'ON'] } />
+        <div className={ styles.clearfix } />
+      </div>
+      <div className={ styles.row }>
+        <div className={ styles.blockTitle }>Character</div>
+        <div className={ styles.clearfix } />
+      </div>
+      <div className={ styles.row }>
+        <div className={ styles.paramName }>Character details</div>
+        <Switch className={ styles.switch } value={ characterDetails } setValue={ setCharacterDetails } values={ ['LOW', 'MEDIUM', 'HIGH', 'ULTRA'] } />
+        <div className={ styles.clearfix } />
+      </div>
+      <div className={ styles.row }>
+        <div className={ styles.paramName }>Hair physics</div>
+        <Switch className={ styles.switch } value={ hairPhysics } setValue={ setHairPhysics } values={ ['OFF', 'ON'] } />
+        <div className={ styles.clearfix } />
+      </div>
 
-        }
-
-    }, [ resolution, antialias, viewRange, shadowQuality, postprocessing, depthOfField, hdr, bloom, characterDetails, hairPhysics ] );
-
-    useEffect( () => {
-
-        loadSettings();
-
-    }, [] );
-
-    //
-
-    return (
-        <div className={ classNames( styles.tabContent, active ? styles.active : null ) }>
-            <div className={ styles.blockTitle }>Display</div>
-            <div className={ styles.row }>
-                <div className={ styles.paramName }>Resolution</div>
-                <Switch className={ styles.switch } value={ resolution } setValue={ setResolution } values={ [ 'LOW', 'MEDIUM', 'HIGH' ] } />
-                <div className={ styles.clearfix } />
-            </div>
-            <div className={ styles.row }>
-                <div className={ styles.paramName }>Antialias</div>
-                <Switch className={ styles.switch } value={ antialias } setValue={ setAntialias } values={ [ 'MSAA', 'FXAA', 'NONE' ] } />
-                <div className={ styles.clearfix } />
-            </div>
-            <div className={ styles.row }>
-                <div className={ styles.paramName }>View range</div>
-                <Switch className={ styles.switch } value={ viewRange } setValue={ setViewRange } values={ [ 'LOW', 'MEDIUM', 'HIGH' ] } />
-                <div className={ styles.clearfix } />
-            </div>
-            <div className={ styles.row }>
-                <div className={ styles.paramName }>Shadows quality</div>
-                <Switch className={ styles.switch } value={ shadowQuality } setValue={ setShadowQuality } values={ [ 'OFF', 'LOW', 'MEDIUM', 'HIGH' ] } />
-                <div className={ styles.clearfix } />
-            </div>
-            <div className={ styles.row }>
-                <div className={ styles.blockTitle }>Postprocessing</div>
-                <div className={ styles.clearfix } />
-            </div>
-            <div className={ styles.row }>
-                <div className={ styles.paramName }>Enabled</div>
-                <Switch className={ styles.switch } value={ postprocessing } setValue={ setPostprocessing } values={ [ 'OFF', 'ON' ] } />
-                <div className={ styles.clearfix } />
-            </div>
-            <div className={ styles.row }>
-                <div className={ styles.paramName }>Depth of field</div>
-                <Switch className={ styles.switch } value={ depthOfField } setValue={ setDepthOfField } values={ [ 'OFF', 'ON' ] } />
-                <div className={ styles.clearfix } />
-            </div>
-            <div className={ styles.row }>
-                <div className={ styles.paramName }>HDR</div>
-                <Switch className={ styles.switch } value={ hdr } setValue={ setHdr } values={ [ 'OFF', 'ON' ] } />
-                <div className={ styles.clearfix } />
-            </div>
-            <div className={ styles.row }>
-                <div className={ styles.paramName }>Bloom</div>
-                <Switch className={ styles.switch } value={ bloom } setValue={ setBloom } values={ [ 'OFF', 'ON' ] } />
-                <div className={ styles.clearfix } />
-            </div>
-            <div className={ styles.row }>
-                <div className={ styles.blockTitle }>Character</div>
-                <div className={ styles.clearfix } />
-            </div>
-            <div className={ styles.row }>
-                <div className={ styles.paramName }>Character details</div>
-                <Switch className={ styles.switch } value={ characterDetails } setValue={ setCharacterDetails } values={ [ 'LOW', 'MEDIUM', 'HIGH', 'ULTRA' ] } />
-                <div className={ styles.clearfix } />
-            </div>
-            <div className={ styles.row }>
-                <div className={ styles.paramName }>Hair physics</div>
-                <Switch className={ styles.switch } value={ hairPhysics } setValue={ setHairPhysics } values={ [ 'OFF', 'ON' ] } />
-                <div className={ styles.clearfix } />
-            </div>
-
-            <div className={ classNames( styles.applyBtn, changesNotSaved ? styles.active : null ) } onClick={ handleApplySettingsBtnClick } >
-                { appyingChanges ? 'APPLYING' : 'APPLY' }
-            </div>
-        </div>
-    );
-
+      <div className={ classNames(styles.applyBtn, changesNotSaved ? styles.active : null) } onClick={ handleApplySettingsBtnClick } >
+        { appyingChanges ? 'APPLYING' : 'APPLY' }
+      </div>
+    </div>
+  );
 };


### PR DESCRIPTION
this PR closes #2550.  I've set up defaults for all GFX settings, not just the character details.  All GFX settings that go from `LOW` to `ULTRA` will be set to match the output from detect-gpu.  Settings that can be `ON` or `OFF` will be `ON` if detected gpu tier is above 1, which is `HIGH` or `ULTRA`, and `OFF` if lower than that.

If we want any of these GFX defaults to stay fixed, or we want to change the tiers which they are enabled, the adjustment can be done very quickly.

Due to eslinting, I would again suggest turning off white space when reviewing.