### PR TITLE
traverse on app instead of glb.scene

### DIFF
--- a/character-physics.js
+++ b/character-physics.js
@@ -202,7 +202,7 @@ class CharacterPhysics {
 
         // Patch fix to fix vehicles and mounts for now
         let rideMesh = null;
-        controlledApp.glb.scene.traverse(o => {
+        controlledApp.traverse(o => {
           if (rideMesh === null && o.isSkinnedMesh) {
             rideMesh = o;
           }


### PR DESCRIPTION
## Describe your changes
-Changed from app.glb.scene.traverse to app.traverse to make sure it doesnt falls into null error.

-When creating a custom app with index.js, the app no longer contains app.glb property, so when it tries to access app.glb.scene it drops the error `Cannot read properties of undefined (reading 'scene')` breaking this part of the code

-We're using Object3D.traverse (https://threejs.org/docs/#api/en/core/Object3D.traverse) to find in any of the children a skinned mesh that contains a bone with sitbone component by name (also optional set by the user), directly in app.glb.scene.

-My suggestion is to use Object3D.traverse directly on the app (that is also an object3D), instead of trying it always on the .glb.scene (that will be null when an index is defined), this will avoid future issues.

## What are the steps for a QA tester to test this pull request?
1- load any mount that uses as start_url index.js instead of a .glb file
2- app will throw error

## Issue ticket number and link
#3458  

## Screenshots and/or video

Without Fix (app freezes)

https://user-images.githubusercontent.com/1117257/182714612-8cae9faa-0e52-492c-9404-ade85ac4fa2e.mp4

With Fix with an index.js file: (Im aware some errors are present, but this bugs/errors have to do with the plane app and not this specific bug )

https://user-images.githubusercontent.com/1117257/182714258-4795efdf-bae8-4071-bfbe-6ab0b5956ab3.mp4

With fix with a normal .glb file (hovercraft)

https://user-images.githubusercontent.com/1117257/182715251-b5b6a448-9591-4aaa-ac7f-7c04d5e98411.mp4


## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I am not adding any irrelevant code or assets
- [x] I am only including the changes needed to implement the change
- [ ] I have playtested and intentionally tried to find error cases but couldn't
