### PR TITLE
Bugfix avatars foot offset

### DIFF
--- a/avatars/avatars.js
+++ b/avatars/avatars.js
@@ -996,7 +996,7 @@ class Avatar {
 
     const armatureQuaternion = armature.quaternion.clone();
     const armatureMatrixInverse = armature.matrixWorld.clone().invert();
-    armature.position.set(0, 0, 0);
+    // armature.position.set(0, 0, 0);
     armature.quaternion.set(0, 0, 0, 1);
     armature.scale.set(1, 1, 1);
     armature.updateMatrix();

--- a/avatars/util.mjs
+++ b/avatars/util.mjs
@@ -45,9 +45,20 @@ export const getHeight = (() => {
   const localVector = new THREE.Vector3();
   return function(object) {
     const modelBones = getModelBones(object);
-    return getEyePosition(modelBones)
-      .sub(modelBones.Root.getWorldPosition(localVector))
+    const result = getEyePosition(modelBones)
+      // .sub(localVector.setFromMatrixPosition(modelBones.Root.matrixWorld))
       .y;
+    /* console.log(
+      'get eye',
+      modelBones.Head,
+      getEyePosition(modelBones).toArray().join(', '),
+      localVector.setFromMatrixPosition(modelBones.Root.matrixWorld).toArray().join(', '),
+      result
+    ); */
+    if (result < 0) {
+      debugger;
+    }
+    return result;
   };
 })();
 export const makeBoneMap = object => {


### PR DESCRIPTION
Cleans up some math for avatars that crashed due to having their armature local offset below the floor, as well as letting the avatar define the foot-to-floor distance via the initial position of the export.