### PR TITLE
Fix clipped MegaHup

### DIFF
--- a/src/MegaHup.jsx
+++ b/src/MegaHup.jsx
@@ -13,18 +13,19 @@ import styles from './MegaHup.module.css';
 // const {useLocalPlayer} = metaversefile;
 // import {chatTextSpeed} from '../constants.js';
 
-const width = 400;
-
 const MegaHup = function({
   open = false,
   npcPlayer = null,
 }) {
   const [height, setHeight] = useState(window.innerHeight);
+  const [width, setWidth] = useState(window.innerWidth);
+
   const canvasRef = useRef();
 
   useEffect(() => {
     const resize = e => {
       setHeight(e.target.innerHeight);
+      setWidth(e.target.innerWidth);
     };
     window.addEventListener('resize', resize);
     return () => {
@@ -71,7 +72,7 @@ const MegaHup = function({
       world.appManager.addEventListener('frame', frame);
       const resize = e => {
         // console.log('diorama set size', width, window.innerHeight);
-        diorama.setSize(width, window.innerHeight);
+        diorama.setSize(window.innerWidth, window.innerHeight);
       };
       window.addEventListener('resize', resize);
 

--- a/src/MegaHup.module.css
+++ b/src/MegaHup.module.css
@@ -1,8 +1,8 @@
 .megaHup {
   display: flex;
   position: fixed;
-  top: 0;
-  right: 0;
+  top: -200px;
+  right: -35%;
   flex-direction: column;
   /* position: absolute;
   bottom: 30px;

--- a/src/components/general/character-select/CharacterSelect.jsx
+++ b/src/components/general/character-select/CharacterSelect.jsx
@@ -30,7 +30,7 @@ return '/@proxy/' + dataUrlPrefix + encodeURIComponent(content).replace(/\%/g, '
 
 //
 
-const userTokenCharacters = Array(7);
+const userTokenCharacters = Array(5);
 for (let i = 0; i < userTokenCharacters.length; i++) {
     userTokenCharacters[i] = {
         name: '',
@@ -408,6 +408,10 @@ export const CharacterSelect = () => {
             <div
                 className={classnames(styles.menu, opened ? styles.open : null)}
             >
+                <MegaHup
+                    open={opened}
+                    npcPlayer={opened ? npcPlayer : null}
+                />
                 <div className={styles.heading}>
                     <h1>Character select</h1>
                 </div>
@@ -462,11 +466,6 @@ export const CharacterSelect = () => {
             {(opened && text) ?
               <RpgText className={styles.text} styles={styles} text={text} textSpeed={chatTextSpeed} />
             : null}
-
-            <MegaHup
-              open={opened}
-              npcPlayer={opened ? npcPlayer : null}
-            />
         </div>
     );
 };


### PR DESCRIPTION
This PR fixes the clipping issues on the avatar selection canvas, and puts the avatar behind the tokens + inside the menu object so that the tokens are selectable even with the wider canvas.

So this fixes both the ugly hard clipping -- which is more apparent in the Cryptoavatars even -- and the layering when the winder is small.

Current:

![image](https://user-images.githubusercontent.com/18633264/181738152-d2346d06-d21a-4933-9ad7-4821d8f5260e.png)

Fixed:

![image](https://user-images.githubusercontent.com/18633264/181738257-fc8d3ff7-02f6-4057-a055-74cd26e16938.png)
