### PR TITLE
`addConvexShape()` auto push into `app.physicsObjects`.

### DIFF
--- a/metaversefile-api.js
+++ b/metaversefile-api.js
@@ -721,6 +721,12 @@ metaversefile.setApi({
         app.physicsObjects.push(physicsObject);
         return physicsObject;
       })(physicsScene.addConvexGeometry);
+      physicsScene.addConvexShape = (addConvexShape => function(mesh) {
+        const physicsObject = addConvexShape.apply(this, arguments);
+        // app.add(physicsObject);
+        app.physicsObjects.push(physicsObject);
+        return physicsObject;
+      })(physicsScene.addConvexShape);
       physicsScene.addCookedConvexGeometry = (addCookedConvexGeometry => function(buffer, position, quaternion, scale) {
         const physicsObject = addCookedConvexGeometry.apply(this, arguments);
         // app.add(physicsObject);


### PR DESCRIPTION
Replace `addConvexShape()` in `metaversefile-api.js`, to support auto push into `app.physicsObjects`.
The same way as `addConvexGeometry()`.