### PR TITLE
Make wear component imply wear on activate

### DIFF
--- a/metaverse_components/wear.js
+++ b/metaverse_components/wear.js
@@ -13,6 +13,8 @@ const localVector = new THREE.Vector3();
 const localQuaternion = new THREE.Quaternion();
 
 export default (app, component) => {
+  const {useActivate} = metaversefile;
+  
   let wearSpec = null;
   let modelBones = null;
   let appAimAnimationMixers = null;
@@ -278,6 +280,10 @@ export default (app, component) => {
         }
       }
     }
+  });
+
+  useActivate(() => {
+    app.wear();
   });
 
   return {


### PR DESCRIPTION
Makes the wear component in charge of wearing an app on activate. Previously this was handled in the individual type handlers, but it really should be handled by the relevant component.

Some apps and type templates which were handling this need to be updated to not perform a double-wear.