### PR TITLE
Fix `addConvexGeometry()` args mismatch issue.

### DIFF
--- a/physics-manager.js
+++ b/physics-manager.js
@@ -258,13 +258,15 @@ class PhysicsScene extends EventTarget {
     physicsMesh.updateMatrixWorld()
     return physicsObject
   }
-  addConvexGeometry(mesh) {
+  addConvexGeometry(mesh, dynamic = false, external = false) {
     const physicsMesh = convertMeshToPhysicsMesh(mesh)
   
     const physicsId = getNextPhysicsId()
     physx.physxWorker.addConvexGeometryPhysics(
       this.scene,
       physicsMesh,
+      dynamic,
+      external,
       physicsId
     )
     physicsMesh.geometry = this.extractPhysicsGeometryForId(physicsId)


### PR DESCRIPTION
The args mismatch will cause no `physicsId` arg send into `physx.physxWorker.addConvexGeometryPhysics()` function.