### PR TITLE
Fix moving remove physics capsule

### DIFF
--- a/character-controller.js
+++ b/character-controller.js
@@ -1392,12 +1392,18 @@ class RemotePlayer extends InterpolatedPlayer {
           actionBinaryInterpolant.snapshot(timeDiff);
         }
 
-        this.avatar?.setVelocity(
-          timeDiff / 1000,
-          this.lastPosition,
-          this.positionInterpolant.get(),
-          this.quaternionInterpolant.get()
-          );
+        if(this.avatar){
+          localVector.copy(this.position);
+          localVector.y -= this.avatar.height * 0.5;
+          physicsScene.setCharacterControllerPosition(this.characterController, localVector);
+          
+          this.avatar.setVelocity(
+            timeDiff / 1000,
+            this.lastPosition,
+            this.positionInterpolant.get(),
+            this.quaternionInterpolant.get()
+            );
+          }
         this.lastPosition.copy(this.position);
       }
     }


### PR DESCRIPTION
When a remote player's position is updated, call setCharacterControllerPosition

To test: players in a multiplayer session should be able to bump into each other now.