### PR TITLE
Death

### DIFF
--- a/character-controller.js
+++ b/character-controller.js
@@ -69,7 +69,7 @@ const _getSession = () => {
 function makeCancelFn() {
   let live = true;
   return {
-    isLive() {
+    isAlive() {
       return live;
     },
     cancel() {
@@ -647,7 +647,7 @@ class StatePlayer extends PlayerBase {
     const _setNextAvatarApp = app => {
       (() => {
         const avatar = switchAvatar(this.avatar, app);
-        if (!cancelFn.isLive()) return;
+        if (!cancelFn.isAlive()) return;
         this.avatar = avatar;
 
         this.dispatchEvent({
@@ -687,7 +687,7 @@ class StatePlayer extends PlayerBase {
           const addPromise = this.appManager.pendingAddPromises.get(instanceId);
           if (addPromise) {
             const nextAvatarApp = await addPromise;
-            if (!cancelFn.isLive()) return;
+            if (!cancelFn.isAlive()) return;
             _setNextAvatarApp(nextAvatarApp);
           } else {
             console.warn('switching avatar to instanceId that does not exist in any app manager', instanceId);
@@ -855,6 +855,12 @@ class StatePlayer extends PlayerBase {
     this.appManager.destroy();
   
     super.destroy();
+  }
+  setAlive(isAlive) {
+    this.isAlive = isAlive;
+    this.avatar.model.visible = isAlive;
+    if(this.characterFx.nameplate) this.characterFx.nameplate.visible = isAlive;
+    this.pushPlayerUpdates();
   }
 }
 class InterpolatedPlayer extends StatePlayer {

--- a/game.js
+++ b/game.js
@@ -488,6 +488,8 @@ const _gameUpdate = (timestamp, timeDiff) => {
   const renderer = getRenderer();
   const localPlayer = getLocalPlayer();
 
+  if (!localPlayer.isAlive) return
+
   const _handlePush = () => {
     if (gameManager.canPush()) {
       if (ioManager.keys.forward) {

--- a/io-manager.js
+++ b/io-manager.js
@@ -592,6 +592,13 @@ ioManager.keydown = e => {
       debug.toggle();
       break;
     }
+    case 75: { // K
+      console.log("died")
+      const localPlayer = metaversefile.useLocalPlayer();
+      localPlayer.setAlive(false)
+      ioManager.dispatchEvent(new MessageEvent('death', {data: {isAlive: false}}));
+      break;
+    }
     case 192: { // tilde
       game.toggleEditMode();
       break;

--- a/src/components/app/App.jsx
+++ b/src/components/app/App.jsx
@@ -19,6 +19,7 @@ import { Settings } from '../general/settings';
 import { WorldObjectsList } from '../general/world-objects-list';
 import { IoHandler, registerIoEventHandler, unregisterIoEventHandler } from '../general/io-handler';
 import { ZoneTitleCard } from '../general/zone-title-card';
+import { Death } from '../general/death';
 import { Quests } from '../play-mode/quests';
 import { MapGen } from '../general/map-gen/MapGen.jsx';
 import { LoadingBox } from '../../LoadingBox.jsx';
@@ -301,6 +302,7 @@ export const App = () => {
                 <QuickMenu />
                 <ZoneTitleCard />
                 <MapGen />
+                <Death />
                 <Quests />
                 <LoadingBox />
                 <FocusBar />

--- a/src/components/general/death/Death.jsx
+++ b/src/components/general/death/Death.jsx
@@ -1,0 +1,38 @@
+import React, {useEffect, useState} from 'react';
+import classnames from 'classnames';
+import styles from './death.module.css';
+import metaversefile from 'metaversefile';
+import ioManager from '../../../../io-manager';
+import {DeathFx} from './DeathFx';
+
+export const Death = () => {
+  const [isDeath, setIsDeath] = useState(false);
+
+  useEffect(() => {
+    const onSetLive = e => {
+      setIsDeath(!e.data.isAlive);
+    };
+    ioManager.addEventListener('death', onSetLive);
+    return () => {
+      ioManager.removeEventListener('death', onSetLive);
+    };
+  });
+
+  return (
+    <div className={classnames(styles.Death, isDeath && styles.open)}>
+      <div>YOU HAVE DIED</div>
+      <div>Press "RESPAWN" TO CONTINUE</div>
+      <div
+        className={styles.respawn}
+        onClick={() => {
+          const localPlayer = metaversefile.useLocalPlayer();
+          localPlayer.setAlive(true);
+          setIsDeath(false);
+        }}
+      >
+        RESPAWN
+      </div>
+      <DeathFx enabled={isDeath}></DeathFx>
+    </div>
+  );
+};

--- a/src/components/general/death/DeathFx.jsx
+++ b/src/components/general/death/DeathFx.jsx
@@ -1,0 +1,71 @@
+import * as THREE from 'three';
+import React, {useState, useEffect, useRef} from 'react';
+import {world} from '../../../../world.js';
+import {RainBgFxMesh} from '../../../../background-fx/RainBgFx.js';
+import styles from './death.module.css';
+
+export const DeathFx = ({enabled}) => {
+  const [renderer, setRenderer] = useState(null);
+  const canvasRef = useRef();
+
+  const scene = new THREE.Scene();
+  const camera = new THREE.OrthographicCamera();
+
+  const rainBgFxMesh = new RainBgFxMesh();
+  rainBgFxMesh.frustumCulled = false;
+  scene.add(rainBgFxMesh);
+
+  const _updateRendererSize = renderer => {
+    renderer.setSize(window.innerWidth, window.innerHeight);
+    renderer.setPixelRatio(window.devicePixelRatio);
+  };
+  const _updateAspectRatio = () => {
+    rainBgFxMesh.material.uniforms.aspectRatio.value =
+      window.innerWidth / window.innerHeight;
+    rainBgFxMesh.material.uniforms.aspectRatio.needsUpdate = true;
+  };
+  _updateAspectRatio();
+
+  useEffect(() => {
+    function resize() {
+      if (renderer) {
+        _updateRendererSize(renderer);
+        _updateAspectRatio();
+      }
+    }
+    window.addEventListener('resize', resize);
+    return () => {
+      window.removeEventListener('resize', resize);
+    };
+  }, [renderer]);
+
+  useEffect(() => {
+    if (canvasRef.current && enabled) {
+      const canvas = canvasRef.current;
+
+      const renderer = new THREE.WebGLRenderer({
+        canvas,
+        antialias: true,
+        alpha: true,
+      });
+      _updateRendererSize(renderer);
+      _updateAspectRatio();
+      setRenderer(renderer);
+
+      async function frame(e) {
+        const {timestamp, timeDiff} = e.data;
+
+        rainBgFxMesh.update(timestamp, timeDiff);
+
+        renderer.clear();
+        renderer.render(scene, camera);
+      }
+      world.appManager.addEventListener('frame', frame);
+      return () => {
+        world.appManager.removeEventListener('frame', frame);
+      };
+    }
+  }, [canvasRef, enabled]);
+
+  return <canvas className={styles.rainFx} ref={canvasRef} />;
+};

--- a/src/components/general/death/death.module.css
+++ b/src/components/general/death/death.module.css
@@ -1,0 +1,41 @@
+.Death {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    font-family: "PlazaRegular";
+    font-size: 5vw;
+    color: #f00;
+    text-shadow: 2px 2px 0px #333;
+    transform: none;
+    transition: transform 1s cubic-bezier(0, 1, 0, 1);
+    z-index: 100;
+    display: flex;
+    flex-direction: column;
+    gap: 2vw;
+    align-items: center;
+    justify-content: center;
+  }
+  
+  .Death:not(.open) {
+    transform: translateY(-100%);
+  }
+  
+  .Death .respawn {
+    border: 1px solid red;
+    border-radius: 2vw;
+    cursor: pointer;
+    text-align: center;
+    padding: 0 2vw;
+  }
+  
+  .Death .rainFx {
+    position: fixed;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    right: 0;
+    z-index: -1;
+    pointer-events: none;
+  }

--- a/src/components/general/death/index.jsx
+++ b/src/components/general/death/index.jsx
@@ -1,0 +1,2 @@
+import {Death} from './Death';
+export {Death};


### PR DESCRIPTION
This adds a death screen, and restrict's players controls while they are dead

This is a to-do PR

- [ ] Teleport player back to the current scene's spawn point
- [ ] Drop any items that are unclaimed (but keep any claimed items)
- [ ] Play a player death sound
- [ ] Play a player death animation
- [ ] Allow player to see their player die before showing death screen