### PR TITLE
Fix remote player use [E]

### DIFF
--- a/avatars/animationHelpers.js
+++ b/avatars/animationHelpers.js
@@ -1233,7 +1233,9 @@ export const _applyAnimation = (avatar, now, moveFactors) => {
       let defaultAnimation = 'grab_forward';
 
       const activateAction = localPlayer.getAction('activate');
-      if (activateAction.animationName) {
+      // activateAction can be null on remote player on the last frame the action is removed
+      // so we null check it before checkout for the animation name
+      if (activateAction && activateAction.animationName) {
         defaultAnimation = activateAction.animationName;
       }
 

--- a/avatars/animationHelpers.js
+++ b/avatars/animationHelpers.js
@@ -1229,29 +1229,30 @@ export const _applyAnimation = (avatar, now, moveFactors) => {
 
     if (avatar.activateTime > 0) {
       const localPlayer = metaversefile.useLocalPlayer();
-
-      let defaultAnimation = 'grab_forward';
-
       const activateAction = localPlayer.getAction('activate');
-      // activateAction can be null on remote player on the last frame the action is removed
-      // so we null check it before checkout for the animation name
-      if (activateAction && activateAction.animationName) {
-        defaultAnimation = activateAction.animationName;
+
+      // activateAction can be null on remote player on the last frame of a use action since it is removed first
+      if (activateAction) {
+        let defaultAnimation = 'grab_forward';
+
+        if (activateAction.animationName) {
+          defaultAnimation = activateAction.animationName;
+        }
+
+        const activateAnimation = activateAnimations[defaultAnimation].animation;
+        const src2 = activateAnimation.interpolants[k];
+        const t2 = ((avatar.activateTime / 1000) * activateAnimations[defaultAnimation].speedFactor) % activateAnimation.duration;
+        const v2 = src2.evaluate(t2);
+
+        const f = avatar.activateTime > 0 ? Math.min(cubicBezier(t2), 1) : (1 - Math.min(cubicBezier(t2), 1));
+
+        lerpFn
+          .call(
+            dst,
+            localQuaternion.fromArray(v2),
+            f,
+          );
       }
-
-      const activateAnimation = activateAnimations[defaultAnimation].animation;
-      const src2 = activateAnimation.interpolants[k];
-      const t2 = ((avatar.activateTime / 1000) * activateAnimations[defaultAnimation].speedFactor) % activateAnimation.duration;
-      const v2 = src2.evaluate(t2);
-
-      const f = avatar.activateTime > 0 ? Math.min(cubicBezier(t2), 1) : (1 - Math.min(cubicBezier(t2), 1));
-
-      lerpFn
-        .call(
-          dst,
-          localQuaternion.fromArray(v2),
-          f,
-        );
     }
   };
 


### PR DESCRIPTION
Right now, when the player goes to use an item an error is thrown on the last frame of the use. This is because there is a race condition with the use action itself being removed from the network state. The easy fix for this is to null check the action before checking it's animation name. This only handles this edge case and otherwise the code is ignored.

This depends on several multiplayer dependencies, but can be tested to not break anything on single player at least.