### PR TITLE
app crashing while we try to open character panel

### DIFF
--- a/game.js
+++ b/game.js
@@ -1683,7 +1683,7 @@ class GameManager extends EventTarget {
       let neckBone;
       e.avatar.model.traverse(
         (object) => {
-          if (object.type === "Bone" && object.name === "Head") {
+          if (object.type === "Bone" && object.name.toUpperCase().includes("HEAD")) {
             return neckBone = object;
           }
         }


### PR DESCRIPTION
App would crash if the avatar does not have the bone name 'Head' when we create the diorama. Change it to search the bone name that include 'head'.

related:
https://github.com/webaverse/app/issues/3476

https://user-images.githubusercontent.com/60634884/182975033-a989014e-7747-4b8f-aed9-0b1d5be64200.mp4


