### PR TITLE
Fast instancing allocator

### DIFF
--- a/instancing.js
+++ b/instancing.js
@@ -195,7 +195,7 @@ export class GeometryAllocator {
 
     this.boundingType = boundingType;
 
-    this.positionFreeList = new FreeList(bufferSize * 3);
+    this.positionFreeList = new FreeList(bufferSize * 3, 3);
     this.indexFreeList = new FreeList(bufferSize);
 
     this.drawStarts = new Int32Array(maxNumDraws);

--- a/instancing.js
+++ b/instancing.js
@@ -114,28 +114,20 @@ export class FreeList {
     }
   }
   alloc(size) {
-    if (size > 0) {
-      const slotSize = _getClosestPowerOf2(size);
-      let slot = this.slots.get(slotSize);
-      if (slot === undefined) {
-        slot = new FreeListArray(slotSize, this);
-        this.slots.set(slotSize, slot);
-      }
-      const index = slot.alloc();
-      this.slotSizes.set(index, slotSize);
-
-      const entry = {
-        start: index,
-        count: size,
-      };
-      return entry;
-    } else {
-      debugger;
-      return {
-        start: 0,
-        count: 0,
-      };
+    const slotSize = _getClosestPowerOf2(size);
+    let slot = this.slots.get(slotSize);
+    if (slot === undefined) {
+      slot = new FreeListArray(slotSize, this);
+      this.slots.set(slotSize, slot);
     }
+    const index = slot.alloc();
+    this.slotSizes.set(index, slotSize);
+
+    const entry = {
+      start: index,
+      count: size,
+    };
+    return entry;
   }
   free(entry) {
     const {start: index} = entry;


### PR DESCRIPTION
This rewrites the instancing allocator implementation with three fundamental changes:

- Alignment is a first class concept, and needed for position buffers like the terrain.
- We no longer use a free list, but a set of circular buffers based on power-of-two sizing. This makes allocation and free O(1).
- We now return the address from `alloc()`, instead of a slot object. This helps GC pressure.