### PR TITLE
Fix hit event of app/hitTracker not trigger and hurt action not added problem.

### DIFF
--- a/metaverse_components/npc.js
+++ b/metaverse_components/npc.js
@@ -94,19 +94,21 @@ try {
 
     app.getPhysicsObjects = () => npcPlayer ? [npcPlayer.characterController] : [];
 
-    app.addEventListener('hit', e => {
-      if (!npcPlayer.hasAction('hurt')) {
-        const newAction = {
-          type: 'hurt',
-          animation: 'pain_back',
-        };
-        npcPlayer.addAction(newAction);
-        
-        setTimeout(() => {
-          npcPlayer.removeAction('hurt');
-        }, hurtAnimationDuration * 1000);
-      }
-    });
+    app.addEventListener('bindHitTracker', e => {
+      app.hitTracker.addEventListener('hit', e => {
+        if (!npcPlayer.hasAction('hurt')) {
+          const newAction = {
+            type: 'hurt',
+            animation: 'pain_back',
+          };
+          npcPlayer.addAction(newAction);
+          
+          setTimeout(() => {
+            npcPlayer.removeAction('hurt');
+          }, hurtAnimationDuration * 1000);
+        }
+      });
+    })
 
     let targetSpec = null;
     useActivate(() => {

--- a/metaverse_components/npc.js
+++ b/metaverse_components/npc.js
@@ -94,7 +94,7 @@ try {
 
     app.getPhysicsObjects = () => npcPlayer ? [npcPlayer.characterController] : [];
 
-    app.addEventListener('bindHitTracker', e => {
+    app.addEventListener('hittrackeradded', e => {
       app.hitTracker.addEventListener('hit', e => {
         if (!npcPlayer.hasAction('hurt')) {
           const newAction = {

--- a/world.js
+++ b/world.js
@@ -292,6 +292,7 @@ const _getBindSceneForRenderPriority = renderPriority => {
 const _bindHitTracker = app => {
   const hitTracker = hpManager.makeHitTracker();
   hitTracker.bind(app);
+  app.dispatchEvent({type: 'bindHitTracker'});
 
   const die = () => {
     world.appManager.removeTrackedApp(app.instanceId);

--- a/world.js
+++ b/world.js
@@ -292,7 +292,7 @@ const _getBindSceneForRenderPriority = renderPriority => {
 const _bindHitTracker = app => {
   const hitTracker = hpManager.makeHitTracker();
   hitTracker.bind(app);
-  app.dispatchEvent({type: 'bindHitTracker'});
+  app.dispatchEvent({type: 'hittrackeradded'});
 
   const die = () => {
     world.appManager.removeTrackedApp(app.instanceId);


### PR DESCRIPTION
Partially Fix: https://github.com/webaverse/app/issues/2480

Before, NPC's hit event not triggered, hurtAction not added, react to hit as other nonliving objects:

https://user-images.githubusercontent.com/10785634/166220649-920bc294-49ef-47ba-87d7-5ba764674908.mp4

After, NPC's hit event triggered, hurtAction added, react to hit with hurt animation:

https://user-images.githubusercontent.com/10785634/166220733-3ad95540-8a5b-4f67-b112-1eb3d925719a.mp4


