### PR TITLE
Fix right ikHand wrongly triggered problem.

### DIFF
--- a/character-physics.js
+++ b/character-physics.js
@@ -304,7 +304,7 @@ class CharacterPhysics {
       // const isPlayingEnvelopeIkAnimation = !!useAction && useAction.ik === 'bow';
       const isHandEnabled = (isSession || (isPlayerAiming && isObjectAimable)) /* && !isPlayingEnvelopeIkAnimation */;
       for (let i = 0; i < 2; i++) {
-        const isExpectedHandIndex = i === ((aimComponent?.ikHand === 'left') ? 1 : 0);
+        const isExpectedHandIndex = i === ((aimComponent?.ikHand === 'left') ? 1 : (aimComponent?.ikHand === 'right') ? 0 : null);
         const enabled = isHandEnabled && isExpectedHandIndex;
         this.player.hands[i].enabled = enabled;
       }


### PR DESCRIPTION
Sibling PR: https://github.com/webaverse/pistol/pull/10

Fixed the problem that right ikHand was wrongly triggered when activating sword in aim mode.

![image](https://user-images.githubusercontent.com/10785634/165716382-cab2a951-5aa4-42cf-8877-9e08300dbfe5.png)

![image](https://user-images.githubusercontent.com/10785634/165716333-bb4695ad-7c41-48c6-9edb-3c40b89938bf.png)
