### PR TITLE
Bugfix unwear actions

### DIFF
--- a/character-controller.js
+++ b/character-controller.js
@@ -292,13 +292,20 @@ class PlayerBase extends THREE.Object3D {
 
     if (loadoutIndex >= 0 && loadoutIndex < numLoadoutSlots) {
       const _removeOldApp = () => {
-        const action = this.getActionsState().get(loadoutIndex);
-        if (action) {
-          const app = this.appManager.getAppByInstanceId(action.instanceId);
+        const actions = this.getActionsState();
+        let oldLoadoutAction = null;
+        for (let i = 0; i < actions.length; i++) {
+          const action = actions.get(i);
+          if (action.type === 'wear' && action.loadoutIndex === loadoutIndex) {
+            oldLoadoutAction = action;
+            break;
+          }
+        }
+        if (oldLoadoutAction) {
+          const app = this.appManager.getAppByInstanceId(oldLoadoutAction.instanceId);
           this.unwear(app, {
             destroy: true,
           });
-          // this.removeActionIndex(loadoutIndex);
         }
       };
       _removeOldApp();


### PR DESCRIPTION
When introducing the new numbered loadout system, I broke the code for detecting a conflicting wear. It used the action index rather than the loadout index, causing corruption of actions during pickup.

This PR fixes that method to look up and remove the wear action by its loadout index.