### PR TITLE
Fix double avatars for local in multiplayer room

### DIFF
--- a/character-controller.js
+++ b/character-controller.js
@@ -1118,7 +1118,6 @@ class LocalPlayer extends UninterpolatedPlayer {
     this.playersArray.doc.transact(function tx() {
       self.playerMap = new Z.Map();
 
-      self.appManager.bindState(self.getAppsState());
       self.playerMap.set('playerId', self.playerId);
 
       self.position.toArray(self.transform, 0);
@@ -1149,6 +1148,7 @@ class LocalPlayer extends UninterpolatedPlayer {
         self.playerMap.set('voiceSpec', voiceSpec);
       }
       self.playersArray.push([self.playerMap]);
+      self.appManager.bindState(self.getAppsState());
     });
   }
   grab(app, hand = 'left') {


### PR DESCRIPTION
On joining a multiplayer world, before:
![image](https://user-images.githubusercontent.com/18633264/181908924-9c4f0b06-18d4-4088-adff-11b6778fa4f0.png)


Now, after PR
![image](https://user-images.githubusercontent.com/18633264/181908945-c9154ddc-5e99-44ac-a4c8-0693e12fa303.png)
