### PR TITLE
Prevent unwanted jumping when go down slope.

### DIFF
--- a/character-physics.js
+++ b/character-physics.js
@@ -91,7 +91,22 @@ class CharacterPhysics {
         this.player.characterController.position
       );
       // const collided = flags !== 0;
-      const grounded = !!(flags & 0x1); 
+      let grounded = !!(flags & 0x1); 
+
+      if (!grounded && !this.player.getAction('jump') && !this.player.getAction('fly')) { // prevent jump when go down slope
+        const flags = physicsManager.moveCharacterController(
+          this.player.characterController,
+          localVector3.set(0, -0.06, 0),
+          minDist,
+          0,
+          localVector4,
+        );
+        const newGrounded = !!(flags & 0x1); 
+        if (newGrounded) {
+          grounded = true;
+          this.player.characterController.position.copy(localVector4);
+        }
+      }
 
       this.player.characterController.updateMatrixWorld();
       this.player.characterController.matrixWorld.decompose(localVector, localQuaternion, localVector2);

--- a/character-physics.js
+++ b/character-physics.js
@@ -34,6 +34,7 @@ const upVector = new THREE.Vector3(0, 1, 0);
 const leftHandOffset = new THREE.Vector3(0.2, -0.2, -0.4);
 const rightHandOffset = new THREE.Vector3(-0.2, -0.2, -0.4);
 const z22Quaternion = new THREE.Quaternion().setFromAxisAngle(new THREE.Vector3(0, 0, 1), -Math.PI/8);
+const groundStickOffset = 0.03;
 
 class CharacterPhysics {
   constructor(player) {
@@ -96,7 +97,7 @@ class CharacterPhysics {
       if (!grounded && !this.player.getAction('jump') && !this.player.getAction('fly')) { // prevent jump when go down slope
         const flags = physicsManager.moveCharacterController(
           this.player.characterController,
-          localVector3.set(0, -0.06, 0),
+          localVector3.set(0, -groundStickOffset, 0),
           minDist,
           0,
           localVector4,
@@ -105,6 +106,8 @@ class CharacterPhysics {
         if (newGrounded) {
           grounded = true;
           this.player.characterController.position.copy(localVector4);
+        } else {
+          this.player.characterController.position.y += groundStickOffset;
         }
       }
 

--- a/character-physics.js
+++ b/character-physics.js
@@ -95,6 +95,7 @@ class CharacterPhysics {
       let grounded = !!(flags & 0x1); 
 
       if (!grounded && !this.player.getAction('jump') && !this.player.getAction('fly')) { // prevent jump when go down slope
+        const oldY = this.player.characterController.position.y;
         const flags = physicsManager.moveCharacterController(
           this.player.characterController,
           localVector3.set(0, -groundStickOffset, 0),
@@ -107,7 +108,7 @@ class CharacterPhysics {
           grounded = true;
           this.player.characterController.position.copy(localVector4);
         } else {
-          this.player.characterController.position.y += groundStickOffset;
+          this.player.characterController.position.y = oldY;
         }
       }
 


### PR DESCRIPTION
Fix: https://github.com/webaverse/app/issues/2006

If player not grounded, move player down a little when and only when he/she is very near to ground.
To prevent unwanted jumping when go down slope.
And not affect intentional jumping, flying, falling.

Before:

https://user-images.githubusercontent.com/10785634/164200309-b77fc64a-a0aa-4201-8610-9250ac8b0d65.mp4

https://user-images.githubusercontent.com/10785634/164200323-f4a42cfa-e3af-4c0d-ba23-9fdc24f52b2c.mp4

After:

https://user-images.githubusercontent.com/10785634/164200356-4e3a965e-d5c9-48a8-85c5-e5f0f8fb49e1.mp4


https://user-images.githubusercontent.com/10785634/164202028-d6c83ef5-d0a4-4ac6-b7b9-af32445c911d.mp4



