### PR TITLE
Offscreen engine manager

### DIFF
--- a/offscreen-engine-manager.js
+++ b/offscreen-engine-manager.js
@@ -1,0 +1,4 @@
+import {OffscreenEngine} from './offscreen-engine.js';
+
+const offscreenEngineManager = new OffscreenEngine();
+export default offscreenEngineManager;

--- a/spritesheet-manager.js
+++ b/spritesheet-manager.js
@@ -1,11 +1,10 @@
 import {createObjectSprite} from './object-spriter.js';
-import {OffscreenEngine} from './offscreen-engine.js';
+import offscreenEngineManager from './offscreen-engine-manager.js';
 
 class SpritesheetManager {
   constructor() {
     this.spritesheetCache = new Map();
-    this.offscreenEngine = new OffscreenEngine();
-    this.getSpriteSheetForAppUrlInternal = this.offscreenEngine.createFunction([
+    this.getSpriteSheetForAppUrlInternal = offscreenEngineManager.createFunction([
       `\
       import {createObjectSpriteAsync} from './object-spriter.js';
       import metaversefile from './metaversefile-api.js';

--- a/webaverse.js
+++ b/webaverse.js
@@ -554,23 +554,6 @@ const _startHacks = webaverse => {
           titleCardHack: webaverse.titleCardHack,
         }
       }));
-    } else if (e.which === 111) { // /
-      (async () => {
-        const offscreenEngine = new OffscreenEngine();
-        // await offscreenEngine.waitForLoad();
-
-        const fn = offscreenEngine.createFunction([
-          `import * as THREE from 'three';`,
-          function(a, b) {
-            return new THREE.Vector3().fromArray(a)
-              .add(new THREE.Vector3().fromArray(b))
-              .toArray();
-          },
-        ]);
-        const result = await fn([1, 2, 3], [4, 5, 6]);
-        console.log('final result', result);
-        offscreenEngine.destroy();
-      })();
     } else if (e.which === 75) { // K
       if (!haloMeshApp) {
         haloMeshApp = metaversefileApi.createApp();


### PR DESCRIPTION
Fixes https://github.com/webaverse/app/issues/2861.

Does avatar icon rendering for all emotions in a separate render thread using `OffscreenEngine` (shared engine with the object spritesheet renderer).

This should speed up loading by parallelizing better.

Also uses `ImageBitmap` instead of `canvas` for rendering the avatar icon, which should be slightly faster.