### PR TITLE
Npcs component

### DIFF
--- a/metaverse-components.js
+++ b/metaverse-components.js
@@ -1,9 +1,11 @@
 import wear from './metaverse_components/wear.js';
 import drop from './metaverse_components/drop.js';
+import npc from './metaverse_components/npc.js';
 
 const componentTemplates = {
   wear,
   drop,
+  npc,
 };
 export {
   componentTemplates,

--- a/metaverse_components/npc.js
+++ b/metaverse_components/npc.js
@@ -1,0 +1,216 @@
+import * as THREE from 'three';
+import metaversefile from 'metaversefile';
+
+const localVector = new THREE.Vector3();
+
+export default (app, component) => {
+try {
+  const {useFrame, useActivate, useLocalPlayer, useVoices, useChatManager, useLoreAIScene, useAvatarAnimations, useNpcManager, usePhysics, useCleanup} = metaversefile;
+  // const scene = useScene();
+  const npcManager = useNpcManager();
+  const localPlayer = useLocalPlayer();
+  const physics = usePhysics();
+  const chatManager = useChatManager();
+  const loreAIScene = useLoreAIScene();
+  const voices = useVoices();
+  const animations = useAvatarAnimations();
+  const hurtAnimation = animations.find(a => a.isHurt);
+  const hurtAnimationDuration = hurtAnimation.duration;
+
+  const mode = app.getComponent('mode') ?? 'attached';
+
+  if (mode === 'attached') {
+    const npcName = component.name ?? 'Anon';
+    const npcVoiceName = component.voice ?? 'Shining armor';
+    const npcBio = component.bio ?? 'A generic avatar.';
+    // const npcAvatarUrl = app.getComponent('avatarUrl') ?? `/avatars/Drake_hacker_v6_Guilty.vrm`;
+    let npcWear = component.wear ?? [];
+    if (!Array.isArray(npcWear)) {
+      npcWear = [npcWear];
+    }
+
+    let live = true;
+    let vrmApp = app;
+    let npcPlayer = null;
+    /* e.waitUntil(*/(async () => {
+      // const u2 = npcAvatarUrl;
+      // const m = await metaversefile.import(u2);
+      // if (!live) return;
+      
+      // vrmApp = metaversefile.createApp({
+      //   name: u2,
+      // });
+
+      /* vrmApp.matrixWorld.copy(app.matrixWorld);
+      vrmApp.matrix.copy(app.matrixWorld)
+        .decompose(vrmApp.position, vrmApp.quaternion, vrmApp.scale);
+      vrmApp.name = 'npc';
+      vrmApp.setComponent('physics', true); */
+
+      // await vrmApp.addModule(m);
+      // if (!live) return;
+
+      const position = vrmApp.position.clone()
+        .add(new THREE.Vector3(0, 1, 0));
+      const {quaternion, scale} = vrmApp;
+      const newNpcPlayer = npcManager.createNpc({
+        name: npcName,
+        avatarApp: vrmApp,
+        position,
+        quaternion,
+        scale,
+      });
+      // if (!live) return;
+
+      const _setVoice = () => {
+        const voice = voices.voiceEndpoints.find(v => v.name === npcVoiceName);
+        if (voice) {
+          newNpcPlayer.setVoiceEndpoint(voice.drive_id);
+        } else {
+          console.warn('unknown voice name', npcVoiceName, voices.voiceEndpoints);
+        }
+      };
+      _setVoice();
+
+      const _updateWearables = async () => {
+        const wearablePromises = npcWear.map(wear => (async () => {
+          const {start_url} = wear;
+          const app = await metaversefile.createAppAsync({
+            start_url,
+          });
+          // if (!live) return;
+
+          newNpcPlayer.wear(app);
+        })());
+        await wearablePromises;
+      };
+      await _updateWearables();
+      if (!live) return;
+
+      // scene.add(vrmApp);
+      
+      npcPlayer = newNpcPlayer;
+    })()// );
+
+    app.getPhysicsObjects = () => npcPlayer ? [npcPlayer.characterController] : [];
+
+    app.addEventListener('hit', e => {
+      if (!npcPlayer.hasAction('hurt')) {
+        const newAction = {
+          type: 'hurt',
+          animation: 'pain_back',
+        };
+        npcPlayer.addAction(newAction);
+        
+        setTimeout(() => {
+          npcPlayer.removeAction('hurt');
+        }, hurtAnimationDuration * 1000);
+      }
+    });
+
+    let targetSpec = null;
+    useActivate(() => {
+      // console.log('activate npc');
+      if (targetSpec?.object !== localPlayer) {
+        targetSpec = {
+          type: 'follow',
+          object: localPlayer,
+        };
+      } else {
+        targetSpec = null;
+      }
+    });
+
+    /* console.log('got deets', {
+      npcName,
+      npcVoice,
+      npcBio,
+      npcAvatarUrl,
+    }); */
+
+    const character = loreAIScene.addCharacter({
+      name: npcName,
+      bio: npcBio,
+    });
+    // console.log('got character', character);
+    character.addEventListener('say', e => {
+      console.log('got character say', e.data);
+      const {message, emote, action, object, target} = e.data;
+      chatManager.addPlayerMessage(npcPlayer, message);
+      if (emote === 'supersaiyan' || action === 'supersaiyan' || /supersaiyan/i.test(object) || /supersaiyan/i.test(target)) {
+        const newSssAction = {
+          type: 'sss',
+        };
+        npcPlayer.addAction(newSssAction);  
+      } else if (action === 'follow' || (object === 'none' && target === localPlayer.name)) { // follow player
+        targetSpec = {
+          type: 'follow',
+          object: localPlayer,
+        };
+      } else if (action === 'stop') { // stop
+        targetSpec = null;
+      } else if (action === 'moveto' || (object !== 'none' && target === 'none')) { // move to object
+        console.log('move to object', object);
+        /* target = localPlayer;
+        targetType = 'follow'; */
+      } else if (action === 'moveto' || (object === 'none' && target !== 'none')) { // move to player
+        // console.log('move to', object);
+        targetSpec = {
+          type: 'moveto',
+          object: localPlayer,
+        };
+      } else if (['pickup', 'grab', 'take', 'get'].includes(action)) { // pick up object
+        console.log('pickup', action, object, target);
+      } else if (['use', 'activate'].includes(action)) { // use object
+        console.log('use', action, object, target);
+      }
+    });
+
+    const slowdownFactor = 0.4;
+    const walkSpeed = 0.075 * slowdownFactor;
+    const runSpeed = walkSpeed * 8;
+    const speedDistanceRate = 0.07;
+    useFrame(({timestamp, timeDiff}) => {
+      if (npcPlayer && physics.getPhysicsEnabled()) {
+        if (targetSpec) {
+          const target = targetSpec.object;
+          const v = localVector.setFromMatrixPosition(target.matrixWorld)
+            .sub(npcPlayer.position);
+          v.y = 0;
+          const distance = v.length();
+          if (targetSpec.type === 'moveto' && distance < 2) {
+            targetSpec = null;
+          } else {
+            const speed = Math.min(Math.max(walkSpeed + ((distance - 1.5) * speedDistanceRate), 0), runSpeed);
+            v.normalize()
+              .multiplyScalar(speed * timeDiff);
+            npcPlayer.characterPhysics.applyWasd(v);
+          }
+        }
+
+        npcPlayer.eyeballTarget.copy(localPlayer.position);
+        npcPlayer.eyeballTargetEnabled = true;
+
+        npcPlayer.updatePhysics(timestamp, timeDiff);
+        npcPlayer.updateAvatar(timestamp, timeDiff);
+      }
+    });
+
+    useCleanup(() => {
+      live = false;
+
+      // scene.remove(vrmApp);
+
+      if (npcPlayer) {
+        npcPlayer.destroy();
+      }
+
+      loreAIScene.removeCharacter(character);
+    });
+  }
+
+  return app;
+} catch(err) {
+  console.warn(err);
+}
+};

--- a/scenes/battalion.scn
+++ b/scenes/battalion.scn
@@ -74,23 +74,15 @@
         0,
         0
       ],
