### PR TITLE
Avatar runs faster when tried with naruto run in crouch mode bug

### DIFF
--- a/game.js
+++ b/game.js
@@ -1623,7 +1623,7 @@ class GameManager extends EventTarget {
     }
     const localPlayer = playersManager.getLocalPlayer();
     const sprintMultiplier = (ioManager.keys.shift && !isCrouched) ?
-      (ioManager.keys.doubleTap ? 20 : 3)
+      (localPlayer.hasAction('narutoRun') ? 20 : 3)
     :
     ((isSwimming && !isFlying) ? 5 - localPlayer.getAction('swim').swimDamping : 1);
     speed *= sprintMultiplier;


### PR DESCRIPTION
Instead of using `ioManager.keys.doubleTap`, use narutoRun action to set the speed value.

related:
https://github.com/webaverse/app/issues/3461


Result:

https://user-images.githubusercontent.com/60634884/182724190-bbdc5743-ca25-4370-bcbc-cd0b598803d2.mp4


