### PR TITLE
Added randomString() for instanceId

### DIFF
--- a/game.js
+++ b/game.js
@@ -25,7 +25,7 @@ import npcManager from './npc-manager.js';
 import raycastManager from './raycast-manager.js';
 import zTargeting from './z-targeting.js';
 import Avatar from './avatars/avatars.js';
-import {getRandomString} from './util.js';
+import {makeId} from './util.js';
 
 const localVector = new THREE.Vector3();
 const localVector2 = new THREE.Vector3();
@@ -1438,7 +1438,7 @@ class GameManager extends EventTarget {
     const app = await metaversefileApi.createAppAsync({
       start_url: u,
     });
-    app.instanceId = getRandomString();
+    app.instanceId = makeId(6);
     // this process "creates" a new app on what we currently have in inventory
     world.appManager.importApp(app);
     app.activate();

--- a/game.js
+++ b/game.js
@@ -25,6 +25,7 @@ import npcManager from './npc-manager.js';
 import raycastManager from './raycast-manager.js';
 import zTargeting from './z-targeting.js';
 import Avatar from './avatars/avatars.js';
+import {getRandomString} from './util.js';
 
 const localVector = new THREE.Vector3();
 const localVector2 = new THREE.Vector3();
@@ -1437,6 +1438,8 @@ class GameManager extends EventTarget {
     const app = await metaversefileApi.createAppAsync({
       start_url: u,
     });
+    app.instanceId = getRandomString();
+    // this process "creates" a new app on what we currently have in inventory
     world.appManager.importApp(app);
     app.activate();
     // XXX set to index


### PR DESCRIPTION
-Apps loaded from Equipment were created with an instanceId = '' (not setup)
-When searching by instance by Id, every object from the inventory matched instanceId = '', so it would return the first one it found (sword)
-Sword did not have the same functionality as mount, but had the same id, so it crashed the app trying to use sword as mount.