### PR TITLE
Fixing wearing and unwearing pets in multiplayer (and bugs in single player)

### DIFF
--- a/character-controller.js
+++ b/character-controller.js
@@ -457,7 +457,9 @@ class PlayerBase extends THREE.Object3D {
           app.updateMatrixWorld();
         }
       };
-      _setAppTransform();
+      if (!app.getComponent('pet') && !app.getComponent('sit')) {
+        _setAppTransform();
+      }
 
       const _deinitPhysics = () => {
         const physicsObjects = app.getPhysicsObjects();

--- a/character-controller.js
+++ b/character-controller.js
@@ -933,6 +933,8 @@ class InterpolatedPlayer extends StatePlayer {
       pickUp: new InfiniteActionInterpolant(() => this.actionBinaryInterpolants.pickUp.get(), 0),
       unuse: new InfiniteActionInterpolant(() => !this.actionBinaryInterpolants.use.get(), 0),
       aim: new InfiniteActionInterpolant(() => this.actionBinaryInterpolants.aim.get(), 0),
+      aimRightTransition: new BiActionInterpolant(() => this.hasAction('aim') && this.hands[0].enabled, 0, aimTransitionMaxTime),
+      aimLeftTransition: new BiActionInterpolant(() => this.hasAction('aim') && this.hands[1].enabled, 0, aimTransitionMaxTime),
       narutoRun: new InfiniteActionInterpolant(() => this.actionBinaryInterpolants.narutoRun.get(), 0),
       fly: new InfiniteActionInterpolant(() => this.actionBinaryInterpolants.fly.get(), 0),
       jump: new InfiniteActionInterpolant(() => this.actionBinaryInterpolants.jump.get(), 0),

--- a/character-controller.js
+++ b/character-controller.js
@@ -508,8 +508,6 @@ class PlayerBase extends THREE.Object3D {
     this.characterSfx.destroy();
     this.characterFx.destroy();
     this.characterBehavior.destroy();
-
-    super.destroy();
   }
 }
 const controlActionTypes = [

--- a/character-controller.js
+++ b/character-controller.js
@@ -36,7 +36,7 @@ import {CharacterBehavior} from './character-behavior.js';
 import {CharacterFx} from './character-fx.js';
 import {VoicePack, VoicePackVoicer} from './voice-output/voice-pack-voicer.js';
 import {VoiceEndpoint, VoiceEndpointVoicer, getVoiceEndpointUrl} from './voice-output/voice-endpoint-voicer.js';
-import {BinaryInterpolant, BiActionInterpolant, UniActionInterpolant, InfiniteActionInterpolant, PositionInterpolant, QuaternionInterpolant, FixedTimeStep} from './interpolants.js';
+import {BinaryInterpolant, BiActionInterpolant, UniActionInterpolant, InfiniteActionInterpolant, PositionInterpolant, QuaternionInterpolant} from './interpolants.js';
 import {applyPlayerToAvatar, switchAvatar} from './player-avatar-binding.js';
 import {
   defaultPlayerName,
@@ -879,13 +879,6 @@ class InterpolatedPlayer extends StatePlayer {
     
     this.positionInterpolant = new PositionInterpolant(() => this.getPosition(), avatarInterpolationTimeDelay, avatarInterpolationNumFrames);
     this.quaternionInterpolant = new QuaternionInterpolant(() => this.getQuaternion(), avatarInterpolationTimeDelay, avatarInterpolationNumFrames);
-    this.positionTimeStep = new FixedTimeStep(timeDiff => {
-      this.positionInterpolant.snapshot(timeDiff);
-    }, avatarInterpolationFrameRate);
-    this.quaternionTimeStep = new FixedTimeStep(timeDiff => {
-      this.quaternionInterpolant.snapshot(timeDiff);
-    }, avatarInterpolationFrameRate);
-    
     this.actionBinaryInterpolants = {
       crouch: new BinaryInterpolant(() => this.hasAction('crouch'), avatarInterpolationTimeDelay, avatarInterpolationNumFrames),
       activate: new BinaryInterpolant(() => this.hasAction('activate'), avatarInterpolationTimeDelay, avatarInterpolationNumFrames),
@@ -906,26 +899,6 @@ class InterpolatedPlayer extends StatePlayer {
       hurt: new BinaryInterpolant(() => this.hasAction('hurt'), avatarInterpolationTimeDelay, avatarInterpolationNumFrames),
     };
     this.actionBinaryInterpolantsArray = Object.keys(this.actionBinaryInterpolants).map(k => this.actionBinaryInterpolants[k]);
-    this.actionBinaryTimeSteps = {
-      crouch: new FixedTimeStep(timeDiff => {this.actionBinaryInterpolants.crouch.snapshot(timeDiff);}, avatarInterpolationFrameRate),
-      activate: new FixedTimeStep(timeDiff => {this.actionBinaryInterpolants.activate.snapshot(timeDiff);}, avatarInterpolationFrameRate),
-      use: new FixedTimeStep(timeDiff => {this.actionBinaryInterpolants.use.snapshot(timeDiff);}, avatarInterpolationFrameRate),
-      pickUp: new FixedTimeStep(timeDiff => {this.actionBinaryInterpolants.pickUp.snapshot(timeDiff);}, avatarInterpolationFrameRate),
-      aim: new FixedTimeStep(timeDiff => {this.actionBinaryInterpolants.aim.snapshot(timeDiff);}, avatarInterpolationFrameRate),
-      narutoRun: new FixedTimeStep(timeDiff => {this.actionBinaryInterpolants.narutoRun.snapshot(timeDiff);}, avatarInterpolationFrameRate),
-      fly: new FixedTimeStep(timeDiff => {this.actionBinaryInterpolants.fly.snapshot(timeDiff);}, avatarInterpolationFrameRate),
-      jump: new FixedTimeStep(timeDiff => {this.actionBinaryInterpolants.jump.snapshot(timeDiff);}, avatarInterpolationFrameRate),
-      dance: new FixedTimeStep(timeDiff => {this.actionBinaryInterpolants.dance.snapshot(timeDiff);}, avatarInterpolationFrameRate),
-      emote: new FixedTimeStep(timeDiff => {this.actionBinaryInterpolants.emote.snapshot(timeDiff);}, avatarInterpolationFrameRate),
-      // throw: new FixedTimeStep(timeDiff => {this.actionBinaryInterpolants.throw.snapshot(timeDiff);}, avatarInterpolationFrameRate),
-      // chargeJump: new FixedTimeStep(timeDiff => {this.actionBinaryInterpolants.chargeJump.snapshot(timeDiff);}, avatarInterpolationFrameRate),
-      // standCharge: new FixedTimeStep(timeDiff => {this.actionBinaryInterpolants.standCharge.snapshot(timeDiff);}, avatarInterpolationFrameRate),
-      // fallLoop: new FixedTimeStep(timeDiff => {this.actionBinaryInterpolants.fallLoop.snapshot(timeDiff);}, avatarInterpolationFrameRate),
-      // swordSideSlash: new FixedTimeStep(timeDiff => {this.actionBinaryInterpolants.swordSideSlash.snapshot(timeDiff);}, avatarInterpolationFrameRate),
-      // swordTopDownSlash: new FixedTimeStep(timeDiff => {this.actionBinaryInterpolants.swordTopDownSlash.snapshot(timeDiff);}, avatarInterpolationFrameRate),
-      hurt: new FixedTimeStep(timeDiff => {this.actionBinaryInterpolants.hurt.snapshot(timeDiff);}, avatarInterpolationFrameRate),
-    };
-    this.actionBinaryTimeStepsArray = Object.keys(this.actionBinaryTimeSteps).map(k => this.actionBinaryTimeSteps[k]);
     this.actionInterpolants = {
       crouch: new BiActionInterpolant(() => this.actionBinaryInterpolants.crouch.get(), 0, crouchMaxTime),
       activate: new UniActionInterpolant(() => this.actionBinaryInterpolants.activate.get(), 0, activateMaxTime),
@@ -956,15 +929,8 @@ class InterpolatedPlayer extends StatePlayer {
     };
   }
   updateInterpolation(timeDiff) {
-    this.positionTimeStep.update(timeDiff);
-    this.quaternionTimeStep.update(timeDiff);
-    
     this.positionInterpolant.update(timeDiff);
     this.quaternionInterpolant.update(timeDiff);
-    
-    for (const actionInterpolantTimeStep of this.actionBinaryTimeStepsArray) {
-      actionInterpolantTimeStep.update(timeDiff);
-    }
     for (const actionBinaryInterpolant of this.actionBinaryInterpolantsArray) {
       actionBinaryInterpolant.update(timeDiff);
     }

--- a/character-controller.js
+++ b/character-controller.js
@@ -150,6 +150,15 @@ class PlayerBase extends THREE.Object3D {
   constructor() {
     super();
 
+    this.name = defaultPlayerName;
+    this.bio = defaultPlayerBio;
+    this.characterPhysics = new CharacterPhysics(this);
+    this.characterHups = new CharacterHups(this);
+    this.characterSfx = new CharacterSfx(this);
+    this.characterFx = new CharacterFx(this);
+    this.characterHitter = new CharacterHitter(this);
+    this.characterBehavior = new CharacterBehavior(this);
+
     this.leftHand = new PlayerHand();
     this.rightHand = new PlayerHand();
     this.hands = [
@@ -494,7 +503,13 @@ class PlayerBase extends THREE.Object3D {
     }
   }
   destroy() {
-    // nothing
+    this.characterPhysics.destroy();
+    this.characterHups.destroy();
+    this.characterSfx.destroy();
+    this.characterFx.destroy();
+    this.characterBehavior.destroy();
+
+    super.destroy();
   }
 }
 const controlActionTypes = [
@@ -703,9 +718,8 @@ class StatePlayer extends PlayerBase {
     this.syncAvatarCancelFn = null;
   }
   setSpawnPoint(position, quaternion) {
-    const localPlayer = metaversefile.useLocalPlayer();
-    localPlayer.position.copy(position);
-    localPlayer.quaternion.copy(quaternion);
+    this.position.copy(position);
+    this.quaternion.copy(quaternion);
 
     camera.position.copy(position);
     camera.quaternion.copy(quaternion);
@@ -1006,15 +1020,6 @@ class LocalPlayer extends UninterpolatedPlayer {
     this.isLocalPlayer = !opts.npc;
     this.isNpcPlayer = !!opts.npc;
     this.detached = !!opts.detached;
-
-    this.name = defaultPlayerName;
-    this.bio = defaultPlayerBio;
-    this.characterPhysics = new CharacterPhysics(this);
-    this.characterHups = new CharacterHups(this);
-    this.characterSfx = new CharacterSfx(this);
-    this.characterFx = new CharacterFx(this);
-    this.characterHitter = new CharacterHitter(this);
-    this.characterBehavior = new CharacterBehavior(this);
   }
   async setPlayerSpec(playerSpec) {
     const p = this.setAvatarUrl(playerSpec.avatarUrl);
@@ -1240,15 +1245,6 @@ class LocalPlayer extends UninterpolatedPlayer {
       this.resetPhysics();
     };
   })() */
-  destroy() {
-    this.characterPhysics.destroy();
-    this.characterHups.destroy();
-    this.characterSfx.destroy();
-    this.characterFx.destroy();
-    this.characterBehavior.destroy();
-
-    super.destroy();
-  }
 }
 class RemotePlayer extends InterpolatedPlayer {
   constructor(opts) {

--- a/character-sfx.js
+++ b/character-sfx.js
@@ -207,7 +207,10 @@ class CharacterSfx {
       }
       
     };
-    _handleStep();
+
+    if (!this.player.hasAction('sit')) {
+      _handleStep();
+    }
 
     const _handleNarutoRun = () => {
       

--- a/interpolants.js
+++ b/interpolants.js
@@ -65,7 +65,7 @@ const _makeSnapshots = (constructor, numFrames) => {
     result[i] = {
       startValue: constructor(),
       // endValue: constructor(),
-      startTime: 0,
+      // startTime: 0,
       endTime: 0,
     };
   }
@@ -81,7 +81,7 @@ export class SnapshotInterpolant {
     this.seekFn = seekFn;
     
     this.readTime = 0;
-    this.writeTime = 0;
+    // this.writeTime = 0;
 
     this.snapshots = _makeSnapshots(constructor, numFrames);
     this.snapshotWriteIndex = 0;
@@ -90,22 +90,48 @@ export class SnapshotInterpolant {
   }
   update(timeDiff) {
     this.readTime += timeDiff;
+    
+    let minEndTime = Infinity;
+    let maxEndTime = -Infinity;
+    for (let i = 0; i < this.numFrames; i++) {
+      const snapshot = this.snapshots[i];
+      if (snapshot.endTime < minEndTime) {
+        minEndTime = snapshot.endTime;
+      }
+      if (snapshot.endTime > maxEndTime) {
+        maxEndTime = snapshot.endTime;
+      }
+    }
 
-    const effectiveReadTime = this.readTime - this.timeDelay;
-    this.seekTo(effectiveReadTime);
+    if (maxEndTime > 0) { // if we had at least one snapshot
+      if (
+        (this.readTime - this.timeDelay) < minEndTime ||
+        (this.readTime - this.timeDelay) > maxEndTime
+      ) {
+        this.readTime = maxEndTime;
+      }
+
+      const effectiveReadTime = this.readTime - this.timeDelay;
+
+      this.seekTo(effectiveReadTime);
+    }
   }
   seekTo(t) {
     for (let i = -(this.numFrames - 1); i < 0; i++) {
       const index = this.snapshotWriteIndex + i;
       const snapshot = this.snapshots[mod(index, this.numFrames)];
-      if (snapshot.startTime >= t && t <= snapshot.endTime) {
-        const duration = snapshot.endTime - snapshot.startTime;
-        const f = (duration > 0 && duration < Infinity) ? ((t - snapshot.startTime) / duration) : 0;
-        const {startValue} = snapshot;
-        const nextSnapshot = this.snapshots[mod(index + 1, this.numFrames)];
-        const {startValue: endValue} = nextSnapshot;
-        this.value = this.seekFn(this.value, startValue, endValue, f);
-        return;
+      if (t <= snapshot.endTime) {
+        const prevSnapshot = this.snapshots[mod(index - 1, this.numFrames)];
+        const startTime = prevSnapshot.endTime;
+        if (t >= startTime) {
+          const duration = snapshot.endTime - startTime;
+          const f = (duration > 0 && duration < Infinity) ? ((t - startTime) / duration) : 0;
+          const {startValue} = snapshot;
+          const nextSnapshot = this.snapshots[mod(index + 1, this.numFrames)];
+          const {startValue: endValue} = nextSnapshot;
+          this.value = this.seekFn(this.value, startValue, endValue, f);
+          return;
+        }
       }
     }
     console.warn('could not seek to time', t, JSON.parse(JSON.stringify(this.snapshots)));
@@ -114,12 +140,14 @@ export class SnapshotInterpolant {
     const value = this.fn();
     // console.log('got value', value.join(','), timeDiff);
     const writeSnapshot = this.snapshots[this.snapshotWriteIndex];
+    
+    const lastWriteSnapshot = this.snapshots[mod(this.snapshotWriteIndex - 1, this.numFrames)];
+    const startTime = lastWriteSnapshot.endTime;
+    
     writeSnapshot.startValue = this.readFn(writeSnapshot.startValue, value);
-    writeSnapshot.startTime = this.writeTime;
-    writeSnapshot.endTime = this.writeTime + timeDiff;
+    writeSnapshot.endTime = startTime + timeDiff;
     
     this.snapshotWriteIndex = mod(this.snapshotWriteIndex + 1, this.numFrames);
-    this.writeTime += timeDiff;
   }
   get() {
     return this.value;
@@ -146,13 +174,14 @@ export class PositionInterpolant extends SnapshotInterpolant {
     super(fn, timeDelay, numFrames, () => new THREE.Vector3(), (target, value) => {
       target.fromArray(value);
       if (isNaN(target.x) || isNaN(target.y) || isNaN(target.z)) {
-        debugger;
+        throw new Error('target is NaN');
       }
       return target;
     }, (target, src, dst, f) => {
       target.copy(src).lerp(dst, f);
+      // console.log('position lerp', target.toArray(), f);
       if (isNaN(target.x) || isNaN(target.y) || isNaN(target.z)) {
-        debugger;
+        throw new Error('target is NaN');
       }
       return target;
     });
@@ -162,21 +191,5 @@ export class PositionInterpolant extends SnapshotInterpolant {
 export class QuaternionInterpolant extends SnapshotInterpolant {
   constructor(fn, timeDelay, numFrames) {
     super(fn, timeDelay, numFrames, () => new THREE.Quaternion(), (target, value) => target.fromArray(value), (target, src, dst, f) => target.copy(src).slerp(dst, f));
-  }
-}
-
-// allows ticking at a fixed rate regardless of frame rate
-export class FixedTimeStep {
-  constructor(fn, frameRate) {
-    this.fn = fn;
-    this.maxTime = 1000/frameRate;
-    this.timeAcc = this.maxTime;
-  }
-  update(timeDiff) {
-    this.timeAcc += timeDiff;
-    while (this.timeAcc > this.maxTime) {
-      this.fn(this.maxTime);
-      this.timeAcc -= this.maxTime;
-    }
   }
 }

--- a/metaverse_components/pet.js
+++ b/metaverse_components/pet.js
@@ -18,7 +18,9 @@ export default (app, component) => {
   let walkAction = null;
   let runAction = null;
   let rootBone = null;
-  
+
+  let player = null;
+
   const petComponent = component;
   const _makePetMixer = () => {
     let petMixer, idleAction;
@@ -61,10 +63,12 @@ export default (app, component) => {
       const m = _makePetMixer();
       petMixer = m.petMixer;
       idleAction = m.idleAction;
+      player = null;
     }
   };
   app.addEventListener('wearupdate', e => {
     if (e.wear) {
+      player = metaversefile.getPlayerByAppInstanceId(app.instanceId);
       if (app.glb) {
         const {animations} = app.glb;
         
@@ -90,8 +94,7 @@ export default (app, component) => {
   const smoothVelocity = new THREE.Vector3();
   const lastLookQuaternion = new THREE.Quaternion();
   const _getAppDistance = () => {
-    const localPlayer = useLocalPlayer();
-    const position = localVector.copy(localPlayer.position);
+    const position = localVector.copy(player.position);
     position.y = 0;
     const distance = app.position.distanceTo(position);
     return distance;
@@ -115,8 +118,7 @@ export default (app, component) => {
             const moveDelta = localVector;
             moveDelta.setScalar(0);
             if (_isFar(distance)) { // handle rounding errors
-              const localPlayer = useLocalPlayer();
-              const position = localPlayer.position.clone();
+              const position = player.position.clone();
               position.y = 0;
               const direction = position.clone()
                 .sub(app.position)
@@ -163,13 +165,14 @@ export default (app, component) => {
           }
           const deltaSeconds = timeDiff / 1000;
           petMixer.update(deltaSeconds);
-          petMixer.getRoot().updateMatrixWorld();
+          app.updateMatrixWorld();
         }
       }
     };
     _updateAnimation();
     
     const _updateLook = () => {
+      if (!player) return; // only look at player if following them
       const lookComponent = app.getComponent('look');
       if (lookComponent && app.glb) {
         let skinnedMesh = null;
@@ -190,8 +193,7 @@ export default (app, component) => {
             }
             
             if (!bone.quaternion.equals(lastLookQuaternion)) {
-              const localPlayer = useLocalPlayer();
-              const {position, quaternion} = localPlayer;
+              const {position, quaternion} = player;
               localQuaternion2.setFromRotationMatrix(
                 localMatrix.lookAt(
                   position,

--- a/metaversefile-api.js
+++ b/metaversefile-api.js
@@ -956,6 +956,21 @@ export default () => {
   removeTrackedApp(app) {
     return world.appManager.removeTrackedApp.apply(world.appManager, arguments);
   },
+  getPlayerByAppInstanceId(instanceId) {
+    let result = localPlayer.appManager.getAppByInstanceId(instanceId);
+    if (result) {
+      return localPlayer;
+    } else {
+      const remotePlayers = useRemotePlayers();
+      for (const remotePlayer of remotePlayers) {
+        const remoteApp = remotePlayer.appManager.getAppByInstanceId(instanceId);
+        if (remoteApp) {
+          return remotePlayer;
+        }
+      }
+      return null;
+    }
+  },
   getAppByInstanceId(instanceId) {
     // local
     const localPlayer = getLocalPlayer();

--- a/scenes/scenes.json
+++ b/scenes/scenes.json
@@ -35,5 +35,7 @@
   "crypt.scn",
   "spacepod.scn",
   "plaza.scn",
-  "wind-sample.scn"
+  "wind-sample.scn",
+  "snow-city.scn",
+  "traffic.scn"
 ]

--- a/scenes/snow-city.scn
+++ b/scenes/snow-city.scn
@@ -1,0 +1,81 @@
+{
+  "objects": [
+
+  {
+      "type": "application/spawnpoint",
+      "content": {
+        "position": [-16.85, 10 ,-2.32]
+      }
+    },
+{
+      "type": "application/light",
+      "content": {
+        "lightType": "ambient",
+        "args": [[255, 255, 255], 0.6]
+      }
+    },
+    {
+      "type": "application/light",
+      "content": {
+        "lightType": "directional",
+        "args": [[255, 255, 255], 5],
+        "position": [1, 2, 3],
+        "shadow": [150, 5120, 0.1, 10000, -0.0001]
+      }
+    },
+    
+{
+      
+      "position": [
+        0,
+        0,
+        0
+      ],
+      "quaternion": [
+        0,
+        0,
+        0,
+        0
+      ],
+      "start_url": "https://webaverse.github.io/night-skybox/"
+    },
+{
+      
+      "position": [
+        0,
+        -14,
+        0
+      ],
+      "quaternion": [
+        0,
+        0,
+        0,
+        0
+      ],
+      "start_url": "https://webaverse.github.io/Snow/"
+    },
+
+    {
+      "position": [
+        0,
+        0,
+        0
+      ],
+      "quaternion": [
+        0,
+        0,
+        0,
+        0
+      ],
+      "scale": [
+        1,
+       1,
+        1
+      ],
+      "physics": false,
+      "start_url": "https://webaverse.github.io/Snow-Globe/",
+      "dynamic": true
+    }
+
+]
+}

--- a/scenes/traffic.scn
+++ b/scenes/traffic.scn
@@ -1,0 +1,51 @@
+{
+  "objects": [
+    {
+      "type": "application/spawnpoint",
+      "content": {
+        "position": [9.13, 6 ,-14.24]
+      }
+    },
+{
+      "type": "application/light",
+      "content": {
+        "lightType": "ambient",
+        "args": [[255, 255, 255], 0.5]
+      }
+    },
+    {
+      "type": "application/light",
+      "content": {
+        "lightType": "directional",
+        "args": [[255, 255, 255], 5],
+        "position": [1, 2, 3],
+        "shadow": [150, 5120, 0.1, 10000, -0.0001]
+      }
+    },
+    {
+      "type": "application/rendersettings",
+      "content": {
+        "fog": {
+          "fogType": "exp",
+          "args": [[255, 255, 255], 0.005]
+        }
+      }
+    },
+    {
+      "position": [
+        0,
+        0,
+        0
+      ],
+      "start_url": "https://webaverse.github.io/city/"
+    },
+    {
+      "position": [
+        0,
+        0,
+        0
+      ],
+      "start_url": "https://webaverse.github.io/atmospheric-sky/"
+    }
+  ]
+}

--- a/src/components/editor-mode/scene-menu/SceneMenu.jsx
+++ b/src/components/editor-mode/scene-menu/SceneMenu.jsx
@@ -7,6 +7,7 @@ import voiceInput from '../../../../voice-input/voice-input';
 import sceneNames from '../../../../scenes/scenes.json';
 
 import { AppContext } from '../../app';
+import {makeId} from '../../../../util.js';
 
 import styles from './scene-menu.module.css';
 
@@ -95,32 +96,27 @@ export const SceneMenu = ({ multiplayerConnected, selectedScene, setSelectedScen
     };
 
     const handleRoomCreateBtnClick = async () => {
+        const sceneName = selectedScene.trim();
+        const data = null; // Z.encodeStateAsUpdate( world.getState( true ) );
 
-        alert( 'todo' );
-        // const roomName = _makeName();
-        // const data = null; // Z.encodeStateAsUpdate( world.getState( true ) );
+        const roomName = makeId(5);
 
-        // const res = await fetch( universe.getWorldsHost() + roomName, { method: 'POST', body: data } );
-
-        // if ( res.ok ) {
-
-        //     refreshRooms();
-        //     setSelectedRoom( roomName );
-        //     universe.pushUrl( `/?src=${ encodeURIComponent( sceneName ) }&room=${ roomName }` );
-
-        //     /* this.parent.sendMessage([
-        //         MESSAGE.ROOMSTATE,
-        //         data,
-        //     ]); */
-
-        // } else {
-
-        //     const text = await res.text();
-        //     console.warn( 'error creating room', res.status, text );
-
-        // }
-
-    };
+        const res = await fetch(universe.getWorldsHost() + roomName, {
+          method: 'POST',
+          body: data,
+        });
+    
+        if (res.ok) {
+          refreshRooms();
+          setSelectedRoom(roomName);
+          universe.pushUrl(
+            `/?src=${encodeURIComponent(sceneName)}&room=${roomName}`,
+          );
+        } else {
+          const text = await res.text();
+          console.warn('error creating room', res.status, text);
+        }
+      };
 
     const handleRoomSelect = ( room ) => {
 
@@ -312,7 +308,7 @@ export const SceneMenu = ({ multiplayerConnected, selectedScene, setSelectedScen
                         </div>
                         {
                             rooms.map( ( room, i ) => (
-                                <div className={ styles.room } onClick={ ( e ) => { handleRoomSelect( e, room ) } } key={ i } >
+                                <div className={ styles.room } onClick={ ( e ) => { handleRoomSelect( room ) } } key={ i } >
                                     <img className={ styles.image } src="images/world.jpg" />
                                     <div className={ styles.name } >{ room.name }</div>
                                     <div className={ styles.delete } >


### PR DESCRIPTION
In the current implementation, pets can be offset from their root if they move. When this is fixed, the pet jumps to where the player placed them. This PR fixes that and abstracts the local player references so pets work in multplayer.

To test: wear and unwear fox in the shadows scene. To test multiplayer we'll need to have some other PRs pulled in, however since the pet now treats all players as equal this is effectively guaranteed.