### PR TITLE
Pets: Work for all players (remote, etc) and look at nearest player, not just local player

### DIFF
--- a/metaversefile-api.js
+++ b/metaversefile-api.js
@@ -956,6 +956,21 @@ export default () => {
   removeTrackedApp(app) {
     return world.appManager.removeTrackedApp.apply(world.appManager, arguments);
   },
+  getPlayerByAppInstanceId(instanceId) {
+    let result = localPlayer.appManager.getAppByInstanceId(instanceId);
+    if (result) {
+      return localPlayer;
+    } else {
+      const remotePlayers = useRemotePlayers();
+      for (const remotePlayer of remotePlayers) {
+        const remoteApp = remotePlayer.appManager.getAppByInstanceId(instanceId);
+        if (remoteApp) {
+          return remotePlayer;
+        }
+      }
+      return null;
+    }
+  },
   getAppByInstanceId(instanceId) {
     // local
     const localPlayer = getLocalPlayer();


### PR DESCRIPTION
Replaces https://github.com/webaverse/app/pull/3219

In the current implementation, pets can be offset from their root if they move. When this is fixed, the pet jumps to where the player placed them. This PR fixes that.

This also sets the player reference to the wearing player so pets work in multplayer. The pet will look at the nearest player, as well.

To test: wear and unwear fox in the shadows scene. To test multiplayer we'll need to have some other PRs pulled in, however since the pet now treats all players as equal this is effectively guaranteed.