### PR TITLE
2974 offscreen engine race condition

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -40,7 +40,7 @@ let _inappPreviewHost = '';
 
 switch ( origin ) {
     case 'https://local.webaverse.com': {
-        _inappPreviewHost = `https://local.webaverse.com:${window.location.port}`;
+        _inappPreviewHost = `https://local.webaverse.online:${window.location.port}`;
         break;
     }
     case 'https://dev.webaverse.com': {

--- a/constants.js
+++ b/constants.js
@@ -40,7 +40,7 @@ let _inappPreviewHost = '';
 
 switch ( origin ) {
     case 'https://local.webaverse.com': {
-        _inappPreviewHost = 'https://local.webaverse.online';
+        _inappPreviewHost = `https://local.webaverse.com:${window.location.port}`;
         break;
     }
     case 'https://dev.webaverse.com': {

--- a/offscreen-engine.js
+++ b/offscreen-engine.js
@@ -32,10 +32,7 @@ class OffscreenEngine {
         iframe.onload = null;
         iframe.onerror = null;
       };
-      iframe.onerror = (e)=>{
-        console.log(e)
-        reject()
-      };
+      iframe.onerror = reject;
     });
 
     this.loadPromise = Promise.all([loading, setport]);

--- a/offscreen-engine.js
+++ b/offscreen-engine.js
@@ -4,6 +4,7 @@ import {inappPreviewHost} from './constants.js';
 class OffscreenEngine {
   constructor() {
     const id = getRandomString();
+    this.port = null;
 
     const iframe = document.createElement('iframe');
     iframe.width = '0px';
@@ -11,40 +12,43 @@ class OffscreenEngine {
     iframe.style.cssText = `\
       border: 0;
     `;
-    iframe.src = `${inappPreviewHost}/engine.html#id=${id}`;
-    document.body.appendChild(iframe);
+
     this.iframe = iframe;
-    this.port = null;
     this.live = true;
 
-    this.loadPromise = (async () => {
-      await new Promise((resolve, reject) => {
-        iframe.onload = () => {
-          resolve();
+    const setport = new Promise((resolve, reject) => {
+      const message = (e) => {
+        if (e.data?.method === 'engineReady' && e.data.id === id && e.data.port instanceof MessagePort){
+          window.removeEventListener('message', message);
+          resolve(e.data.port);
+        }
+      };
+      window.addEventListener('message', message);
+    });
 
-          iframe.onload = null;
-          iframe.onerror = null;
-        };
-        iframe.onerror = reject;
-      });
-      if (!this.live) return;
+    const loading = new Promise((resolve, reject) => {
+      iframe.onload = () => {
+        resolve();
+        iframe.onload = null;
+        iframe.onerror = null;
+      };
+      iframe.onerror = (e)=>{
+        console.log(e)
+        reject()
+      };
+    });
 
-      const port = await new Promise((resolve, reject) => {
-        const message = e => {
-          if (e.data?.method === 'engineReady' && e.data.id === id && e.data.port instanceof MessagePort) {
-            resolve(e.data.port);
+    this.loadPromise = Promise.all([loading, setport]);
 
-            window.removeEventListener('message', message);
-          }
-        };
-        window.addEventListener('message', message);
-      });
-      port.start();
-      this.port = port;
-    })();
+    iframe.src = `${inappPreviewHost}/engine.html#id=${id}`;
+    document.body.appendChild(iframe);
   }
   waitForLoad() {
-    return this.loadPromise;
+    return this.loadPromise.then(([, port]) => {
+      this.port = port;
+      this.port.start();
+      return port;
+    });
   }
   createFunction(o) {
     if (!Array.isArray(o)) {

--- a/offscreen-engine.js
+++ b/offscreen-engine.js
@@ -1,5 +1,5 @@
 import {getRandomString} from './util.js';
-import {inappPreviewHost} from './constants.js';
+import {checkOriginAllow, inappPreviewHost} from './constants.js';
 
 class OffscreenEngine {
   constructor() {
@@ -18,6 +18,7 @@ class OffscreenEngine {
 
     const setport = new Promise((resolve, reject) => {
       const message = (e) => {
+        checkOriginAllow(e.origin);
         if (e.data?.method === 'engineReady' && e.data.id === id && e.data.port instanceof MessagePort){
           window.removeEventListener('message', message);
           resolve(e.data.port);


### PR DESCRIPTION
## Issue
https://github.com/webaverse/app/issues/2974

## Fix

- Bind the `engineReady` handler before the iframe source is set. Once the port has been received and the iframe has loaded, the port will be started and the `waitForLoad()` promise is resolved.

- Update the `_inappPreviewHost` constant for dev, so that iframes are loaded locally. (but the fix works even if the iframe is one of the remotes, e.g. app.webaverse.com)

![image](https://user-images.githubusercontent.com/889851/168364884-32ea3647-aeca-4ddf-a392-42e2fa809a0e.png)

## Tested
Tested in `master` and a merge spot check for `z-targeting` (no conflicts)

Be sure to test in a worst-case scenario. User-land browser, with extensions on, and cache enabled. 