### PR TITLE
use totum app to update avatar quality/remove unusable avatar instance

### DIFF
--- a/avatars/avatars.js
+++ b/avatars/avatars.js
@@ -1373,26 +1373,20 @@ class Avatar {
         break;
       }
       case 2: {
-        this.crunchedModel = this.crunchedModel ?? avatarCruncher.crunchAvatarModel( this.model );
         this.crunchedModel.frustumCulled = false;
-        scene.add( this.crunchedModel );
-        this.crunchedModel.visible = true;
         break;
       }
       case 3: {
-        console.log('not implemented'); // XXX
-        this.model.visible = true;
         break;
       }
       case 4: {
-        console.log('not implemented'); // XXX
-        this.model.visible = true;
         break;
       }
       default: {
         throw new Error('unknown avatar quality: ' + quality);
       }
     }
+    this.app.updateQuality();
   }
   update(timestamp, timeDiff) {
     const now = timestamp;


### PR DESCRIPTION
also closes #2530 

at this time, totum only handles the base and crunched avatars, so the avatars class still creates the sprite meshes.  sprite meshes will be moved in another PR, at which point we can further reduce/remove the update function from avatars.js