### PR TITLE
Remove invalid call to updateAvatar on remote players

### DIFF
--- a/players-manager.js
+++ b/players-manager.js
@@ -78,11 +78,11 @@ class PlayersManager {
       this.unbindStateFn = this.playersArray.unobserve.bind(this.playersArray, playersObserveFn);
     }
   }
-  updateRemotePlayers(timestamp, timeDiff) {
-    for (const remotePlayer of this.remotePlayers.values()) {
-      remotePlayer.updateAvatar(timestamp, timeDiff);
-    }
-  }
+  // updateRemotePlayers(timestamp, timeDiff) {
+  //   for (const remotePlayer of this.remotePlayers.values()) {
+  //     remotePlayer.updateAvatar(timestamp, timeDiff);
+  //   }
+  // }
 }
 const playersManager = new PlayersManager();
 

--- a/webaverse.js
+++ b/webaverse.js
@@ -320,7 +320,7 @@ export default class Webaverse extends EventTarget {
           game.update(timestamp, timeDiffCapped);
           
           localPlayer.updateAvatar(timestamp, timeDiffCapped);
-          playersManager.updateRemotePlayers(timestamp, timeDiffCapped);
+          // playersManager.updateRemotePlayers(timestamp, timeDiffCapped);
           
           world.appManager.tick(timestamp, timeDiffCapped, frame);
 


### PR DESCRIPTION
This function doesn't exist on remotePlayers so it just throws an error. We are resolving in a future PR with modification of the observePlayersFn