### PR TITLE
Bugfix postprocessing push/pop

### DIFF
--- a/DepthPass.js
+++ b/DepthPass.js
@@ -36,6 +36,7 @@ class DepthPass extends Pass {
     this.camera = camera;
     this.width = width;
     this.height = height;
+		this.onBeforeRenderScene = onBeforeRenderScene;
     const depthTexture = new DepthTexture();
 		// depthTexture.type = UnsignedShortType;
 

--- a/DepthPass.js
+++ b/DepthPass.js
@@ -105,7 +105,7 @@ class DepthPass extends Pass {
 				this.customScene.add(o);
 			}
 			{
-				const pop = onBeforeRenderScene(this.scene);
+				const pop = this.onBeforeRenderScene(this.scene);
 			  
 				renderer.render( this.customScene, this.camera );
 				
@@ -113,7 +113,7 @@ class DepthPass extends Pass {
 			}
 
 			{
-				const pop = onBeforeRenderScene(this.scene);
+				const pop = this.onBeforeRenderScene(this.scene);
 				
 				scene.overrideMaterial = overrideMaterial;
 				renderer.render( scene, this.camera );

--- a/rendersettings-manager.js
+++ b/rendersettings-manager.js
@@ -70,16 +70,9 @@ class RenderSettingsManager {
     scene.background = background;
     scene.fog = fog;
   }
-  applyRenderSettingsToSceneAndPostProcessing(renderSettings, scene, localPostProcessing) {
-    this.applyRenderSettingsToScene(renderSettings, scene);
-    
-    const {
-      passes = null,
-    } = (renderSettings ?? {});
-    localPostProcessing.setPasses(passes);
-  }
   push(srcScene, dstScene = srcScene, {
     fog = false,
+    postProcessing = null,
   } = {}) {
     const renderSettings = this.findRenderSettings(srcScene);
     this.applyRenderSettingsToScene(renderSettings, dstScene);
@@ -104,10 +97,20 @@ class RenderSettingsManager {
         };
       }
     }
+    if (postProcessing) {
+      const {
+        passes = null,
+      } = (renderSettings ?? {});
+      postProcessing.setPasses(passes);
+    }
 
     return () => {
       fogCleanup && fogCleanup();
       this.applyRenderSettingsToScene(null, dstScene);
+
+      if (postProcessing) {
+        postProcessing.setPasses(null);
+      }
     };
   }
 }

--- a/webaverse.js
+++ b/webaverse.js
@@ -341,7 +341,10 @@ export default class Webaverse extends EventTarget {
         loadoutManager.update(timestamp, timeDiffCapped);
 
         {
-          const popRenderSettings = renderSettingsManager.push(rootScene);
+          const popRenderSettings = renderSettingsManager.push(rootScene, undefined, {
+            fog: true,
+            postProcessing,
+          });
 
           performanceTracker.setGpuPrefix('');
           this.render(timestamp, timeDiffCapped);


### PR DESCRIPTION
We push/pop render settings (fog, background, and post processing stack) every frame, but the push logic regressed in the main render with https://github.com/webaverse/app/pull/2795, since that PR added multi-scene rendering and we needed to change the push method.

This PR re-adds the missing postprocessing/fog push to the main render loop.