### PR TITLE
Dragon icon preview rotation bug

### DIFF
--- a/object-spriter.js
+++ b/object-spriter.js
@@ -112,10 +112,7 @@ const createObjectSpriteInternal = (app, {
       if (physicsObjects.length > 0) {
         const physicsObject = physicsObjects[0];
         const {physicsMesh} = physicsObject;
-        const box = physicsMesh.geometry.boundingBox.clone();
-        box.getCenter = () => app.position; //set box center to app position
-        fitCameraToBoundingBox(sideCamera, box, 1.2);
-        sideCamera.position.y += box.max.y / 2; //move camera position to object center
+        fitCameraToBoundingBox(sideCamera, physicsMesh.geometry.boundingBox, 1.2);
       } else {
         sideCamera.quaternion.setFromRotationMatrix(
           localMatrix.lookAt(

--- a/object-spriter.js
+++ b/object-spriter.js
@@ -112,7 +112,10 @@ const createObjectSpriteInternal = (app, {
       if (physicsObjects.length > 0) {
         const physicsObject = physicsObjects[0];
         const {physicsMesh} = physicsObject;
-        fitCameraToBoundingBox(sideCamera, physicsMesh.geometry.boundingBox, 1.2);
+        const box = physicsMesh.geometry.boundingBox.clone();
+        box.getCenter = () => app.position; //set box center to app position
+        fitCameraToBoundingBox(sideCamera, box, 1.2);
+        sideCamera.position.y += box.max.y / 2; //move camera position to object center
       } else {
         sideCamera.quaternion.setFromRotationMatrix(
           localMatrix.lookAt(

--- a/util.js
+++ b/util.js
@@ -710,7 +710,8 @@ export function getPlayerPrefix(playerId) {
 export function fitCameraToBoundingBox(camera, box, fitOffset = 1) {
   const size = box.getSize(localVector);
   const center = box.getCenter(localVector2);
-
+  center.x = 0;
+  center.z = 0;
   const maxSize = Math.max(size.x, size.y, size.z);
   const fitHeightDistance =
     maxSize / (2 * Math.atan((Math.PI * camera.fov) / 360));


### PR DESCRIPTION
This issue is caused by that the origin of dragon glb is not set to geometry center.  In this PR, I set bounding box center to app position in `object-spriter.js`.

related:
https://github.com/webaverse/app/issues/3501

Result:

https://user-images.githubusercontent.com/60634884/183229241-f1e52d21-1f4b-479d-a4fa-f4a2b4fab58b.mp4


