### PR TITLE
Fix: remove _setNextAvatarApp(null)

### DIFF
--- a/character-controller.js
+++ b/character-controller.js
@@ -694,8 +694,6 @@ class StatePlayer extends PlayerBase {
           }
         }
       }
-    } else {
-      _setNextAvatarApp(null);
     }
     
     this.syncAvatarCancelFn = null;


### PR DESCRIPTION
Right now we are calling _setNextAvatarApp(null) in a worst case-- this crashes multiplayer and is unneeded.