### PR TITLE
Fix error if user clicks while loading

### DIFF
--- a/transform-controls.js
+++ b/transform-controls.js
@@ -63,7 +63,7 @@ const transformControls = {
     binding = o;
   }, */
   handleMouseDown(raycaster) {
-    this.transformAxis = this.transformGizmo.selectAxisWithRaycaster(raycaster);
+    this.transformAxis = this.transformGizmo?.selectAxisWithRaycaster(raycaster);
     if (this.transformAxis) {
       console.log('yes transform axis');
       


### PR DESCRIPTION
If the player clicks the mouse while the world is loading, an error is thrown:

![image](https://user-images.githubusercontent.com/18633264/177968763-c893c0ff-f069-46fa-9246-aedb70caca4d.png)

This null-checks the the transformGizmo before trying to raycast.

To reproduce:
1. Enter world
2. While app is loading, click the mouse
3. Errors will appear in the console