### PR TITLE
Default rendersettings to fog

### DIFF
--- a/DepthPass.js
+++ b/DepthPass.js
@@ -105,7 +105,7 @@ class DepthPass extends Pass {
 				this.customScene.add(o);
 			}
 			{
-				const pop = this.onBeforeRenderScene(this.scene);
+				const pop = this.onBeforeRenderScene(scene);
 			  
 				renderer.render( this.customScene, this.camera );
 				
@@ -113,7 +113,7 @@ class DepthPass extends Pass {
 			}
 
 			{
-				const pop = this.onBeforeRenderScene(this.scene);
+				const pop = this.onBeforeRenderScene(scene);
 				
 				scene.overrideMaterial = overrideMaterial;
 				renderer.render( scene, this.camera );

--- a/renderer.js
+++ b/renderer.js
@@ -81,11 +81,11 @@ function getComposer() {
   return composer;
 }
 
-const scene = new THREE.Object3D();
+const scene = new THREE.Scene();
 scene.name = 'scene';
-const sceneHighPriority = new THREE.Object3D();
+const sceneHighPriority = new THREE.Scene();
 sceneHighPriority.name = 'highPriorioty';
-const sceneLowPriority = new THREE.Object3D();
+const sceneLowPriority = new THREE.Scene();
 sceneLowPriority.name = 'lowPriorioty';
 const rootScene = new THREE.Scene();
 rootScene.name = 'root';

--- a/rendersettings-manager.js
+++ b/rendersettings-manager.js
@@ -67,33 +67,6 @@ class RenderSettingsManager {
     }
     return null;
   }
-  /* #pushFog(srcFog, dstFog) {
-    let fogCleanup = null;
-    if (srcFog) {
-      // if (oldFog.isFog) {
-      //   const oldNear = oldFog.near;
-      //   const oldFar = oldFog.far;
-      //   oldFog.near = Infinity;
-      //   oldFog.far = Infinity;
-      //   fogCleanup = () => {
-      //     oldFog.near = oldNear;
-      //     oldFog.far = oldFar;
-      //   };
-      // } else if (oldFog.isFogExp2) {
-        const oldColor = srcFog.color;
-        const oldDensity = srcFog.density;
-        dstFog.color = srcFog.color;
-        dstFog.density = srcFog.density;
-        fogCleanup = () => {
-          dstFog.color = oldColor;
-          dstFog.density = oldDensity;
-        };
-      // }
-    }
-    return () => {
-      fogCleanup && fogCleanup();
-    };
-  } */
   applyRenderSettingsToScene(renderSettings, scene) {
     const oldBackground = scene.background;
     const oldFog = scene.fog;

--- a/scene-cruncher.js
+++ b/scene-cruncher.js
@@ -468,13 +468,16 @@ export function snapshotMapChunk(
         
         {
           const popRenderSettings = renderSettingsManager.push(scene);
-          const popFogClear = renderSettingsManager.pushFogClear(scene);
+          // const popFogClear = renderSettingsManager.pushFogClear(scene);
 
+          // elide fog rendering for scene snapshot
           // scene.fog = null;
+          scene.fog.density = 0;
+
           renderer.render(scene, camera);
-          
+
           popRenderSettings();
-          popFogClear();
+          // popFogClear();
         }
 
         const imageData = {

--- a/scene-cruncher.js
+++ b/scene-cruncher.js
@@ -468,16 +468,13 @@ export function snapshotMapChunk(
         
         {
           const popRenderSettings = renderSettingsManager.push(scene);
-          // const popFogClear = renderSettingsManager.pushFogClear(scene);
 
           // elide fog rendering for scene snapshot
-          // scene.fog = null;
           scene.fog.density = 0;
-
+          
           renderer.render(scene, camera);
 
           popRenderSettings();
-          // popFogClear();
         }
 
         const imageData = {

--- a/scene-cruncher.js
+++ b/scene-cruncher.js
@@ -320,7 +320,7 @@ const _makeGeometry = (position, quaternion, worldSize, worldDepthResolution, de
 
   return [geometry2/*, cubePositions*/];
 };
-const normalMaterial = new THREE.MeshNormalMaterial();
+// const normalMaterial = new THREE.MeshNormalMaterial();
 const baseMaterial = new THREE.MeshBasicMaterial({
   map: null,
   color: 0xFFFFFF,


### PR DESCRIPTION
Defaults rendersettings to always enable FogExp2 in the shader, but adjusting the constants accordingly.

This reduces hitches due to shader recompile when the fog settings change, since we no longer need to enable/disable the fog in the shader chunks.