### PR TITLE
Sync player's `eyeTarget` and `eyeballTarget`.

### DIFF
--- a/avatars/avatars.js
+++ b/avatars/avatars.js
@@ -78,7 +78,7 @@ const textEncoder = new TextEncoder();
 
 // const y180Quaternion = new THREE.Quaternion().setFromAxisAngle(new THREE.Vector3(0, 1, 0), Math.PI);
 const maxIdleVelocity = 0.01;
-const maxEyeTargetTime = 2000;
+const maxHeadTargetTime = 2000;
 
 /* VRMSpringBoneImporter.prototype._createSpringBone = (_createSpringBone => {
   const localVector = new THREE.Vector3();
@@ -546,9 +546,9 @@ class Avatar {
     // this.allHairBones = allHairBones;
     this.hairBones = hairBones; */
     
-    this.eyeTarget = new THREE.Vector3();
-    this.eyeTargetInverted = false;
-    this.eyeTargetEnabled = false;
+    this.headTarget = new THREE.Vector3();
+    this.headTargetInverted = false;
+    this.headTargetEnabled = false;
 
     this.eyeballTarget = new THREE.Vector3();
     this.eyeballTargetPlane = new THREE.Plane();
@@ -950,9 +950,9 @@ class Avatar {
     this.lastIsBackward = false;
     this.lastBackwardFactor = 0;
     this.backwardAnimationSpec = null;
-    this.startEyeTargetQuaternion = new THREE.Quaternion();
-    this.lastNeedsEyeTarget = false;
-    this.lastEyeTargetTime = -Infinity;
+    this.startHeadTargetQuaternion = new THREE.Quaternion();
+    this.lastNeedsHeadTarget = false;
+    this.lastHeadTargetTime = -Infinity;
 
     this.manuallySetMouth=false;
   }
@@ -1469,47 +1469,47 @@ class Avatar {
       ); */
     };
 
