### PR TITLE
made damageMesh visibility optional

### DIFF
--- a/hp-manager.js
+++ b/hp-manager.js
@@ -108,7 +108,7 @@ const makeHitTracker = ({
     const result = hitTracker.damage(damage);
     const {hit, died} = result;
     if (hit) {
-      const {collisionId, hitPosition, hitDirection, hitQuaternion} = opts;
+      const {collisionId, hitPosition, hitDirection, hitQuaternion, damageMeshVisible = true} = opts;
 
       if (died) {
         triggerDamageAnimation(collisionId);
@@ -119,20 +119,22 @@ const makeHitTracker = ({
       }
 
       {
-        const damageMeshApp = metaversefileApi.createApp();
-        (async () => {
-          await metaverseModules.waitForLoad();
-          const {modules} = metaversefileApi.useDefaultModules();
-          const m = modules['damageMesh'];
-          await damageMeshApp.addModule(m);
-        })();
-        damageMeshApp.position.copy(hitPosition);
-        localEuler.setFromQuaternion(hitQuaternion, 'YXZ');
-        localEuler.x = 0;
-        localEuler.z = 0;
-        damageMeshApp.quaternion.setFromEuler(localEuler);
-        damageMeshApp.updateMatrixWorld();
-        scene.add(damageMeshApp);
+        if(damageMeshVisible) {
+          const damageMeshApp = metaversefileApi.createApp();
+          (async () => {
+            await metaverseModules.waitForLoad();
+            const {modules} = metaversefileApi.useDefaultModules();
+            const m = modules['damageMesh'];
+            await damageMeshApp.addModule(m);
+          })();
+          damageMeshApp.position.copy(hitPosition);
+          localEuler.setFromQuaternion(hitQuaternion, 'YXZ');
+          localEuler.x = 0;
+          localEuler.z = 0;
+          damageMeshApp.quaternion.setFromEuler(localEuler);
+          damageMeshApp.updateMatrixWorld();
+          scene.add(damageMeshApp);
+        }
       }
 
       hitTracker.dispatchEvent({


### PR DESCRIPTION
Due to requests I made the damageMesh (damage numbers) optional.

No need to modify the code in the weapon apps, default is set to true (visible) in here.

Can disable points by adding `damageMeshVisible: false` in the `targetApp.hit()` opts