### PR TITLE
fix sonic boom collision bug

### DIFF
--- a/metaverse_modules/sonic-boom/index.js
+++ b/metaverse_modules/sonic-boom/index.js
@@ -22,21 +22,16 @@ export default () => {
   const electronicballTexture = textureLoader.load(`${baseUrl}/textures/electronic-ball2.png`);
   const noiseMap = textureLoader.load(`${baseUrl}/textures/noise.jpg`);
 
-    let currentPos=new THREE.Vector3();
     let currentDir=new THREE.Vector3();
-    let prePos=new THREE.Vector3();
     //################################################ trace narutoRun Time ########################################
     {
+        let localVector = new THREE.Vector3();
         useFrame(() => {
             
-            //console.log(camera.rotation.y-localPlayer.rotation.y);
-            //console.log(localPlayer.actionInterpolants.jump)
-            currentPos.x=localPlayer.position.x;
-            //currentPos.y=localPlayer.position.y;
-            currentPos.z=localPlayer.position.z;
-            currentDir.x=currentPos.x-prePos.x;
-            //currentDir.y=currentPos.y-prePos.y;
-            currentDir.z=currentPos.z-prePos.z;
+            localVector.x=0;
+            localVector.y=0;
+            localVector.z=-1;
+            currentDir = localVector.applyQuaternion( localPlayer.quaternion );
             currentDir.normalize();
             if (localPlayer.hasAction('narutoRun')){
                     narutoRunTime++;
@@ -46,9 +41,6 @@ export default () => {
                 narutoRunTime=0;
                 
             }
-            prePos.x=currentPos.x;
-            //prePos.y=currentPos.y;
-            prePos.z=currentPos.z;     
             
         });
     }


### PR DESCRIPTION
I found there is a sonic boom collision bug, where when you collide with the object, the trail should still be attached behind the avatar.  But the trail position is wrong when collision. And that is because of the direction calculation. So I change the calculation.
this is the bug:

https://user-images.githubusercontent.com/60634884/160922003-af8793a0-77e0-477e-92d0-e031f87e6589.mp4

And this is after I fix:

https://user-images.githubusercontent.com/60634884/160922132-e56ed39b-e568-4700-b3b4-bff00bb46e50.mp4


