### PR TITLE
Separate avatar velocity from avatar update loop

### DIFF
--- a/avatars/avatars.js
+++ b/avatars/avatars.js
@@ -1490,7 +1490,7 @@ class Avatar {
     localEuler.setFromQuaternion(currentQuaternion, 'YXZ');
     localEuler.set(0, -(localEuler.y + Math.PI), 0);
     positionDiff.applyEuler(localEuler);
-    this.velocity.copy(positionDiff).add(this.lastVelocity).divideScalar(2);
+    this.velocity.copy(positionDiff);
     this.lastVelocity.copy(this.velocity);
     this.direction.copy(positionDiff).normalize();
     this.lastPosition.copy(currentPosition);

--- a/avatars/avatars.js
+++ b/avatars/avatars.js
@@ -447,6 +447,12 @@ class Avatar {
     this.vrmExtension = object?.parser?.json?.extensions?.VRM;
     this.firstPersonCurves = getFirstPersonCurves(this.vrmExtension); 
 
+    // should the velocity be automatically updated?
+    // set to false on remote player _setNextAvatarApp()
+    // otherwise, can have weird behavior when remote avatar is moving
+    this.shouldUpdateVelocity = true;
+    this.lastVelocity = new THREE.Vector3();
+
     const {
       skinnedMeshes,
       skeleton,
@@ -1475,6 +1481,25 @@ class Avatar {
     }
   }
 
+  setVelocity(timeDiffS, lastPosition, currentPosition, currentQuaternion) {
+    // Set the velocity, which will be considered by the animation controller
+    const positionDiff = localVector.copy(lastPosition)
+      .sub(currentPosition)
+      .divideScalar(Math.max(timeDiffS, 0.001))
+      .multiplyScalar(0.1);
+    localEuler.setFromQuaternion(currentQuaternion, 'YXZ');
+    localEuler.set(0, -(localEuler.y + Math.PI), 0);
+    positionDiff.applyEuler(localEuler);
+    this.velocity.copy(positionDiff).add(this.lastVelocity).divideScalar(2);
+    this.lastVelocity.copy(this.velocity);
+    this.direction.copy(positionDiff).normalize();
+    this.lastPosition.copy(currentPosition);
+
+    if (this.velocity.length() > maxIdleVelocity) {
+      this.lastMoveTime = performance.now();
+    }
+  }
+
   update(timestamp, timeDiff) {
     const now = timestamp;
     const timeDiffS = timeDiff / 1000;
@@ -1491,27 +1516,11 @@ class Avatar {
     this.aimLeftFactor = this.aimLeftTransitionTime / aimTransitionMaxTime;
     this.aimLeftFactorReverse = 1 - this.aimLeftFactor;
 
-    const _updateHmdPosition = () => {
+    const _updateAvatarVelocity = () => {
       const currentPosition = this.inputs.hmd.position;
       const currentQuaternion = this.inputs.hmd.quaternion;
       
-      const positionDiff = localVector.copy(this.lastPosition)
-        .sub(currentPosition)
-        .divideScalar(timeDiffS)
-        .multiplyScalar(0.1);
-      localEuler.setFromQuaternion(currentQuaternion, 'YXZ');
-      localEuler.x = 0;
-      localEuler.z = 0;
-      localEuler.y += Math.PI;
-      localEuler2.set(-localEuler.x, -localEuler.y, -localEuler.z, localEuler.order);
-      positionDiff.applyEuler(localEuler2);
-      this.velocity.copy(positionDiff);
-      this.lastPosition.copy(currentPosition);
-      this.direction.copy(positionDiff).normalize();
-
-      if (this.velocity.length() > maxIdleVelocity) {
-        this.lastMoveTime = now;
-      }
+      this.setVelocity(timeDiffS, this.lastPosition, currentPosition, currentQuaternion);
     };
     
     const _overwritePose = poseName => {
@@ -1901,7 +1910,9 @@ class Avatar {
     
     
 
-    _updateHmdPosition();
+    if (this.shouldUpdateVelocity) {
+      _updateAvatarVelocity();
+    }
     _applyAnimation(this, now, moveFactors);
 
     if (this.poseAnimation) {

--- a/avatars/avatars.js
+++ b/avatars/avatars.js
@@ -1515,13 +1515,6 @@ class Avatar {
     this.aimRightFactorReverse = 1 - this.aimRightFactor;
     this.aimLeftFactor = this.aimLeftTransitionTime / aimTransitionMaxTime;
     this.aimLeftFactorReverse = 1 - this.aimLeftFactor;
-
-    const _updateAvatarVelocity = () => {
-      const currentPosition = this.inputs.hmd.position;
-      const currentQuaternion = this.inputs.hmd.quaternion;
-      
-      this.setVelocity(timeDiffS, this.lastPosition, currentPosition, currentQuaternion);
-    };
     
     const _overwritePose = poseName => {
       const poseAnimation = animations.index[poseName];
@@ -1908,10 +1901,15 @@ class Avatar {
       _motionControls.call(this)
     }
     
-    
-
+    // for the local player we want to update the velocity immediately
+    // on remote players this is called from the RemotePlayer -> observePlayerFn
     if (this.shouldUpdateVelocity) {
-      _updateAvatarVelocity();
+      this.setVelocity(
+        timeDiffS,
+        this.lastPosition,
+        this.inputs.hmd.position,
+        this.inputs.hmd.quaternion
+      );
     }
     _applyAnimation(this, now, moveFactors);
 

--- a/avatars/avatars.js
+++ b/avatars/avatars.js
@@ -410,7 +410,8 @@ class Avatar {
         },
       };
     }
-
+    
+    this.isLocalPlayer = options.isLocalPlayer !== undefined ? options.isLocalPlayer : true;
     this.object = object;
 
     const model = (() => {
@@ -447,10 +448,6 @@ class Avatar {
     this.vrmExtension = object?.parser?.json?.extensions?.VRM;
     this.firstPersonCurves = getFirstPersonCurves(this.vrmExtension); 
 
-    // should the velocity be automatically updated?
-    // set to false on remote player _setNextAvatarApp()
-    // otherwise, can have weird behavior when remote avatar is moving
-    this.shouldUpdateVelocity = true;
     this.lastVelocity = new THREE.Vector3();
 
     const {
@@ -1903,7 +1900,7 @@ class Avatar {
     
     // for the local player we want to update the velocity immediately
     // on remote players this is called from the RemotePlayer -> observePlayerFn
-    if (this.shouldUpdateVelocity) {
+    if (this.isLocalPlayer) {
       this.setVelocity(
         timeDiffS,
         this.lastPosition,

--- a/character-controller.js
+++ b/character-controller.js
@@ -662,8 +662,6 @@ class StatePlayer extends PlayerBase {
         
         if (this.isLocalPlayer) {
           physicsScene.disableGeometryQueries(this.characterController);
-        } else {
-          avatar.shouldUpdateVelocity = false;
         }
       })();
       

--- a/character-controller.js
+++ b/character-controller.js
@@ -662,6 +662,8 @@ class StatePlayer extends PlayerBase {
         
         if (this.isLocalPlayer) {
           physicsScene.disableGeometryQueries(this.characterController);
+        } else {
+          avatar.shouldUpdateVelocity = false;
         }
       })();
       

--- a/player-avatar-binding.js
+++ b/player-avatar-binding.js
@@ -7,6 +7,7 @@ import {unFrustumCull, enableShadows} from './util.js';
 import {
   getEyePosition,
 } from './avatars/util.mjs';
+import {getLocalPlayer} from './players.js';
 
 const appSymbol = 'app'; // Symbol('app');
 const avatarSymbol = 'avatar'; // Symbol('avatar');
@@ -51,18 +52,23 @@ export function applyPlayerModesToAvatar(player, session, rig) {
 export function makeAvatar(app) {
   if (app) {
     const {skinnedVrm} = app;
+
+    // get the local player
+    const isLocalPlayer = app.instanceId === getLocalPlayer().getAvatarInstanceId();
+
     if (skinnedVrm) {
       const avatar = new Avatar(skinnedVrm, {
+        isLocalPlayer,
         fingers: true,
         hair: true,
         visemes: true,
         debug: false,
       });
       avatar[appSymbol] = app;
-      
+
       unFrustumCull(app);
       enableShadows(app);
-      
+
       return avatar;
     }
   }


### PR DESCRIPTION
Right now we are updating the avatar velocity every frame.

The problem is that if we don't receive updated velocity information this frame we can get hiccups. The solution I have found is to update the velocity on remote avatars when the observer updates on transform calls, since any change in motion would necessitate a change in velocity. Also, this velocity is used to update the appearance of the avatar, nothing to do with position.