### PR TITLE
apply scale to all selected physics objects

### DIFF
--- a/src/components/general/world-objects-list/WorldObjectsList.jsx
+++ b/src/components/general/world-objects-list/WorldObjectsList.jsx
@@ -106,8 +106,9 @@ export const WorldObjectsList = () => {
     const updatePhysics = () => {
 
         const physicsObjects = selectedApp.getPhysicsObjects();
-        physicsManager.setGeometryScale( physicsObjects[0].physicsId, selectedApp.scale );
-
+        physicsObjects.forEach( ( physicsObject ) => {
+            physicsManager.setGeometryScale( physicsObject.physicsId, selectedApp.scale );
+        });
     };
 
     const stopPropagation = ( event ) => {


### PR DESCRIPTION
Fixes #3096 

This PR fixes two issues. 

1) selecting objects without physics would crash because the zero index was hardcoded.
2) editing objects with more than one physics object would only update the scale of the first object.