-      "start_url": "https://webaverse.github.io/npc/",
+      "start_url": "/avatars/drake_hacker_v3_vian.vrm",
       "components": [
         {
-          "key": "name",
-          "value": "Drake"
-        },
-        {
-          "key": "voice",
-          "value": "Shining Armor"
-        },
-        {
-          "key": "avatarUrl",
-          "value": "/avatars/drake_hacker_v3_vian.vrm"
-        },
-        {
-          "key": "bio",
-          "value": "His nickname is DRK. 15/M hacker. Loves guns. Likes plotting new hacks. He has the best equipment and is always ready for a fight."
+          "key": "npc",
+          "value": {
+            "name": "Drake",
+            "voice": "Shining Armor",
+            "bio": "His nickname is DRK. 15/M hacker. Loves guns. Likes plotting new hacks. He has the best equipment and is always ready for a fight."
+          }
         }
       ]
     },

--- a/scenes/hangout.scn
+++ b/scenes/hangout.scn
@@ -134,23 +134,15 @@
         0,
         1
       ],
-      "start_url": "https://webaverse.github.io/npc/",
+      "start_url": "/avatars/scillia_drophunter_v15_vian.vrm",
       "components": [
         {
-          "key": "name",
-          "value": "Scillia"
-        },
-        {
-          "key": "voice",
-          "value": "Sweetie Belle"
-        },
-        {
-          "key": "avatarUrl",
-          "value": "/avatars/scillia_drophunter_v15_vian.vrm"
-        },
-        {
-          "key": "bio",
-          "value": "Her nickname is Scilly or SLY. 13/F drop hunter. She is an adventurer, swordfighter and fan of potions. She is exceptionally skilled and can go Super Saiyan."
+          "key": "npc",
+          "value": {
+            "name": "Scillia",
+            "voice": "Sweetie Belle",
+            "bio": "Her nickname is Scilly or SLY. 13/F drop hunter. She is an adventurer, swordfighter and fan of potions. She is exceptionally skilled and can go Super Saiyan."
+          }
         }
       ]
     },
