### PR TITLE
Fix `unuseAnimation` not clear problem.

### DIFF
--- a/player-avatar-binding.js
+++ b/player-avatar-binding.js
@@ -127,6 +127,8 @@ export function applyPlayerActionsToAvatar(player, rig) {
   if (rig.unuseTime === 0) { // this means use is active
     if (useAction?.animationEnvelope) {
       rig.unuseAnimation = rig.useAnimationEnvelope[2]; // the last animation in the triplet is the unuse animation
+    } else {
+      rig.unuseAnimation = null;
     }
   }
 


### PR DESCRIPTION
Currently `unuseAnimation` never be cleared.
Will cause, after used bow, an extra `unuseAnimation` after each `useAnimation`, such as sil/sword, pistol, etc.

This PR fixed this problem.