### PR TITLE
Let localPlayer look at selected z-target. ( 2nd try )

### DIFF
--- a/game.js
+++ b/game.js
@@ -1002,11 +1002,10 @@ const _gameUpdate = (timestamp, timeDiff) => {
           .unproject(camera);
         localPlayer.avatar.eyeTargetInverted = false;
         localPlayer.avatar.eyeTargetEnabled = true;
-      // this is commented out because it doesn't always look in the right direction
-      /* } else if (cameraManager.target && cameraManager.target2) {
-        cameraManager.target2.getWorldPosition(localPlayer.avatar.eyeTarget);
+      } else if (zTargeting?.focusTargetReticle?.position) {
+        localPlayer.avatar.eyeTarget.copy(zTargeting.focusTargetReticle.position);
         localPlayer.avatar.eyeTargetInverted = true;
-        localPlayer.avatar.eyeTargetEnabled = true; */
+        localPlayer.avatar.eyeTargetEnabled = true;
       } else {
         localPlayer.avatar.eyeTargetEnabled = false;
       }


### PR DESCRIPTION
Fix: https://github.com/webaverse/app/pull/2941#issuecomment-1118009106

Used `zTargeting.focusTargetReticle.position` instead of `cameraManager.target2.position`.

![image](https://user-images.githubusercontent.com/10785634/166869291-cf79e1ed-5798-43a3-a1f8-eb2e5b24db34.png)
![image](https://user-images.githubusercontent.com/10785634/166869301-303ef183-dc47-42da-b39c-18fb8ddbc87b.png)
![image](https://user-images.githubusercontent.com/10785634/166869309-71c22d65-5ddb-4873-a0a5-389eece1dbcc.png)
![image](https://user-images.githubusercontent.com/10785634/166869315-931a6a7a-25af-4d8f-8ee5-d56717a21c67.png)
