### PR TITLE
Fix `addCookedConvexGeometry()`.

### DIFF
--- a/physics-manager.js
+++ b/physics-manager.js
@@ -328,7 +328,9 @@ class PhysicsScene extends EventTarget {
     buffer,
     position,
     quaternion,
-    scale
+    scale,
+    dynamic = false,
+    external = false,
   ) {
     const physicsId = getNextPhysicsId()
     physx.physxWorker.addCookedConvexGeometryPhysics(
@@ -337,6 +339,8 @@ class PhysicsScene extends EventTarget {
       position,
       quaternion,
       scale,
+      dynamic,
+      external,
       physicsId
     )
   
@@ -379,7 +383,7 @@ class PhysicsScene extends EventTarget {
     physicsMesh.updateMatrixWorld()
     return physicsObject
   }
-  addConvexShape(shapeAddress, position, quaternion, scale, dynamic, external, physicsGeometry = null) {
+  addConvexShape(shapeAddress, position, quaternion, scale, dynamic = false, external = false, physicsGeometry = null) {
     const physicsId = getNextPhysicsId()
   
     physx.physxWorker.addConvexShapePhysics(

--- a/physx.js
+++ b/physx.js
@@ -1607,7 +1607,7 @@ const physxWorker = (() => {
     const scaleBuffer = scratchStack.f32.subarray(7, 10)
     scale.toArray(scaleBuffer)
 
-    const shape = Module._createShapePhysics(
+    const shape = Module._createConvexShapePhysics(
       physics,
       buffer2.byteOffset,
       buffer2.byteLength,


### PR DESCRIPTION
Follow: https://github.com/webaverse/app/pull/3353

Fix `addCookedConvexGeometry()` args mismatch, and wrongly called `Module._createShapePhysics()` not `Module._createConvexShapePhysics()` issues.