### PR TITLE
Z-Targeting: Multiplayer: Fix micMediaStream undefined variable in world.js

### DIFF
--- a/world.js
+++ b/world.js
@@ -96,9 +96,6 @@ world.connectRoom = async u => {
       wsrtc.removeEventListener('init', init);
       
       localPlayer.bindState(state.getArray(playersMapName));
-      if (mediaStream) {
-        wsrtc.enableMic(mediaStream);
-      }
     };
     wsrtc.addEventListener('init', init);
   };


### PR DESCRIPTION
This PR removes an uninitialized variable that was crashing multiplayer