### PR TITLE
Bugfix rendersettings fog setting

### DIFF
--- a/scene-cruncher.js
+++ b/scene-cruncher.js
@@ -465,13 +465,17 @@ export function snapshotMapChunk(
         renderer.setRenderTarget(renderTarget);
         renderer.clear();
         scene.overrideMaterial = overrideMaterial;
+        
+        {
+          const popRenderSettings = renderSettingsManager.push(scene);
+          const popFogClear = renderSettingsManager.pushFogClear(scene);
 
-        const pop = renderSettingsManager.push(scene, undefined, {
-          fog: false,
-        });
-        // scene.fog = null;
-        renderer.render(scene, camera);
-        pop();
+          // scene.fog = null;
+          renderer.render(scene, camera);
+          
+          popRenderSettings();
+          popFogClear();
+        }
 
         const imageData = {
           data: new Uint8Array(wrp1.x * wrp1.y * 4),

--- a/webaverse.js
+++ b/webaverse.js
@@ -342,7 +342,6 @@ export default class Webaverse extends EventTarget {
 
         {
           const popRenderSettings = renderSettingsManager.push(rootScene, undefined, {
-            fog: true,
             postProcessing,
           });
 


### PR DESCRIPTION
Fixes https://github.com/webaverse/app/issues/2857.

Pushes fog onto the stack so that depth rendersettings push does not clobber previous fog settings. A new method, `pushFogClear`, is added for use by the scene cruncher to generate fogless scene previews as needed.