### PR TITLE
Refactor world and universe files

### DIFF
--- a/src/components/editor-mode/scene-menu/SceneMenu.jsx
+++ b/src/components/editor-mode/scene-menu/SceneMenu.jsx
@@ -2,7 +2,6 @@
 import React, { useState, useEffect, useContext, useRef } from 'react';
 import classnames from 'classnames';
 
-import { world } from '../../../../world'
 import universe from '../../../../universe'
 import voiceInput from '../../../../voice-input/voice-input';
 import sceneNames from '../../../../scenes/scenes.json';
@@ -127,7 +126,7 @@ export const SceneMenu = ({ multiplayerConnected, selectedScene, setSelectedScen
 
         setState({ openedPanel: null });
 
-        if ( ! world.isConnected() ) {
+        if ( ! universe.isConnected() ) {
 
             universe.pushUrl( `/?src=${ encodeURIComponent( selectedScene ) }&room=${ room.name }` );
 

--- a/universe.js
+++ b/universe.js
@@ -4,20 +4,27 @@ responsibilities include loading the world on url change.
 */
 
 // import * as THREE from 'three';
-import * as Z from 'zjs';
-import {world} from './world.js';
-import physicsManager from './physics-manager.js';
-import {loadOverworld} from './overworld.js';
-import {initialPosY} from './constants.js';
-import {parseQuery} from './util.js';
 import metaversefile from 'metaversefile';
+import WSRTC from 'wsrtc/wsrtc.js';
+import * as Z from 'zjs';
+
+import {appsMapName, initialPosY, playersMapName} from './constants.js';
+import {loadOverworld} from './overworld.js';
+import physicsManager from './physics-manager.js';
+import physxWorkerManager from './physx-worker-manager.js';
+import physx from './physx.js';
+import {playersManager} from './players-manager.js';
+import {getLocalPlayer} from './players.js';
 import sceneNames from './scenes/scenes.json';
+import {parseQuery} from './util.js';
+import {world} from './world.js';
 
 const physicsScene = physicsManager.getScene();
 
 class Universe extends EventTarget {
   constructor() {
     super();
+    this.wsrtc = null;
 
     this.currentWorld = null;
     this.sceneLoadedPromise = null;
@@ -27,7 +34,7 @@ class Universe extends EventTarget {
       ((window.location.port ? parseInt(window.location.port, 10) : (window.location.protocol === 'https:' ? 443 : 80)) + 1) + '/worlds/';
   }
   async enterWorld(worldSpec) {
-    world.disconnectRoom();
+    this.disconnectRoom();
     
     const localPlayer = metaversefile.useLocalPlayer();
     /* localPlayer.teleportTo(new THREE.Vector3(0, 1.5, 0), camera.quaternion, {
@@ -47,7 +54,7 @@ class Universe extends EventTarget {
       const {src, room} = worldSpec;
       if (!room) {
         const state = new Z.Doc();
-        world.connectState(state);
+        this.connectState(state);
         
         let match;
         if (src === undefined) {
@@ -70,7 +77,7 @@ class Universe extends EventTarget {
       } else {
         const p = (async () => {
           const roomUrl = this.getWorldsHost() + room;
-          await world.connectRoom(roomUrl);
+          await this.connectRoom(roomUrl);
         })();
         promises.push(p);
       }
@@ -119,6 +126,83 @@ class Universe extends EventTarget {
         });
       }
     }
+  }
+
+  isConnected() { return !!this.wsrtc; }
+
+  getConnection() { return this.wsrtc; }
+
+  // called by enterWorld() in universe.js
+  // This is called in single player mode instead of connectRoom
+  connectState(state) {
+    state.setResolvePriority(1);
+    playersManager.bindState(state.getArray(playersMapName));
+
+    world.appManager.unbindState();
+    world.appManager.clear();
+    const appsArray = state.get(appsMapName, Z.Array);
+
+    world.appManager.bindState(appsArray);
+
+    const localPlayer = getLocalPlayer();
+    localPlayer.bindState(state.getArray(playersMapName));
+  }
+
+  // called by enterWorld() in universe.js
+  // This is called when a user joins a multiplayer room
+  // either from single player or directly from a link
+  async connectRoom(u, state = new Z.Doc()) {
+    // Players cannot be initialized until the physx worker is loaded
+    // Otherwise you will receive allocation errors because the module instance is undefined
+    await physx.waitForLoad();
+    await physxWorkerManager.waitForLoad();
+    const localPlayer = getLocalPlayer();
+
+    state.setResolvePriority(1);
+
+    // Create a new instance of the websocket rtc client
+    // This comes from webaverse/wsrtc/wsrtc.js
+    this.wsrtc = new WSRTC(u, {
+      localPlayer,
+      crdtState: state,
+    });
+
+    // This is called when the websocket connection opens, i.e. server is connectedw
+    const open = e => {
+      this.wsrtc.removeEventListener('open', open);
+      // Clear the last world state
+      const appsArray = state.get(appsMapName, Z.Array);
+      playersManager.bindState(state.getArray(playersMapName));
+
+      // Unbind the world state to clear existing apps
+      world.appManager.unbindState();
+      world.appManager.clear();
+      // Bind the new state
+      world.appManager.bindState(appsArray);
+
+      // Called by WSRTC when the connection is initialized
+      const init = e => {
+        this.wsrtc.removeEventListener('init', init);
+        localPlayer.bindState(state.getArray(playersMapName));
+
+        this.wsrtc.addEventListener('audio', e => {
+          const player = playersManager.remotePlayersByInteger.get(e.data.playerId);
+          player.processAudioData(e.data);
+        });
+      };
+
+      this.wsrtc.addEventListener('init', init);
+    };
+
+    this.wsrtc.addEventListener('open', open);
+
+    return this.wsrtc;
+  }
+
+  // called by enterWorld() in universe.js, to make sure we aren't already connected
+  disconnectRoom() {
+    if (this.wsrtc && this.wsrtc.state === 'open') this.wsrtc.close();
+    this.wsrtc = null;
   }
 }
 const universe = new Universe();

--- a/voice-input/voice-input.js
+++ b/voice-input/voice-input.js
@@ -21,7 +21,7 @@ class VoiceInput extends EventTarget {
     const localPlayer = metaversefile.useLocalPlayer();
     localPlayer.setMicMediaStream(this.mediaStream);
 
-    const wsrtc = world.getConnection();
+    const wsrtc = universe.getConnection();
     if (wsrtc) {
       wsrtc.enableMic(this.mediaStream);
     }
@@ -34,7 +34,7 @@ class VoiceInput extends EventTarget {
   }
   disableMic() {
     /* if (this.micEnabled()) */ {
-      const wsrtc = world.getConnection();
+      const wsrtc = universe.getConnection();
       if (wsrtc) {
         wsrtc.disableMic();
       } else {

--- a/world.js
+++ b/world.js
@@ -1,278 +1,6 @@
-/*
-this file contains the singleplayer code.
-*/
-
-import * as THREE from 'three';
-// import * as Y from 'yjs';
-import * as Z from 'zjs/z.mjs';
-import WSRTC from 'wsrtc/wsrtc.js';
-
 import hpManager from './hp-manager.js';
-// import {rigManager} from './rig.js';
 import {AppManager} from './app-manager.js';
-// import {chatManager} from './chat-manager.js';
-// import {getState, setState} from './state.js';
-// import {makeId} from './util.js';
 import {scene, sceneHighPriority, sceneLowPriority, sceneLowerPriority, sceneLowestPriority} from './renderer.js';
-// import metaversefileApi from 'metaversefile';
-import {appsMapName, playersMapName} from './constants.js';
-import {playersManager} from './players-manager.js';
-import {getLocalPlayer} from './players.js';
-// import * as metaverseModules from './metaverse-modules.js';
-// import {createParticleSystem} from './particle-system.js';
-// import * as sounds from './sounds.js';
-// import loreAI from './ai/lore/lore-ai.js';
-
-// const localEuler = new THREE.Euler();
-
-// world
-export const world = {};
-world.winds = [];
-
-const appManager = new AppManager({
-  appsMap: null,
-});
-world.appManager = appManager;
-
-// world.particleSystem = createParticleSystem();
-// scene.add(world.particleSystem);
-
-// multiplayer
-let wsrtc = null;
-
-/* // The extra Pose buffers we send along
-const extra = {
-  leftGamepadPosition: new Float32Array(3),
-  leftGamepadQuaternion: new Float32Array(4),
-  leftGamepad: new Float32Array(3),
-  rightGamepadPosition: new Float32Array(3),
-  rightGamepadQuaternion: new Float32Array(4),
-  rightGamepad: new Float32Array(3),
-  attr: new Float32Array(3),
-  direction: new Float32Array(3),
-  velocity: new Float32Array(3),
-  states: new Float32Array(15),
-}; */
-
-world.getConnection = () => wsrtc;
-
-world.connectState = state => {
-  state.setResolvePriority(1);
-
-  world.appManager.unbindState();
-  world.appManager.clear();
-  world.appManager.bindState(state.getArray(appsMapName));
-  
-  playersManager.bindState(state.getArray(playersMapName));
-  
-  const localPlayer = getLocalPlayer();
-  localPlayer.bindState(state.getArray(playersMapName));
-  
-  // note: here we should load up the apps in the state since it won't happen automatically.
-  // until we implement that, only fresh state is supported...
-};
-world.isConnected = () => !!wsrtc;
-world.connectRoom = async u => {
-  // await WSRTC.waitForReady();
-  
-  const localPlayer = getLocalPlayer();
-
-  world.appManager.unbindState();
-  world.appManager.clear();
-
-  const state = new Z.Doc();
-  state.setResolvePriority(1);
-  wsrtc = new WSRTC(u, {
-    localPlayer,
-    crdtState: state,
-  });
-  const open = e => {
-    wsrtc.removeEventListener('open', open);
-    
-    world.appManager.bindState(state.getArray(appsMapName));
-    playersManager.bindState(state.getArray(playersMapName));
-    
-    const init = e => {
-      wsrtc.removeEventListener('init', init);
-      
-      localPlayer.bindState(state.getArray(playersMapName));
-      if (mediaStream) {
-        wsrtc.enableMic(mediaStream);
-      }
-    };
-    wsrtc.addEventListener('init', init);
-  };
-  wsrtc.addEventListener('open', open);
-
-  /* const sendUpdate = () => {
-    const rig = localPlayer.avatar;
-    if (rig) {
-      const {hmd, leftGamepad, rightGamepad} = rig.inputs;
-      const user = wsrtc.localUser;
-      
-      hmd.position.toArray(user.pose.position);
-      hmd.quaternion.toArray(user.pose.quaternion);
-      leftGamepad.position.toArray(extra.leftGamepadPosition);
-      leftGamepad.quaternion.toArray(extra.leftGamepadQuaternion);
-      extra.leftGamepad[0] = leftGamepad.pointer ? 1 : 0;
-      extra.leftGamepad[1] = leftGamepad.grip ? 1 : 0;
-      extra.leftGamepad[2] = leftGamepad.enabled ? 1 : 0;
-      rightGamepad.position.toArray(extra.rightGamepadPosition);
-      rightGamepad.quaternion.toArray(extra.rightGamepadPosition);
-      extra.rightGamepad[0] = rightGamepad.pointer ? 1 : 0;
-      extra.rightGamepad[1] = rightGamepad.grip ? 1 : 0;
-      extra.rightGamepad[2] = rightGamepad.enabled ? 1 : 0;
-      extra.attr[0] = rig.getFloorHeight() ? 1 : 0;
-      extra.attr[1] = rig.getTopEnabled() ? 1 : 0;
-      extra.attr[2] = rig.getBottomEnabled() ? 1 : 0;
-      rig.direction.toArray(extra.direction);
-      rig.velocity.toArray(extra.velocity);
-      extra.states[0] = rig.jumpState,
-      extra.states[1] = rig.jumpTime;
-      extra.states[2] = rig.flyState;
-      extra.states[3] = rig.flyTime;
-      extra.states[4] = rig.useTime;
-      extra.states[5] = rig.useAnimation;
-      extra.states[6] = rig.sitState;
-      extra.states[7] = rig.sitAnimation;
-      // extra.states[8] = rig.danceState;
-      extra.states[9] = rig.danceFactor;
-      extra.states[10] = rig.danceAnimation;
-      extra.states[11] = rig.throwState;
-      extra.states[12] = rig.throwTime;
-      extra.states[13] = rig.crouchState;
-      extra.states[14] = rig.crouchTime;
-
-      user.setPose(
-        user.pose.position,
-        user.pose.quaternion,
-        user.pose.scale,
-        [
-          extra.leftGamepadPosition,
-          extra.leftGamepadQuaternion,
-          extra.leftGamepad,
-          extra.rightGamepadPosition,
-          extra.rightGamepadQuaternion,
-          extra.rightGamepad,
-          extra.attr,
-          extra.direction,
-          extra.velocity,
-          extra.states,
-        ],
-      );
-    }
-  };
-  const sendMetadataUpdate = () => {
-    const localPlayer = metaversefileApi.useLocalPlayer();
-    const rig = localPlayer.avatar;
-    if (rig) {
-      wsrtc.localUser.setMetadata({
-        name,
-        avatarUrl: rig.app.contentId,
-      });
-    }
-  }; */
-
-  // const name = makeId(5);
-  // let interval, intervalMetadata;
-  wsrtc.addEventListener('open', async e => {
-    console.log('Channel Open!');
-
-    // interval = setInterval(sendUpdate, 10);
-    // intervalMetadata = setInterval(sendMetadataUpdate, 1000);
-    // wsrtc.enableMic();
-  }, {once: true});
-
-  wsrtc.addEventListener('close', e => {
-    console.log('Channel Close!');
-
-    /* const peerRigIds = rigManager.peerRigs.keys();
-    for (const peerRigId of peerRigIds) {
-      rigManager.removePeerRig(peerRigId);
-    }
-    if (interval) {
-      clearInterval(interval);
-    }
-    if (intervalMetadata) {
-      clearInterval(intervalMetadata);
-    } */
-  }, {once: true});
-
-  /* wsrtc.addEventListener('join', async e => {
-    const player = e.data;
-  
-    player.audioNode.connect(WSRTC.getAudioContext().destination);
-
-    let joined = true;
-    player.addEventListener('leave', async () => {
-      rigManager.removePeerRig(player.id);
-      joined = false;
-    });
-    let running = false;
-    const queue = [];
-    const _handleUpdate = async meta => {
-      if (!running) {
-        running = true;
-        if (joined) {
-          const peerRig = rigManager.peerRigs.get(player.id);
-          if (!peerRig) {
-            await rigManager.addPeerRig(player.id, meta);
-            const peerRig = rigManager.peerRigs.get(player.id);
-            if (joined) {
-              peerRig.peerConnection = player;
-            } else {
-              rigManager.removePeerRig(player.id);
-            }
-          } else {
-            if (typeof meta.name === 'string') {
-              // XXX set the name
-            }
-            if (typeof meta.avatarUrl === 'string') {
-              await rigManager.setPeerAvatarUrl(player.id, meta.avatarUrl);
-            }
-          }
-        }
-        running = false;
-        if (queue.length > 0) {
-          _handleUpdate(queue.pop());
-        }
-      } else {
-        queue.push(meta);
-      }
-    };
-    player.metadata.addEventListener('update', e => {
-      const meta = player.metadata.toJSON();
-      // console.log('meta', meta);
-      _handleUpdate(meta);
-    });
-    player.pose.addEventListener('update', e => {
-      rigManager.setPeerAvatarPose(player);
-    });
-  }); */
-
-  wsrtc.close = (close => function() {
-    close.apply(this, arguments);
-
-    wsrtc.dispatchEvent(new MessageEvent('close'));
-  })(wsrtc.close);
-
-  return wsrtc;
-};
-world.disconnectRoom = () => {
-  if (wsrtc) {
-    wsrtc.close();
-    wsrtc = null;
-
-    // world.clear();
-    // world.newState();
-  }
-};
-/* world.clear = () => {
-  appManager.clear();
-}; */
-/* world.save = () => {
-  return world.appManager.state.toJSON();
-}; */
 
 const _getBindSceneForRenderPriority = renderPriority => {
   switch (renderPriority) {
@@ -288,44 +16,40 @@ const _getBindSceneForRenderPriority = renderPriority => {
     case 'lowest': {
       return sceneLowestPriority;
     }
-    /* case 'postPerspectiveScene': {
-      return postScenePerspective;
-    }
-    case 'postOrthographicScene': {
-      return postSceneOrthographic;
-    } */
     default: {
       return scene;
     }
   }
 };
-const _bindHitTracker = app => {
-  const hitTracker = hpManager.makeHitTracker();
-  hitTracker.bind(app);
-  app.dispatchEvent({type: 'hittrackeradded'});
 
-  const die = () => {
-    world.appManager.removeTrackedApp(app.instanceId);
-  };
-  app.addEventListener('die', die);
-};
-appManager.addEventListener('appadd', e => {
-  const app = e.data;
-  const bindScene = _getBindSceneForRenderPriority(app.getComponent('renderPriority'));
-  bindScene.add(app);
+// Handles the world and objects in it, has an app manager just like a player
+export class World {
+  constructor() {
+    this.appManager = new AppManager();
+    this.winds = [];
+    // This handles adding apps to the world scene
+    this.appManager.addEventListener('appadd', e => {
+      const app = e.data;
+      const bindScene = _getBindSceneForRenderPriority(app.getComponent('renderPriority'));
+      bindScene.add(app);
 
-  _bindHitTracker(app);
-});
-appManager.addEventListener('trackedappmigrate', async e => {
-  const {app, sourceAppManager, destinationAppManager} = e.data;
-  if (this === sourceAppManager) {
-    app.hitTracker.unbind();
-  } else if (this === destinationAppManager) {
-    _bindHitTracker(app);
+      const hitTracker = hpManager.makeHitTracker();
+      hitTracker.bind(app);
+      app.dispatchEvent({type: 'hittrackeradded'});
+
+      const die = () => {
+        this.appManager.removeTrackedApp(app.instanceId);
+      };
+      app.addEventListener('die', die);
+    });
+
+    // This handles removal of apps from the scene when we leave the world
+    this.appManager.addEventListener('appremove', async e => {
+      const app = e.data;
+      app.hitTracker.unbind();
+      app.parent.remove(app);
+    });
   }
-});
-appManager.addEventListener('appremove', async e => {
-  const app = e.data;
-  app.hitTracker.unbind();
-  app.parent.remove(app);
-});
+}
+
+export const world = new World();


### PR DESCRIPTION
Multiplayer connection and disconnection was handled awkward between universe.js and world.js -- we don't want the multiplayer system to necessary be dependent on the lifecycle of the world object. This moves that functionality to universe.js, which also simplifies imports and calls elsewhere. Also made World a proper class object to be more inline with code elsewhere.

The player update will throw errors when joining or leaving the world, because this is going to be handled in a separate PR. The success for this PR is that you can join or leave a multiplayer room at all, since the functions we are moving are isConnected and getConnection checks.