### PR TITLE
Direct sound-files.json importing

### DIFF
--- a/sounds.js
+++ b/sounds.js
@@ -1,33 +1,35 @@
 import Avatar from './avatars/avatars.js';
-import {loadJson, loadAudioBuffer} from './util.js';
+import {/*loadJson, */loadAudioBuffer} from './util.js';
+import soundFileSpecs from './public/sounds/sound-files.json';
+
+const _getSoundFiles = regex => soundFileSpecs.filter(f => regex.test(f.name));
+const soundFiles = {
+  walk: _getSoundFiles(/^walk\//),
+  run: _getSoundFiles(/^run\//),
+  jump: _getSoundFiles(/^jump\//),
+  land: _getSoundFiles(/^land\//),
+  narutoRun: _getSoundFiles(/^narutoRun\//),
+  sonicBoom: _getSoundFiles(/^sonicBoom\//),
+  chomp: _getSoundFiles(/^food\/chomp/),
+  combat: _getSoundFiles(/^combat\//),
+  gulp: _getSoundFiles(/^food\/gulp/),
+  enemyDeath: _getSoundFiles(/enemyDeath/),
+};
 
 let soundFileAudioBuffer;
-const soundFiles = {};
 const loadPromise = (async () => {
   await Avatar.waitForLoad();
 
   const audioContext = Avatar.getAudioContext();
-  const [
-    soundFileSpecs,
+  /* const [
+    // soundFileSpecs,
     _soundFileAudioBuffer,
   ] = await Promise.all([
-    loadJson(`/sounds/sound-files.json`),
+    // loadJson(`/sounds/sound-files.json`),
     loadAudioBuffer(audioContext, '/sounds/sounds.mp3'),
-  ]);
+  ]); */
 
-  soundFiles.walk = soundFileSpecs.filter(f => /^walk\//.test(f.name));
-  soundFiles.run = soundFileSpecs.filter(f => /^run\//.test(f.name));
-  soundFiles.jump = soundFileSpecs.filter(f => /^jump\//.test(f.name));
-  soundFiles.land = soundFileSpecs.filter(f => /^land\//.test(f.name));
-  soundFiles.narutoRun = soundFileSpecs.filter(f => /^narutoRun\//.test(f.name));
-  soundFiles.sonicBoom = soundFileSpecs.filter(f => /^sonicBoom\//.test(f.name));
-  soundFiles.chomp = soundFileSpecs.filter(f => /^food\/chomp/.test(f.name));
-  soundFiles.combat = soundFileSpecs.filter(f => /^combat\//.test(f.name));
-  soundFiles.gulp = soundFileSpecs.filter(f => /^food\/gulp/.test(f.name));
-  soundFiles.enemyDeath = soundFileSpecs.filter(f => /enemyDeath/.test(f.name));
-  soundFileAudioBuffer = _soundFileAudioBuffer;
-
-  // console.log('loaded audio', soundFileSpecs, soundFileAudioBuffer);
+  soundFileAudioBuffer = await loadAudioBuffer(audioContext, '/sounds/sounds.mp3');
 })();
 const waitForLoad = () => loadPromise;
 

--- a/sounds.js
+++ b/sounds.js
@@ -1,5 +1,5 @@
 import Avatar from './avatars/avatars.js';
-import {/*loadJson, */loadAudioBuffer} from './util.js';
+import {loadAudioBuffer} from './util.js';
 import soundFileSpecs from './public/sounds/sound-files.json';
 
 const _getSoundFiles = regex => soundFileSpecs.filter(f => regex.test(f.name));
@@ -21,14 +21,6 @@ const loadPromise = (async () => {
   await Avatar.waitForLoad();
 
   const audioContext = Avatar.getAudioContext();
-  /* const [
-    // soundFileSpecs,
-    _soundFileAudioBuffer,
-  ] = await Promise.all([
-    // loadJson(`/sounds/sound-files.json`),
-    loadAudioBuffer(audioContext, '/sounds/sounds.mp3'),
-  ]); */
-
   soundFileAudioBuffer = await loadAudioBuffer(audioContext, '/sounds/sounds.mp3');
 })();
 const waitForLoad = () => loadPromise;


### PR DESCRIPTION
Use

```import soundFileSpecs from './public/sounds/sound-files.json';```

instead of a dynamic import.

This makes a difference for the offscreen engine case, which does not wait for load, but whose apps might access the sounds list immediately. Loading the JSON synchronously with the sounds module solves the problem.

It might also be slightly faster since we don't need to run asynchronous `fetch`.