### PR TITLE
Multiplayer fix invalid call to nonexistant remoteplayer update

### DIFF
--- a/players-manager.js
+++ b/players-manager.js
@@ -78,11 +78,11 @@ class PlayersManager {
       this.unbindStateFn = this.playersArray.unobserve.bind(this.playersArray, playersObserveFn);
     }
   }
-  updateRemotePlayers(timestamp, timeDiff) {
-    for (const remotePlayer of this.remotePlayers.values()) {
-      remotePlayer.updateAvatar(timestamp, timeDiff);
-    }
-  }
+  // updateRemotePlayers(timestamp, timeDiff) {
+  //   for (const remotePlayer of this.remotePlayers.values()) {
+  //     remotePlayer.updateAvatar(timestamp, timeDiff);
+  //   }
+  // }
 }
 const playersManager = new PlayersManager();
 

--- a/webaverse.js
+++ b/webaverse.js
@@ -319,7 +319,7 @@ export default class Webaverse extends EventTarget {
           game.update(timestamp, timeDiffCapped);
           
           localPlayer.updateAvatar(timestamp, timeDiffCapped);
-          playersManager.updateRemotePlayers(timestamp, timeDiffCapped);
+          // playersManager.updateRemotePlayers(timestamp, timeDiffCapped);
           
           world.appManager.tick(timestamp, timeDiffCapped, frame);
 


### PR DESCRIPTION
updateAvatar on remote players throws an error. Anyways we want the updates to be coming from the player observer function on remote players to avoid timing issues. This PR removes the invalid method call so at least we're not throwing errors -- a future PR will add a new update function to the playersObserverFn