### PR TITLE
Don't play footsteps while character is sitting

### DIFF
--- a/character-sfx.js
+++ b/character-sfx.js
@@ -207,7 +207,10 @@ class CharacterSfx {
       }
       
     };
-    _handleStep();
+
+    if (!this.player.hasAction('sit')) {
+      _handleStep();
+    }
 
     const _handleNarutoRun = () => {
       


### PR DESCRIPTION
This PR adds a check to see if the character is sitting before playing a footstep sound. This fixes footsteps playing while the player is on a mount or vehicle.