-    const _updateEyeTarget = () => {
+    const _updateHeadTarget = () => {
       const eyePosition = getEyePosition(this.modelBones);
       const globalQuaternion = localQuaternion2.setFromRotationMatrix(
-        this.eyeTargetInverted ?
+        this.headTargetInverted ?
           localMatrix.lookAt(
-            this.eyeTarget,
+            this.headTarget,
             eyePosition,
             upVector
           )
           :
           localMatrix.lookAt(
             eyePosition,
-            this.eyeTarget,
+            this.headTarget,
             upVector
           )
       );
       // this.modelBoneOutputs.Root.updateMatrixWorld();
       this.modelBoneOutputs.Neck.matrixWorld.decompose(localVector, localQuaternion, localVector2);
 
-      const needsEyeTarget = this.eyeTargetEnabled && this.modelBones.Root.quaternion.angleTo(globalQuaternion) < Math.PI * 0.4;
-      if (needsEyeTarget && !this.lastNeedsEyeTarget) {
-        this.startEyeTargetQuaternion.copy(localQuaternion);
-        this.lastEyeTargetTime = now;
-      } else if (this.lastNeedsEyeTarget && !needsEyeTarget) {
-        this.startEyeTargetQuaternion.copy(localQuaternion);
-        this.lastEyeTargetTime = now;
+      const needsHeadTarget = this.headTargetEnabled && this.modelBones.Root.quaternion.angleTo(globalQuaternion) < Math.PI * 0.4;
+      if (needsHeadTarget && !this.lastNeedsHeadTarget) {
+        this.startHeadTargetQuaternion.copy(localQuaternion);
+        this.lastHeadTargetTime = now;
+      } else if (this.lastNeedsHeadTarget && !needsHeadTarget) {
+        this.startHeadTargetQuaternion.copy(localQuaternion);
+        this.lastHeadTargetTime = now;
       }
-      this.lastNeedsEyeTarget = needsEyeTarget;
+      this.lastNeedsHeadTarget = needsHeadTarget;
 
-      const eyeTargetFactor = Math.min(Math.max((now - this.lastEyeTargetTime) / maxEyeTargetTime, 0), 1);
-      if (needsEyeTarget) {
-        localQuaternion.copy(this.startEyeTargetQuaternion)
-          .slerp(globalQuaternion, cubicBezier(eyeTargetFactor));
+      const headTargetFactor = Math.min(Math.max((now - this.lastHeadTargetTime) / maxHeadTargetTime, 0), 1);
+      if (needsHeadTarget) {
+        localQuaternion.copy(this.startHeadTargetQuaternion)
+          .slerp(globalQuaternion, cubicBezier(headTargetFactor));
         this.modelBoneOutputs.Neck.matrixWorld.compose(localVector, localQuaternion, localVector2)
         this.modelBoneOutputs.Neck.matrix.copy(this.modelBoneOutputs.Neck.matrixWorld)
           .premultiply(localMatrix2.copy(this.modelBoneOutputs.Neck.parent.matrixWorld).invert())
           .decompose(this.modelBoneOutputs.Neck.position, this.modelBoneOutputs.Neck.quaternion, localVector2);
       } else {
-        if (eyeTargetFactor < 1) {
-          localQuaternion2.copy(this.startEyeTargetQuaternion)
-            .slerp(localQuaternion, cubicBezier(eyeTargetFactor));
+        if (headTargetFactor < 1) {
+          localQuaternion2.copy(this.startHeadTargetQuaternion)
+            .slerp(localQuaternion, cubicBezier(headTargetFactor));
           localMatrix.compose(localVector.set(0, 0, 0), localQuaternion2, localVector2.set(1, 1, 1))
             .premultiply(localMatrix2.copy(this.modelBoneOutputs.Neck.parent.matrixWorld).invert())
             .decompose(localVector, localQuaternion, localVector2);
@@ -1523,7 +1523,7 @@ class Avatar {
 
       const lookerEyeballTarget = this.looker.update(now);
       let eyeballTargetEnabled = this.eyeballTargetEnabled;
-      if (this.needLimitEyeballTargetRange && !this.lastNeedsEyeTarget) eyeballTargetEnabled = false;
+      if (this.needLimitEyeballTargetRange && !this.lastNeedsHeadTarget) eyeballTargetEnabled = false;
       const eyeballTarget = eyeballTargetEnabled ? this.eyeballTarget : lookerEyeballTarget;
 
       if (eyeballTarget && this.firstPersonCurves) {
@@ -1850,7 +1850,7 @@ class Avatar {
     this.shoulderTransforms.Update();
     this.legsManager.Update();
 
-    _updateEyeTarget();
+    _updateHeadTarget();
     _updateEyeballTarget();
 
     this.modelBoneOutputs.Root.updateMatrixWorld();

--- a/avatars/avatars.js
+++ b/avatars/avatars.js
@@ -549,8 +549,10 @@ class Avatar {
     this.eyeTarget = new THREE.Vector3();
     this.eyeTargetInverted = false;
     this.eyeTargetEnabled = false;
+
     this.eyeballTarget = new THREE.Vector3();
     this.eyeballTargetPlane = new THREE.Plane();
+    this.needLimitEyeballTargetRange = false;
     this.eyeballTargetEnabled = false;
 
     if (options.hair) {
@@ -1520,7 +1522,9 @@ class Avatar {
       const rightEye = this.modelBoneOutputs['Eye_R'];
 
       const lookerEyeballTarget = this.looker.update(now);
-      const eyeballTarget = this.eyeballTargetEnabled ? this.eyeballTarget : lookerEyeballTarget;
+      let eyeballTargetEnabled = this.eyeballTargetEnabled;
+      if (this.needLimitEyeballTargetRange && !this.lastNeedsEyeTarget) eyeballTargetEnabled = false;
+      const eyeballTarget = eyeballTargetEnabled ? this.eyeballTarget : lookerEyeballTarget;
 
       if (eyeballTarget && this.firstPersonCurves) {
         const {

--- a/character-controller.js
+++ b/character-controller.js
@@ -159,6 +159,9 @@ class PlayerBase extends THREE.Object3D {
       app.parent && app.parent.remove(app);
     });
 
+    this.eyeTarget = new THREE.Vector3();
+    this.eyeTargetInverted = false;
+    this.eyeTargetEnabled = false;
     this.eyeballTarget = new THREE.Vector3();
     this.eyeballTargetEnabled = false;
     this.voicePack = null;
@@ -436,9 +439,9 @@ class PlayerBase extends THREE.Object3D {
   }
   setTarget(target) { // set both eye(head) and eyeball target;
     if (target) {
-      this.avatar.eyeTarget.copy(target);
-      this.avatar.eyeTargetInverted = true;
-      this.avatar.eyeTargetEnabled = true;
+      this.eyeTarget.copy(target);
+      this.eyeTargetInverted = true;
+      this.eyeTargetEnabled = true;
       if (this.avatar.lastNeedsEyeTarget) {
         this.eyeballTarget.copy(target);
         this.eyeballTargetEnabled = true;
@@ -446,7 +449,7 @@ class PlayerBase extends THREE.Object3D {
         this.eyeballTargetEnabled = false;
       }
     } else {
-      this.avatar.eyeTargetEnabled = false;
+      this.eyeTargetEnabled = false;
       this.eyeballTargetEnabled = false;
     }
   }

--- a/character-controller.js
+++ b/character-controller.js
@@ -161,8 +161,6 @@ class PlayerBase extends THREE.Object3D {
 
     this.eyeballTarget = new THREE.Vector3();
     this.eyeballTargetEnabled = false;
-    // this.target = new THREE.Vector3(); // target for both eye(head) and eyeball;
-    // this.targetEnabled = false;
     this.voicePack = null;
     this.voiceEndpoint = null;
   }
@@ -451,13 +449,6 @@ class PlayerBase extends THREE.Object3D {
       this.avatar.eyeTargetEnabled = false;
       this.eyeballTargetEnabled = false;
     }
-
-    // if (target) {
-    //   this.target.copy(target);
-    //   this.targetEnabled = true;
-    // } else {
-    //   this.targetEnabled = false;
-    // }
   }
   destroy() {
     // nothing

--- a/character-controller.js
+++ b/character-controller.js
@@ -161,6 +161,8 @@ class PlayerBase extends THREE.Object3D {
 
     this.eyeballTarget = new THREE.Vector3();
     this.eyeballTargetEnabled = false;
+    // this.target = new THREE.Vector3(); // target for both eye(head) and eyeball;
+    // this.targetEnabled = false;
     this.voicePack = null;
     this.voiceEndpoint = null;
   }
@@ -433,6 +435,24 @@ class PlayerBase extends THREE.Object3D {
       };
       _emitEvents();
     }
+  }
+  setTarget(target) { // set both eye(head) and eyeball target;
+    this.avatar.eyeTarget.copy(target);
+    this.avatar.eyeTargetEnabled = true;
+    this.avatar.eyeTargetInverted = true;
+    if (this.avatar.lastNeedsEyeTarget) {
+      this.eyeballTarget.copy(target);
+      this.eyeballTargetEnabled = true;
+    } else {
+      this.eyeballTargetEnabled = false;
+    }
+
+    // if (target) {
+    //   this.target.copy(target);
+    //   this.targetEnabled = true;
+    // } else {
+    //   this.targetEnabled = false;
+    // }
   }
   destroy() {
     // nothing

--- a/character-controller.js
+++ b/character-controller.js
@@ -159,9 +159,9 @@ class PlayerBase extends THREE.Object3D {
       app.parent && app.parent.remove(app);
     });
 
-    this.eyeTarget = new THREE.Vector3();
-    this.eyeTargetInverted = false;
-    this.eyeTargetEnabled = false;
+    this.headTarget = new THREE.Vector3();
+    this.headTargetInverted = false;
+    this.headTargetEnabled = false;
     
     this.eyeballTarget = new THREE.Vector3();
     this.needLimitEyeballTargetRange = false;
@@ -440,17 +440,17 @@ class PlayerBase extends THREE.Object3D {
       _emitEvents();
     }
   }
-  setTarget(target) { // set both eye(head) and eyeball target;
+  setTarget(target) { // set both head and eyeball target;
     if (target) {
-      this.eyeTarget.copy(target);
-      this.eyeTargetInverted = true;
-      this.eyeTargetEnabled = true;
+      this.headTarget.copy(target);
+      this.headTargetInverted = true;
+      this.headTargetEnabled = true;
 
       this.eyeballTarget.copy(target);
       this.needLimitEyeballTargetRange = true;
       this.eyeballTargetEnabled = true;
     } else {
-      this.eyeTargetEnabled = false;
+      this.headTargetEnabled = false;
       this.eyeballTargetEnabled = false;
     }
   }

--- a/character-controller.js
+++ b/character-controller.js
@@ -162,8 +162,11 @@ class PlayerBase extends THREE.Object3D {
     this.eyeTarget = new THREE.Vector3();
     this.eyeTargetInverted = false;
     this.eyeTargetEnabled = false;
+    
     this.eyeballTarget = new THREE.Vector3();
+    this.needLimitEyeballTargetRange = false;
     this.eyeballTargetEnabled = false;
+    
     this.voicePack = null;
     this.voiceEndpoint = null;
   }
@@ -442,12 +445,10 @@ class PlayerBase extends THREE.Object3D {
       this.eyeTarget.copy(target);
       this.eyeTargetInverted = true;
       this.eyeTargetEnabled = true;
-      if (this.avatar.lastNeedsEyeTarget) {
-        this.eyeballTarget.copy(target);
-        this.eyeballTargetEnabled = true;
-      } else {
-        this.eyeballTargetEnabled = false;
-      }
+
+      this.eyeballTarget.copy(target);
+      this.needLimitEyeballTargetRange = true;
+      this.eyeballTargetEnabled = true;
     } else {
       this.eyeTargetEnabled = false;
       this.eyeballTargetEnabled = false;

--- a/character-controller.js
+++ b/character-controller.js
@@ -437,13 +437,18 @@ class PlayerBase extends THREE.Object3D {
     }
   }
   setTarget(target) { // set both eye(head) and eyeball target;
-    this.avatar.eyeTarget.copy(target);
-    this.avatar.eyeTargetEnabled = true;
-    this.avatar.eyeTargetInverted = true;
-    if (this.avatar.lastNeedsEyeTarget) {
-      this.eyeballTarget.copy(target);
-      this.eyeballTargetEnabled = true;
+    if (target) {
+      this.avatar.eyeTarget.copy(target);
+      this.avatar.eyeTargetInverted = true;
+      this.avatar.eyeTargetEnabled = true;
+      if (this.avatar.lastNeedsEyeTarget) {
+        this.eyeballTarget.copy(target);
+        this.eyeballTargetEnabled = true;
+      } else {
+        this.eyeballTargetEnabled = false;
+      }
     } else {
+      this.avatar.eyeTargetEnabled = false;
       this.eyeballTargetEnabled = false;
     }
 

--- a/game.js
+++ b/game.js
@@ -996,17 +996,17 @@ const _gameUpdate = (timestamp, timeDiff) => {
     if (localPlayer.avatar) {
       if (mouseSelectedObject && mouseSelectedPosition) {
         // console.log('got', mouseSelectedObject.position.toArray().join(','));
-        localPlayer.eyeTarget.copy(mouseSelectedPosition);
-        localPlayer.eyeTargetInverted = true;
-        localPlayer.eyeTargetEnabled = true;
+        localPlayer.headTarget.copy(mouseSelectedPosition);
+        localPlayer.headTargetInverted = true;
+        localPlayer.headTargetEnabled = true;
       } else if (!cameraManager.pointerLockElement && !cameraManager.target && lastMouseEvent) {
         const renderer = getRenderer();
         const size = renderer.getSize(localVector);
         
-        localPlayer.eyeTarget.set(-(lastMouseEvent.clientX/size.x-0.5), (lastMouseEvent.clientY/size.y-0.5), 1)
+        localPlayer.headTarget.set(-(lastMouseEvent.clientX/size.x-0.5), (lastMouseEvent.clientY/size.y-0.5), 1)
           .unproject(camera);
-        localPlayer.eyeTargetInverted = false;
-        localPlayer.eyeTargetEnabled = true;
+        localPlayer.headTargetInverted = false;
+        localPlayer.headTargetEnabled = true;
       } else if (zTargeting?.focusTargetReticle?.position) {
         localPlayer.setTarget(zTargeting.focusTargetReticle.position);
       } else {

--- a/game.js
+++ b/game.js
@@ -996,17 +996,17 @@ const _gameUpdate = (timestamp, timeDiff) => {
     if (localPlayer.avatar) {
       if (mouseSelectedObject && mouseSelectedPosition) {
         // console.log('got', mouseSelectedObject.position.toArray().join(','));
-        localPlayer.avatar.eyeTarget.copy(mouseSelectedPosition);
-        localPlayer.avatar.eyeTargetInverted = true;
-        localPlayer.avatar.eyeTargetEnabled = true;
+        localPlayer.eyeTarget.copy(mouseSelectedPosition);
+        localPlayer.eyeTargetInverted = true;
+        localPlayer.eyeTargetEnabled = true;
       } else if (!cameraManager.pointerLockElement && !cameraManager.target && lastMouseEvent) {
         const renderer = getRenderer();
         const size = renderer.getSize(localVector);
         
-        localPlayer.avatar.eyeTarget.set(-(lastMouseEvent.clientX/size.x-0.5), (lastMouseEvent.clientY/size.y-0.5), 1)
+        localPlayer.eyeTarget.set(-(lastMouseEvent.clientX/size.x-0.5), (lastMouseEvent.clientY/size.y-0.5), 1)
           .unproject(camera);
-        localPlayer.avatar.eyeTargetInverted = false;
-        localPlayer.avatar.eyeTargetEnabled = true;
+        localPlayer.eyeTargetInverted = false;
+        localPlayer.eyeTargetEnabled = true;
       } else if (zTargeting?.focusTargetReticle?.position) {
         localPlayer.setTarget(zTargeting.focusTargetReticle.position);
       } else {

--- a/game.js
+++ b/game.js
@@ -1008,11 +1008,9 @@ const _gameUpdate = (timestamp, timeDiff) => {
         localPlayer.avatar.eyeTargetInverted = false;
         localPlayer.avatar.eyeTargetEnabled = true;
       } else if (zTargeting?.focusTargetReticle?.position) {
-        localPlayer.avatar.eyeTarget.copy(zTargeting.focusTargetReticle.position);
-        localPlayer.avatar.eyeTargetInverted = true;
-        localPlayer.avatar.eyeTargetEnabled = true;
+        localPlayer.setTarget(zTargeting.focusTargetReticle.position);
       } else {
-        localPlayer.avatar.eyeTargetEnabled = false;
+        localPlayer.setTarget(null);
       }
     }
   };

--- a/game.js
+++ b/game.js
@@ -992,7 +992,7 @@ const _gameUpdate = (timestamp, timeDiff) => {
   };
   _updateBehavior();
   
-  const _updateMouseLook = () => {
+  const _updateLook = () => {
     if (localPlayer.avatar) {
       if (mouseSelectedObject && mouseSelectedPosition) {
         // console.log('got', mouseSelectedObject.position.toArray().join(','));
@@ -1014,7 +1014,7 @@ const _gameUpdate = (timestamp, timeDiff) => {
       }
     }
   };
-  _updateMouseLook();
+  _updateLook();
 
   const crosshairEl = document.getElementById('crosshair');
   if (crosshairEl) {

--- a/metaverse_components/npc.js
+++ b/metaverse_components/npc.js
@@ -193,15 +193,7 @@ try {
           }
         }
 
-        app.npcPlayer.avatar.eyeTarget.copy(localPlayer.position);
-        app.npcPlayer.avatar.eyeTargetEnabled = true;
-        app.npcPlayer.avatar.eyeTargetInverted = true;
-        if (app.npcPlayer.avatar.lastNeedsEyeTarget) {
-          app.npcPlayer.eyeballTarget.copy(localPlayer.position);
-          app.npcPlayer.eyeballTargetEnabled = true;
-        } else {
-          app.npcPlayer.eyeballTargetEnabled = false;
-        }
+        app.npcPlayer.setTarget(localPlayer.position);
 
         app.npcPlayer.updatePhysics(timestamp, timeDiff);
         app.npcPlayer.updateAvatar(timestamp, timeDiff);

--- a/metaverse_components/npc.js
+++ b/metaverse_components/npc.js
@@ -193,8 +193,15 @@ try {
           }
         }
 
-        app.npcPlayer.eyeballTarget.copy(localPlayer.position);
-        app.npcPlayer.eyeballTargetEnabled = true;
+        app.npcPlayer.avatar.eyeTarget.copy(localPlayer.position);
+        app.npcPlayer.avatar.eyeTargetEnabled = true;
+        app.npcPlayer.avatar.eyeTargetInverted = true;
+        if (app.npcPlayer.avatar.lastNeedsEyeTarget) {
+          app.npcPlayer.eyeballTarget.copy(localPlayer.position);
+          app.npcPlayer.eyeballTargetEnabled = true;
+        } else {
+          app.npcPlayer.eyeballTargetEnabled = false;
+        }
 
         app.npcPlayer.updatePhysics(timestamp, timeDiff);
         app.npcPlayer.updateAvatar(timestamp, timeDiff);

--- a/player-avatar-binding.js
+++ b/player-avatar-binding.js
@@ -175,15 +175,15 @@ export function applyPlayerActionsToAvatar(player, rig) {
   rig.hurtAnimation = (hurtAction?.animation) || '';
   rig.hurtTime = player.actionInterpolants.hurt.get();
 }
-// returns whether eyeTarget(head) were applied
-export function applyPlayerEyeTargetToAvatar(player, rig) {
-  if (player.eyeTargetEnabled) {
-    rig.eyeTarget.copy(player.eyeTarget);
-    rig.eyeTargetInverted = player.eyeTargetInverted;
-    rig.eyeTargetEnabled = true;
+// returns whether headTarget were applied
+export function applyPlayerHeadTargetToAvatar(player, rig) {
+  if (player.headTargetEnabled) {
+    rig.headTarget.copy(player.headTarget);
+    rig.headTargetInverted = player.headTargetInverted;
+    rig.headTargetEnabled = true;
     return true;
   } else {
-    rig.eyeTargetEnabled = false;
+    rig.headTargetEnabled = false;
     return false;
   }
 }
@@ -244,7 +244,7 @@ export function applyPlayerToAvatar(player, session, rig, mirrors) {
   
   applyPlayerModesToAvatar(player, session, rig);
   applyPlayerActionsToAvatar(player, rig);
-  applyPlayerEyeTargetToAvatar(player, rig);
+  applyPlayerHeadTargetToAvatar(player, rig);
   applyPlayerEyesToAvatar(player, rig) || applyMirrorsToAvatar(player, rig, mirrors);
   
   applyFacePoseToAvatar(player, rig);

--- a/player-avatar-binding.js
+++ b/player-avatar-binding.js
@@ -191,6 +191,7 @@ export function applyPlayerEyeTargetToAvatar(player, rig) {
 export function applyPlayerEyesToAvatar(player, rig) {
   if (player.eyeballTargetEnabled) {
     rig.eyeballTarget.copy(player.eyeballTarget);
+    rig.needLimitEyeballTargetRange = player.needLimitEyeballTargetRange;
     rig.eyeballTargetEnabled = true;
     return true;
   } else {

--- a/player-avatar-binding.js
+++ b/player-avatar-binding.js
@@ -175,7 +175,19 @@ export function applyPlayerActionsToAvatar(player, rig) {
   rig.hurtAnimation = (hurtAction?.animation) || '';
   rig.hurtTime = player.actionInterpolants.hurt.get();
 }
-// returns whether eyes were applied
+// returns whether eyeTarget(head) were applied
+export function applyPlayerEyeTargetToAvatar(player, rig) {
+  if (player.eyeTargetEnabled) {
+    rig.eyeTarget.copy(player.eyeTarget);
+    rig.eyeTargetInverted = player.eyeTargetInverted;
+    rig.eyeTargetEnabled = true;
+    return true;
+  } else {
+    rig.eyeTargetEnabled = false;
+    return false;
+  }
+}
+// returns whether eyes(eyeballs) were applied
 export function applyPlayerEyesToAvatar(player, rig) {
   if (player.eyeballTargetEnabled) {
     rig.eyeballTarget.copy(player.eyeballTarget);
@@ -231,6 +243,7 @@ export function applyPlayerToAvatar(player, session, rig, mirrors) {
   
   applyPlayerModesToAvatar(player, session, rig);
   applyPlayerActionsToAvatar(player, rig);
+  applyPlayerEyeTargetToAvatar(player, rig);
   applyPlayerEyesToAvatar(player, rig) || applyMirrorsToAvatar(player, rig, mirrors);
   
   applyFacePoseToAvatar(player, rig);


### PR DESCRIPTION

# LocalPlayer

Sync LocalPlayer's `eyeballTarget` with `eyeTarget`, let them both look at `zTargeting.focusTargetReticle`.

### Before:

![image](https://user-images.githubusercontent.com/10785634/167115001-cba20a11-00dd-4c22-b2c0-67fdffff1090.png)


### After:

lastNeedsEyeTarget = true:
![image](https://user-images.githubusercontent.com/10785634/166976733-d464ca2b-713b-448c-b31c-1c8801e3b4fb.png)
![image](https://user-images.githubusercontent.com/10785634/166976627-289ff95c-623d-411c-923e-94a176241201.png)

lastNeedsEyeTarget = false:
![image](https://user-images.githubusercontent.com/10785634/166976938-c120c4b0-9a92-4d39-a584-16c29fb1392e.png)


# NpcPlayer

Sync NpcPlayer's `eyeTarget` with `eyeballTarget`, let them both look at localPlayer by default.

### Before:
![image](https://user-images.githubusercontent.com/10785634/167075521-f48a02aa-364a-4719-b616-485647010fe7.png)

### After:
![image](https://user-images.githubusercontent.com/10785634/167075548-f8abb549-d227-4b8f-ba2b-95f4296022d5.png)
