### PR TITLE
Fix remote player state (also fixes player messages)

### DIFF
--- a/app-manager.js
+++ b/app-manager.js
@@ -167,16 +167,106 @@ class AppManager extends EventTarget {
     }
     this.appsArray = nextAppsArray;
   }
-  loadApps() {
+  async loadApps() {
     for (let i = 0; i < this.appsArray.length; i++) {
       const trackedApp = this.appsArray.get(i, Z.Map);
-      this.dispatchEvent(new MessageEvent('trackedappadd', {
-        data: {
-          trackedApp,
-        },
-      }));
+      if(this.hasTrackedApp(trackedApp.get('instanceId'))) {
+        const app = this.apps.find(app => app.instanceId === trackedApp.get('instanceId'));
+        if(!app){
+          await this.importTrackedApp(trackedApp);
+        }
+      }
     }
   }
+  trackedAppBound (instanceId) {
+    return !!this.trackedAppUnobserveMap.get(instanceId)
+  }
+  
+  async importTrackedApp(trackedApp) {
+    const trackedAppBinding = trackedApp.toJSON();
+    const {instanceId, contentId, transform, components} = trackedAppBinding;
+    
+    const p = makePromise();
+    p.instanceId = instanceId;
+    this.pendingAddPromises.set(instanceId, p);
+
+    let live = true;
+    
+    const clear = e => {
+      live = false;
+      cleanup();
+    };
+    const cleanup = () => {
+      this.removeEventListener('clear', clear);
+      this.pendingAddPromises.delete(instanceId);
+    };
+    this.addEventListener('clear', clear);
+    const _bailout = app => {
+      // Add Error placeholder
+      const errorPH = this.getErrorPlaceholder();
+      if (app) {
+        errorPH.position.fromArray(app.position);
+        errorPH.quaternion.fromArray(app.quaternion);
+        errorPH.scale.fromArray(app.scale);
+      }
+      this.addApp(errorPH);
+
+      // Remove app
+      if (app) {
+        this.removeApp(app);
+        app.destroy();
+      }
+      p.reject(new Error('app cleared during load: ' + contentId));
+    };
+
+    // attempt to load app
+    try {
+      const m = await metaversefile.import(contentId);
+      if (!live) return _bailout(null);
+
+      // create app
+      // as an optimization, the app may be reused by calling addApp() before tracking it
+      const app = metaversefile.createApp();
+
+      // setup
+      {
+        // set pose
+        app.position.fromArray(transform);
+        app.quaternion.fromArray(transform, 3);
+        app.scale.fromArray(transform, 7);
+        app.updateMatrixWorld();
+        app.lastMatrix.copy(app.matrixWorld);
+
+        // set components
+        app.instanceId = instanceId;
+        app.setComponent('physics', true);
+        for (const {key, value} of components) {
+          app.setComponent(key, value);
+        }
+      }
+
+      // initialize app
+      {
+        // console.log('add module', m);
+        const mesh = await app.addModule(m);
+        if (!live) return _bailout(app);
+        if (!mesh) {
+          console.warn('failed to load object', {contentId});
+        }
+
+        this.addApp(app);
+      }
+
+      this.bindTrackedApp(trackedApp, app);
+
+      p.accept(app);
+    } catch (err) {
+      p.reject(err);
+    } finally {
+      cleanup();
+    }
+  }
+
   bindTrackedApp(trackedApp, app) {
     // console.log('bind tracked app', trackedApp.get('instanceId'));
     const _observe = (e, origin) => {
@@ -207,88 +297,7 @@ class AppManager extends EventTarget {
   bindEvents() {
     this.addEventListener('trackedappadd', async e => {
       const {trackedApp} = e.data;
-      const trackedAppBinding = trackedApp.toJSON();
-      const {instanceId, contentId, transform, components} = trackedAppBinding;
-      
-      const p = makePromise();
-      p.instanceId = instanceId;
-      this.pendingAddPromises.set(instanceId, p);
-
-      let live = true;
-      
-      const clear = e => {
-        live = false;
-        cleanup();
-      };
-      const cleanup = () => {
-        this.removeEventListener('clear', clear);
-        this.pendingAddPromises.delete(instanceId);
-      };
-      this.addEventListener('clear', clear);
-      const _bailout = app => {
-        // Add Error placeholder
-        const errorPH = this.getErrorPlaceholder();
-        if (app) {
-          errorPH.position.fromArray(app.position);
-          errorPH.quaternion.fromArray(app.quaternion);
-          errorPH.scale.fromArray(app.scale);
-        }
-        this.addApp(errorPH);
-
-        // Remove app
-        if (app) {
-          this.removeApp(app);
-          app.destroy();
-        }
-        p.reject(new Error('app cleared during load: ' + contentId));
-      };
-
-      // attempt to load app
-      try {
-        const m = await metaversefile.import(contentId);
-        if (!live) return _bailout(null);
-
-        // create app
-        // as an optimization, the app may be reused by calling addApp() before tracking it
-        const app = metaversefile.createApp();
-
-        // setup
-        {
-          // set pose
-          app.position.fromArray(transform);
-          app.quaternion.fromArray(transform, 3);
-          app.scale.fromArray(transform, 7);
-          app.updateMatrixWorld();
-          app.lastMatrix.copy(app.matrixWorld);
-
-          // set components
-          app.instanceId = instanceId;
-          app.setComponent('physics', true);
-          for (const {key, value} of components) {
-            app.setComponent(key, value);
-          }
-        }
-
-        // initialize app
-        {
-          // console.log('add module', m);
-          const mesh = await app.addModule(m);
-          if (!live) return _bailout(app);
-          if (!mesh) {
-            console.warn('failed to load object', {contentId});
-          }
-
-          this.addApp(app);
-        }
-
-        this.bindTrackedApp(trackedApp, app);
-
-        p.accept(app);
-      } catch (err) {
-        p.reject(err);
-      } finally {
-        cleanup();
-      }
+      this.importTrackedApp(trackedApp);
     });
     this.addEventListener('trackedappremove', async e => {
       const {instanceId, app} = e.data;
@@ -386,7 +395,7 @@ class AppManager extends EventTarget {
   }
   getTrackedApp(instanceId) {
     for (const app of this.appsArray) {
-      if (app.get('instanceId') === instanceId) {
+      if (app.instanceId || app.get('instanceId')) {
         return app;
       }
     }
@@ -394,7 +403,7 @@ class AppManager extends EventTarget {
   }
   hasTrackedApp(instanceId) {
     for (const app of this.appsArray) {
-      if (app.get('instanceId') === instanceId) {
+      if ((app.instanceId || app.get('instanceId')) === instanceId) {
         return true;
       }
     }

--- a/character-controller.js
+++ b/character-controller.js
@@ -584,7 +584,6 @@ class StatePlayer extends PlayerBase {
     this.unbindFns = [];
     
     this.transform = new Float32Array(7);
-
     this.bindState(playersArray);
   }
   isBound() {
@@ -650,13 +649,11 @@ class StatePlayer extends PlayerBase {
     
     // blindly add to new state
     this.playersArray = nextPlayersArray;
-    if (this.playersArray) {
-      this.attachState(oldState);
-      this.bindCommonObservers();
-    }
+    this.attachState(oldState);
+    this.bindCommonObservers();
   }
   getAvatarInstanceId() {
-    return this.playerMap?.get('avatar');
+    return this.playerMap.get('avatar');
   }
   // serializers
   getPosition() {
@@ -672,7 +669,6 @@ class StatePlayer extends PlayerBase {
     }
     const cancelFn = makeCancelFn();
     this.syncAvatarCancelFn = cancelFn;
-    
     const instanceId = this.getAvatarInstanceId();
     
     // remove last app
@@ -853,7 +849,7 @@ class StatePlayer extends PlayerBase {
       }
       
       const avatar = self.getAvatarInstanceId();
-      if (j?.avatar?.instanceId) {
+      if (avatar) {
         this.playerMap.set('avatar', avatar);
       }
       
@@ -1074,8 +1070,11 @@ class LocalPlayer extends UninterpolatedPlayer {
     const self = this;
     this.playersArray.doc.transact(function tx() {
       const oldInstanceId = self.playerMap.get('avatar');
-      
-      self.playerMap.set('avatar', app.instanceId);
+      if(app.instanceId){
+        self.playerMap.set('avatar', app.instanceId);
+      } else {
+        throw new Error('app.instanceId is null');
+      }
 
       if (oldInstanceId) {
         self.appManager.removeTrackedAppInternal(oldInstanceId);
@@ -1120,7 +1119,6 @@ class LocalPlayer extends UninterpolatedPlayer {
       self.playerMap = new Z.Map();
 
       self.appManager.bindState(self.getAppsState());
-      self.playersArray.push([self.playerMap]);
       self.playerMap.set('playerId', self.playerId);
 
       self.position.toArray(self.transform, 0);
@@ -1150,10 +1148,10 @@ class LocalPlayer extends UninterpolatedPlayer {
         const voiceSpec = JSON.stringify({audioUrl: self.voiceEndpoint.audioUrl, indexUrl: self.voiceEndpoint.indexUrl, endpointUrl: self.voiceEndpoint ? self.voiceEndpoint.url : ''});
         self.playerMap.set('voiceSpec', voiceSpec);
       }
+      self.playersArray.push([self.playerMap]);
     });
   }
   grab(app, hand = 'left') {
-    const localPlayer = metaversefile.useLocalPlayer();
     const {position, quaternion} = _getSession() ?
       localPlayer[hand === 'left' ? 'leftHand' : 'rightHand']
     :
@@ -1171,7 +1169,7 @@ class LocalPlayer extends UninterpolatedPlayer {
         .premultiply(localMatrix2.compose(position, quaternion, localVector.set(1, 1, 1)).invert())
         .toArray()
     };
-    localPlayer.addAction(grabAction);
+    this.addAction(grabAction);
     
     const physicsObjects = app.getPhysicsObjects();
     for (const physicsObject of physicsObjects) {
@@ -1222,12 +1220,15 @@ class LocalPlayer extends UninterpolatedPlayer {
   pushPlayerUpdates() {
     const self = this;
     this.playersArray.doc.transact(() => {
-      /* if (isNaN(this.position.x) || isNaN(this.position.y) || isNaN(this.position.z)) {
-        debugger;
-      } */
-      self.position.toArray(self.transform);      
-      self.quaternion.toArray(self.transform, 3);
-      self.playerMap.set('transform', self.transform);
+        /* if (isNaN(this.position.x) || isNaN(this.position.y) || isNaN(this.position.z)) {
+          debugger;
+        } */
+      if(!this.matrixWorld.equals(this.lastMatrix)) {
+        self.position.toArray(self.transform);      
+        self.quaternion.toArray(self.transform, 3);
+        self.playerMap.set('transform', self.transform);
+        this.matrixWorld.copy(this.lastMatrix)
+      }
     }, 'push');
 
     this.appManager.updatePhysics();
@@ -1353,7 +1354,7 @@ class RemotePlayer extends InterpolatedPlayer {
     if (index !== -1) {
       this.playerMap = this.playersArray.get(index, Z.Map);
     } else {
-      console.warn('binding to nonexistent player object', this.playersArray.toJSON());
+      throw new Error('binding to nonexistent player object', this.playersArray.toJSON());
     }
     let lastTimestamp = performance.now();
     let lastPosition = new THREE.Vector3();
@@ -1402,9 +1403,14 @@ class RemotePlayer extends InterpolatedPlayer {
     }
     this.playerMap.observe(observePlayerFn);
     this.unbindFns.push(this.playerMap.unobserve.bind(this.playerMap, observePlayerFn));
-
     this.appManager.bindState(this.getAppsState());
-    this.syncAvatar();
+    this.appManager.loadApps().then(() => {
+      if(!this.voicer || !this.voiceEndpoint){
+        let voiceSpec = JSON.parse(this.playerMap.get('voiceSpec'));
+        this.loadVoiceEndpoint(voiceSpec.endpointUrl);
+      }
+      this.syncAvatar();
+    });
   }
   update(timestamp, timeDiff) {
     if(!this.avatar) return // console.log("no avatar"); // avatar takes time to load, ignore until it does

--- a/players-manager.js
+++ b/players-manager.js
@@ -7,8 +7,9 @@ import {RemotePlayer} from './character-controller.js';
 import metaversefileApi from 'metaversefile';
 import {getLocalPlayer} from './players.js';
 
-class PlayersManager {
+class PlayersManager extends EventTarget {
   constructor() {
+    super();
     this.playersArray = null;
     
     this.remotePlayers = new Map();
@@ -73,6 +74,7 @@ class PlayersManager {
             });
             this.remotePlayers.set(playerId, remotePlayer);
             this.remotePlayersByInteger.set(remotePlayer.playerIdInt, remotePlayer);
+            this.dispatchEvent(new MessageEvent('playeradded', { data: { player: remotePlayer } }));
           }
         }
         // console.log('players observe', added, deleted);
@@ -88,6 +90,7 @@ class PlayersManager {
             this.remotePlayers.delete(playerId);
             this.remotePlayersByInteger.delete(remotePlayer.playerIdInt);
             remotePlayer.destroy();
+            this.dispatchEvent(new MessageEvent('playerremoved', { data: { player: remotePlayer } }));
           }
         }
       };

--- a/src/CharacterHups.jsx
+++ b/src/CharacterHups.jsx
@@ -178,6 +178,20 @@ export default function CharacterHups({
       remotePlayer.characterHups.addEventListener('hupremove', hupremove);
     }
 
+    const handlePlayerAdd = (e) => {
+      e.data.player.characterHups.addEventListener('hupadd', hupadd);
+      e.data.player.characterHups.addEventListener('hupremove', hupremove);
+
+    }
+
+    const handlePlayerRemove = (e) => {
+      e.data.player.characterHups.removeEventListener('hupadd', hupadd);
+      e.data.player.characterHups.removeEventListener('hupremove', hupremove);
+    }
+
+    playersManager.addEventListener('playeradded', handlePlayerAdd);
+    playersManager.addEventListener('playerremoved', handlePlayerRemove);
+
     return () => {
       localPlayer.characterHups.removeEventListener('hupadd', hupadd);
       localPlayer.characterHups.removeEventListener('hupremove', hupremove);


### PR DESCRIPTION
This PR makes sure that remote player state is synced, which fixes some reference bugs that were preventing hup messages from appearing. Remote players will call AppManager.loadApps, which will check if any trackedApps haven't been added to the player in the scene.