### PR TITLE
Per module hash performance tracking

### DIFF
--- a/metaversefile-api.js
+++ b/metaversefile-api.js
@@ -437,7 +437,7 @@ metaversefile.setApi({
     if (app) {
       const frame = e => {
         if (!app.paused) {
-          performanceTracker.startCpuObject(`app-${app.modulesHash}`);
+          performanceTracker.startCpuObject(app.modulesHash, app.name);
           fn(e.data);
           performanceTracker.endCpuObject();
         }

--- a/performance-tracker.js
+++ b/performance-tracker.js
@@ -197,7 +197,7 @@ class PerformanceTracker extends EventTarget {
         object.time += gl.getQueryParameter(query, gl.QUERY_RESULT);
         
         // cleanup
-        // gl.deleteQuery(query);
+        gl.deleteQuery(query);
       }
 
       // cleanup

--- a/performance-tracker.js
+++ b/performance-tracker.js
@@ -35,8 +35,12 @@ class PerformanceTracker extends EventTarget {
       this.enabled = e.data.enabled;
     });
   }
-  startCpuObject(id, name = id) {
+  startCpuObject(id, name) {
     if (!this.enabled) return;
+
+    if (name === undefined) {
+      name = id;
+    }
     
     if (this.prefix) {
       name = [this.prefix, name].join('/');

--- a/performance-tracker.js
+++ b/performance-tracker.js
@@ -35,14 +35,14 @@ class PerformanceTracker extends EventTarget {
       this.enabled = e.data.enabled;
     });
   }
-  startCpuObject(name) {
+  startCpuObject(id, name = id) {
     if (!this.enabled) return;
     
     if (this.prefix) {
       name = [this.prefix, name].join('/');
     }
 
-    if (this.currentCpuObject?.name !== name) {
+    if (this.currentCpuObject?.id !== id) {
       if (this.currentCpuObject) {
         this.endCpuObject();
       }
@@ -51,6 +51,7 @@ class PerformanceTracker extends EventTarget {
       if (!currentCpuObject) {
         const now = performance.now();
         currentCpuObject = {
+          id,
           name,
           startTime: now,
           endTime: now,
@@ -66,14 +67,14 @@ class PerformanceTracker extends EventTarget {
     this.currentCpuObject.endTime = performance.now();
     this.currentCpuObject = null;
   }
-  startGpuObject(name) {
+  startGpuObject(id, name = id) {
     if (!this.enabled) return;
     
     if (this.prefix) {
       name = [this.prefix, name].join('/');
     }
 
-    if (this.currentGpuObject?.name !== name) {
+    if (this.currentGpuObject?.id !== id) {
       const gl = getGl();
       const ext = getExt();
 
@@ -87,6 +88,7 @@ class PerformanceTracker extends EventTarget {
       let currentGpuObject = this.gpuResults.get(name);
       if (!currentGpuObject) {
         currentGpuObject = {
+          id,
           name,
           time: 0,
         };
@@ -128,7 +130,7 @@ class PerformanceTracker extends EventTarget {
     const self = this;
     const _makeOnBeforeRender = fn => {
       const resultFn = function() {
-        self.startGpuObject(`app-${app.modulesHash}`);
+        self.startGpuObject(app.modulesHash, app.name);
         fn && fn.apply(this, arguments);
       };
       resultFn[performanceTrackerFnSymbol] = true;

--- a/performance-tracker.js
+++ b/performance-tracker.js
@@ -146,7 +146,7 @@ class PerformanceTracker extends EventTarget {
     };
     const _makeOnAfterRender = fn => {
       const resultFn = function() {
-        if (self.currentGpuObject?.name === name) {
+        if (self.currentGpuObject?.id === app.modulesHash) {
           self.endGpuObject();
         }
         fn && fn.apply(this, arguments);

--- a/performance-tracker.js
+++ b/performance-tracker.js
@@ -128,7 +128,7 @@ class PerformanceTracker extends EventTarget {
     const self = this;
     const _makeOnBeforeRender = fn => {
       const resultFn = function() {
-        self.startGpuObject(app.name);
+        self.startGpuObject(`app-${app.modulesHash}`);
         fn && fn.apply(this, arguments);
       };
       resultFn[performanceTrackerFnSymbol] = true;

--- a/performance-tracker.js
+++ b/performance-tracker.js
@@ -71,8 +71,12 @@ class PerformanceTracker extends EventTarget {
     this.currentCpuObject.endTime = performance.now();
     this.currentCpuObject = null;
   }
-  startGpuObject(id, name = id) {
+  startGpuObject(id, name) {
     if (!this.enabled) return;
+
+    if (name === undefined) {
+      name = id;
+    }
     
     if (this.prefix) {
       name = [this.prefix, name].join('/');

--- a/procgen/murmurhash3.js
+++ b/procgen/murmurhash3.js
@@ -1,0 +1,64 @@
+/**
+ * JS Implementation of MurmurHash3 (r136) (as of May 20, 2011)
+ * 
+ * @author <a href="mailto:gary.court@gmail.com">Gary Court</a>
+ * @see http://github.com/garycourt/murmurhash-js
+ * @author <a href="mailto:aappleby@gmail.com">Austin Appleby</a>
+ * @see http://sites.google.com/site/murmurhash/
+ * 
+ * @param {string} key ASCII only
+ * @param {number} seed Positive integer only
+ * @return {number} 32-bit positive integer hash 
+ */
+
+export function murmurhash3(key, seed) {
+	var remainder, bytes, h1, h1b, c1, c1b, c2, c2b, k1, i;
+	
+	remainder = key.length & 3; // key.length % 4
+	bytes = key.length - remainder;
+	h1 = seed;
+	c1 = 0xcc9e2d51;
+	c2 = 0x1b873593;
+	i = 0;
+	
+	while (i < bytes) {
+	  	k1 = 
+	  	  ((key.charCodeAt(i) & 0xff)) |
+	  	  ((key.charCodeAt(++i) & 0xff) << 8) |
+	  	  ((key.charCodeAt(++i) & 0xff) << 16) |
+	  	  ((key.charCodeAt(++i) & 0xff) << 24);
+		++i;
+		
+		k1 = ((((k1 & 0xffff) * c1) + ((((k1 >>> 16) * c1) & 0xffff) << 16))) & 0xffffffff;
+		k1 = (k1 << 15) | (k1 >>> 17);
+		k1 = ((((k1 & 0xffff) * c2) + ((((k1 >>> 16) * c2) & 0xffff) << 16))) & 0xffffffff;
+
+		h1 ^= k1;
+        h1 = (h1 << 13) | (h1 >>> 19);
+		h1b = ((((h1 & 0xffff) * 5) + ((((h1 >>> 16) * 5) & 0xffff) << 16))) & 0xffffffff;
+		h1 = (((h1b & 0xffff) + 0x6b64) + ((((h1b >>> 16) + 0xe654) & 0xffff) << 16));
+	}
+	
+	k1 = 0;
+	
+	switch (remainder) {
+		case 3: k1 ^= (key.charCodeAt(i + 2) & 0xff) << 16;
+		case 2: k1 ^= (key.charCodeAt(i + 1) & 0xff) << 8;
+		case 1: k1 ^= (key.charCodeAt(i) & 0xff);
+		
+		k1 = (((k1 & 0xffff) * c1) + ((((k1 >>> 16) * c1) & 0xffff) << 16)) & 0xffffffff;
+		k1 = (k1 << 15) | (k1 >>> 17);
+		k1 = (((k1 & 0xffff) * c2) + ((((k1 >>> 16) * c2) & 0xffff) << 16)) & 0xffffffff;
+		h1 ^= k1;
+	}
+	
+	h1 ^= key.length;
+
+	h1 ^= h1 >>> 16;
+	h1 = (((h1 & 0xffff) * 0x85ebca6b) + ((((h1 >>> 16) * 0x85ebca6b) & 0xffff) << 16)) & 0xffffffff;
+	h1 ^= h1 >>> 13;
+	h1 = ((((h1 & 0xffff) * 0xc2b2ae35) + ((((h1 >>> 16) * 0xc2b2ae35) & 0xffff) << 16))) & 0xffffffff;
+	h1 ^= h1 >>> 16;
+
+	return h1 >>> 0;
+}

--- a/procgen/procgen.js
+++ b/procgen/procgen.js
@@ -1,4 +1,5 @@
 import alea from './alea.js';
+import {murmurhash3} from './murmurhash3.js';
 import {
   makeRng,
   createMisc,
@@ -19,6 +20,7 @@ import {
 
 export {
   alea,
+  murmurhash3,
   makeRng,
   createMisc,
   numBlocksPerChunk,


### PR DESCRIPTION
Fixes https://github.com/webaverse/app/issues/2661

Hashes attached module content ids to make sure we are tracking apps the same if they have the same module `contentId`s.