### PR TITLE
Move mirror to metaverse module and update to work with latest three.js

### DIFF
--- a/scenes/street.scn
+++ b/scenes/street.scn
@@ -63,7 +63,7 @@
         0,
         -2
       ],
-      "start_url": "https://webaverse.github.io/mirror/"
+      "start_url": "../metaverse_modules/mirror/"
     },
     {
       "position": [
@@ -207,7 +207,7 @@
         0,
         0.7071067811865475
       ],
-      "start_url": "https://webaverse.github.io/physicscube/"
+      "start_url": "https://avaer.github.io/physicscube/"
     },
     {
       "position": [-2, 1, 1],


### PR DESCRIPTION
## Describe your changes
This PR makes the mirror a metaverse_module and updates to work properly with latest verison of three.js

## What are the steps for a QA tester to test this pull request?
This PR probably needs to be tested against the update-three branch
To test, check out this branch and view the mirror. Does it work?

## Issue ticket number and link
Part of this: https://github.com/webaverse/app/pull/3435

## Screenshots and/or video
n/a, just a mirror working

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I am not adding any irrelevant code or assets
- [x] I am only including the changes needed to implement the change
- [ ] I have playtested and intentionally tried to find error cases but couldn't
