### PR TITLE
Destroy remote players when players-manger is unbound

### DIFF
--- a/players-manager.js
+++ b/players-manager.js
@@ -32,7 +32,9 @@ class PlayersManager {
     return this.playersArray;
   }
   unbindState() {
+    if(this.unbindStateFn != null) {
       this.unbindStateFn();
+    }
       this.playersArray = null;
       this.unbindStateFn = null;
     }

--- a/players-manager.js
+++ b/players-manager.js
@@ -14,27 +14,28 @@ class PlayersManager {
     
     this.unbindStateFn = null;
   }
-  getPlayersState() {
-    return this.playersArray;
-  }
-  unbindState() {
+  clearRemotePlayers() {
     const lastPlayers = this.playersArray;
     if (lastPlayers) {
       const playerSpecs = lastPlayers.toJSON();
       const nonLocalPlayerSpecs = playerSpecs.filter(p => {
         return p.playerId !== getLocalPlayer().playerId;
       });
-      // Destroy all remote players if they still exist
       for (const nonLocalPlayer of nonLocalPlayerSpecs) {
         const remotePlayer = this.remotePlayers.get(nonLocalPlayer.playerId);
         remotePlayer.destroy();
         this.remotePlayers.delete(nonLocalPlayer.playerId);
       }
+    }
+  }
+  getPlayersState() {
+    return this.playersArray;
+  }
+  unbindState() {
       this.unbindStateFn();
       this.playersArray = null;
       this.unbindStateFn = null;
     }
-  }
   bindState(nextPlayersArray) {
     this.unbindState();
     

--- a/players-manager.js
+++ b/players-manager.js
@@ -20,6 +20,16 @@ class PlayersManager {
   unbindState() {
     const lastPlayers = this.playersArray;
     if (lastPlayers) {
+      const playerSpecs = lastPlayers.toJSON();
+      const nonLocalPlayerSpecs = playerSpecs.filter(p => {
+        return p.playerId !== getLocalPlayer().playerId;
+      });
+      // Destroy all remote players if they still exist
+      for (const nonLocalPlayer of nonLocalPlayerSpecs) {
+        const remotePlayer = this.remotePlayers.get(nonLocalPlayer.playerId);
+        remotePlayer.destroy();
+        this.remotePlayers.delete(nonLocalPlayer.playerId);
+      }
       this.unbindStateFn();
       this.playersArray = null;
       this.unbindStateFn = null;

--- a/players-manager.js
+++ b/players-manager.js
@@ -5,6 +5,7 @@ player objects load their own avatar and apps using this binding */
 import * as Z from 'zjs';
 import {RemotePlayer} from './character-controller.js';
 import metaversefileApi from 'metaversefile';
+import {getLocalPlayer} from './players.js';
 
 class PlayersManager {
   constructor() {

--- a/universe.js
+++ b/universe.js
@@ -136,6 +136,7 @@ class Universe extends EventTarget {
   // This is called in single player mode instead of connectRoom
   connectState(state) {
     state.setResolvePriority(1);
+    playersManager.clearRemotePlayers();
     playersManager.bindState(state.getArray(playersMapName));
 
     world.appManager.unbindState();
@@ -169,9 +170,11 @@ class Universe extends EventTarget {
 
     // This is called when the websocket connection opens, i.e. server is connectedw
     const open = e => {
+      playersManager.clearRemotePlayers();
       this.wsrtc.removeEventListener('open', open);
       // Clear the last world state
       const appsArray = state.get(appsMapName, Z.Array);
+
       playersManager.bindState(state.getArray(playersMapName));
 
       // Unbind the world state to clear existing apps


### PR DESCRIPTION
The adds a handler function to destroy any remote players who might be in the scene when the user goes to leave the room.