### PR TITLE
Fix error where Remote Player tries to sync a null avatar when initialized

### DIFF
--- a/character-controller.js
+++ b/character-controller.js
@@ -1281,6 +1281,8 @@ class RemotePlayer extends InterpolatedPlayer {
     
     this.appManager.bindState(this.getAppsState());
     this.appManager.loadApps();
+    
+    this.syncAvatar();
   }
 }
 /* class StaticUninterpolatedPlayer extends UninterpolatedPlayer {

--- a/character-controller.js
+++ b/character-controller.js
@@ -1283,7 +1283,7 @@ class RemotePlayer extends InterpolatedPlayer {
     
     this.appManager.bindState(this.getAppsState());
     this.appManager.loadApps();
-    }
+  }
 }
 /* class StaticUninterpolatedPlayer extends UninterpolatedPlayer {
   constructor(opts) {

--- a/character-controller.js
+++ b/character-controller.js
@@ -696,6 +696,8 @@ class StatePlayer extends PlayerBase {
           }
         }
       }
+    } else {
+      throw new Error("Can't set avatar to instanceId that does not exist in any app manager");
     }
     
     this.syncAvatarCancelFn = null;
@@ -1281,9 +1283,7 @@ class RemotePlayer extends InterpolatedPlayer {
     
     this.appManager.bindState(this.getAppsState());
     this.appManager.loadApps();
-    
-    this.syncAvatar();
-  }
+    }
 }
 /* class StaticUninterpolatedPlayer extends UninterpolatedPlayer {
   constructor(opts) {

--- a/character-controller.js
+++ b/character-controller.js
@@ -696,8 +696,6 @@ class StatePlayer extends PlayerBase {
           }
         }
       }
-    } else {
-      _setNextAvatarApp(null);
     }
     
     this.syncAvatarCancelFn = null;

--- a/character-controller.js
+++ b/character-controller.js
@@ -696,8 +696,6 @@ class StatePlayer extends PlayerBase {
           }
         }
       }
-    } else {
-      throw new Error("Can't set avatar to instanceId that does not exist in any app manager");
     }
     
     this.syncAvatarCancelFn = null;

--- a/players-manager.js
+++ b/players-manager.js
@@ -80,7 +80,7 @@ class PlayersManager {
   }
   updateRemotePlayers(timestamp, timeDiff) {
     for (const remotePlayer of this.remotePlayers.values()) {
-      // remotePlayer.updateAvatar(timestamp, timeDiff);
+      remotePlayer.updateAvatar(timestamp, timeDiff);
     }
   }
 }

--- a/players-manager.js
+++ b/players-manager.js
@@ -80,7 +80,7 @@ class PlayersManager {
   }
   updateRemotePlayers(timestamp, timeDiff) {
     for (const remotePlayer of this.remotePlayers.values()) {
-      remotePlayer.updateAvatar(timestamp, timeDiff);
+      // remotePlayer.updateAvatar(timestamp, timeDiff);
     }
   }
 }


### PR DESCRIPTION
This fixes an error where the remote player tries to sync before their avatar has been created. This PR removes the syncAvatar from the constructor of the remove player, and adds a throw to check if this behavior happens. The remote player syncs their avatar from the avatar variable anyways.

Without this PR, an error will throw on the remote player. With this PR, there are no longer any errors.