### PR TITLE
#3322 update readme to include minimum requirements to run

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ Developer documentation is <a href="https://docs.webaverse.com/docs/index">here<
 User documentation is <a href="https://webaverse.notion.site/User-Docs-3a36b223e39b4f94b3d1f6921a4c297a">here</a>
 </p>
 
+## Minimum Requirements
+
+8 GB Hard Drive space
+4 vCPUs
+8 GB Memory
+
 ## Installation
 
 **Important note before you clone this repo:** This repo uses Git submodules.


### PR DESCRIPTION
Adding minimum requirements to build and run the project. `esbuild` seemed to take up a few GBs of resources and as much CPU as it could (85% at times). This would eventually error out and not build correctly so requests to the server would fail or timeout. 