@@ -166,23 +158,15 @@
         0,
         1
       ],
-      "start_url": "https://webaverse.github.io/npc/",
+      "start_url": "/avatars/drake_hacker_v3_vian.vrm",
       "components": [
         {
-          "key": "name",
-          "value": "Drake"
-        },
-        {
-          "key": "voice",
-          "value": "Shining Armor"
-        },
-        {
-          "key": "avatarUrl",
-          "value": "/avatars/drake_hacker_v3_vian.vrm"
-        },
-        {
-          "key": "bio",
-          "value": "His nickname is DRK. 15/M hacker. Loves guns. Likes plotting new hacks. He has the best equipment and is always ready for a fight."
+          "key": "npc",
+          "value": {
+            "name": "Drake",
+            "voice": "Shining Armor",
+            "bio": "His nickname is DRK. 15/M hacker. Loves guns. Likes plotting new hacks. He has the best equipment and is always ready for a fight."
+          }
         }
       ]
     },
@@ -198,23 +182,15 @@
         0,
         1
       ],
-      "start_url": "https://webaverse.github.io/npc/",
+      "start_url": "/avatars/hya_influencer_v2_vian.vrm",
       "components": [
         {
-          "key": "name",
-          "value": "Hyacinth"
-        },
-        {
-          "key": "voice",
-          "value": "Maud Pie"
-        },
-        {
-          "key": "avatarUrl",
-          "value": "/avatars/hya_influencer_v2_vian.vrm"
-        },
-        {
-          "key": "bio",
-          "value": "Scillia's mentor. 15/F beast tamer. She is quite famous."
+          "key": "npc",
+          "value": {
+            "name": "Hyacinth",
+            "voice": "Maud Pie",
+            "bio": "Scillia's mentor. 15/F beast tamer. She is quite famous."
+          }
         }
       ]
     },
@@ -230,23 +206,15 @@
         0,
         1
       ],
-      "start_url": "https://webaverse.github.io/npc/",
+      "start_url": "/avatars/jun_engineer_v1_vian.vrm",
       "components": [
         {
-          "key": "name",
-          "value": "Juniper"
-        },
-        {
-          "key": "voice",
-          "value": "Cadance"
-        },
-        {
-          "key": "avatarUrl",
-          "value": "/avatars/jun_engineer_v1_vian.vrm"
-        },
-        {
-          "key": "bio",
-          "value": "She is an engineer. 17/F engineer. She is new on the street."
+          "key": "npc",
+          "value": {
+            "name": "Juniper",
+            "voice": "Cadance",
+            "bio": "She is an engineer. 17/F engineer. She is new on the street."
+          }
         }
       ]
     },


### PR DESCRIPTION
Moves https://github.com/webaverse/npc into this repo under the `npc` component, so npcs get a full standard support in the engine.

This makes NPCs a configured subtype of VRM, rather than a ghost app which puppets a VRM. That should make more sense for the typical art creation process (first you make the avatar and then you add details to it, rather than deciding on some details and then making an avatar for them as an afterthought).

Also updates the local npc definitions to the new component style. The old app will still work for backwards compatibility but they are likely to diverge significantly from here.