### PR TITLE
Remove physics from RemotePlayer

### DIFF
--- a/character-controller.js
+++ b/character-controller.js
@@ -156,7 +156,6 @@ class PlayerBase extends THREE.Object3D {
 
     this.name = defaultPlayerName;
     this.bio = defaultPlayerBio;
-    this.characterPhysics = new CharacterPhysics(this);
     this.characterHups = new CharacterHups(this);
     this.characterSfx = new CharacterSfx(this);
     this.characterFx = new CharacterFx(this);
@@ -534,7 +533,6 @@ class PlayerBase extends THREE.Object3D {
     }
   }
   destroy() {
-    this.characterPhysics.destroy();
     this.characterHups.destroy();
     this.characterSfx.destroy();
     this.characterFx.destroy();
@@ -1000,6 +998,8 @@ class LocalPlayer extends UninterpolatedPlayer {
     this.isLocalPlayer = !opts.npc;
     this.isNpcPlayer = !!opts.npc;
     this.detached = !!opts.detached;
+
+    this.characterPhysics = new CharacterPhysics(this);
   }
   async setPlayerSpec(playerSpec) {
     const p = this.setAvatarUrl(playerSpec.avatarUrl);
@@ -1211,6 +1211,10 @@ class LocalPlayer extends UninterpolatedPlayer {
       this.characterHups.update(timestamp);
     }
   }
+  destroy(){
+    super.destroy();
+    this.characterPhysics.destroy();
+  }
   /* teleportTo = (() => {
     const localVector = new THREE.Vector3();
     const localVector2 = new THREE.Vector3();
@@ -1342,10 +1346,7 @@ class RemotePlayer extends InterpolatedPlayer {
           actionBinaryInterpolant.snapshot(timeDiff);
         }
 
-        this.characterPhysics.applyAvatarPhysicsDetail(true, true, timestamp, timeDiff / 1000);
-
         if(this.avatar) {
-          this.characterPhysics.setPosition(this.position);
           this.avatar.setVelocity(
             timeDiff / 1000,
             lastPosition,


### PR DESCRIPTION
Before, we had set up physics on LocalPlayer and RemotePlayer. After discussing with Avaer, we decided to only init CharacterPhysics on local players. This PR implements that as a separate PR to the other multiplayer PRs.