### PR TITLE
Remove `crouchAction` after `useAction`, except when use pistol.

### DIFF
--- a/game.js
+++ b/game.js
@@ -352,6 +352,9 @@ const _startUse = () => {
         };
         // console.log('new use action', newUseAction, useComponent, {animation, animationCombo, animationEnvelope});
         localPlayer.addAction(newUseAction);
+        if (newUseAction.ik !== 'pistol') {
+          localPlayer.removeAction('crouch');
+        }
 
         wearApp.use();
       }


### PR DESCRIPTION
Using weapon when crouching will cause awkward animations, and not reasonable in some cases, especially for large melee cold weapons, like sword and silsword.
So I want to remove `crouchAction` after adding `useAction`.

But using pistol when crouching seems better and reasonable, so I excluded it.

We can still design special crouching version animations/logics for each weapon afterwards, especially something like bow or knife, and exclude them like what pistol do.
But for now I think it's good to prevent using weapons when crouching.