### PR TITLE
Scene settings manager + option to disable flying and naruto run in scenes

### DIFF
--- a/game.js
+++ b/game.js
@@ -26,6 +26,7 @@ import raycastManager from './raycast-manager.js';
 import zTargeting from './z-targeting.js';
 import Avatar from './avatars/avatars.js';
 import {makeId} from './util.js'
+import sceneSettingsManager from './scenesettings-manager.js';
 
 const localVector = new THREE.Vector3();
 const localVector2 = new THREE.Vector3();
@@ -1354,7 +1355,8 @@ class GameManager extends EventTarget {
   }
 
   menuDoubleTap() {
-    if (!this.isCrouched()) {
+    const sceneSettings = sceneSettingsManager.getSceneSettings();
+    if (sceneSettings.allowNarutoRun && !this.isCrouched()) {
       const localPlayer = playersManager.getLocalPlayer();
       const narutoRunAction = localPlayer.getAction('narutoRun');
       if (!narutoRunAction) {
@@ -1406,14 +1408,17 @@ class GameManager extends EventTarget {
         localPlayer.setControlAction({type: 'fallLoop'});
       }
     } else {
-      const flyAction = {
-        type: 'fly',
-        time: 0,
-      };
+      const sceneSettings = sceneSettingsManager.getSceneSettings();
+      if (sceneSettings.allowFlying) {
+        const flyAction = {
+          type: 'fly',
+          time: 0,
+        };
 
-      _unwearAppIfHasSitComponent(localPlayer);
+        _unwearAppIfHasSitComponent(localPlayer);
 
-      localPlayer.setControlAction(flyAction);
+        localPlayer.setControlAction(flyAction);
+      }
     }
   }
   isCrouched() {

--- a/metaversefile-api.js
+++ b/metaversefile-api.js
@@ -1221,8 +1221,8 @@ export default () => {
   async addModule(app, m) {
     // wait to make sure module initialization happens in a clean tick loop,
     // even when adding a module from inside of another module's initialization
-
     await Promise.resolve();
+
     app.name = m.name ?? (m.contentId ? m.contentId.match(/([^\/\.]*)$/)[1] : '');
     app.description = m.description ?? '';
     app.appType = m.type ?? '';

--- a/metaversefile-api.js
+++ b/metaversefile-api.js
@@ -41,6 +41,7 @@ import * as procgen from './procgen/procgen.js';
 import {getHeight} from './avatars/util.mjs';
 import performanceTracker from './performance-tracker.js';
 import renderSettingsManager from './rendersettings-manager.js';
+import sceneSettingsManager from './scenesettings-manager.js';
 import questManager from './quest-manager.js';
 import {murmurhash3} from './procgen/murmurhash3.js';
 import debug from './debug.js';
@@ -174,6 +175,9 @@ class App extends THREE.Object3D {
     } else {
       return null;
     }
+  }
+  getSceneSettings() {
+    return sceneSettingsManager;
   }
   activate({
     physicsId = -1,
@@ -386,6 +390,9 @@ metaversefile.setApi({
   },
   useRenderSettings() {
     return renderSettingsManager;
+  },
+  useSceneSettingsManager() {
+    return sceneSettingsManager;
   },
   useScene() {
     return scene;
@@ -1214,8 +1221,8 @@ export default () => {
   async addModule(app, m) {
     // wait to make sure module initialization happens in a clean tick loop,
     // even when adding a module from inside of another module's initialization
-    await Promise.resolve();
 
+    await Promise.resolve();
     app.name = m.name ?? (m.contentId ? m.contentId.match(/([^\/\.]*)$/)[1] : '');
     app.description = m.description ?? '';
     app.appType = m.type ?? '';

--- a/scenes/scenesettings.scn
+++ b/scenes/scenesettings.scn
@@ -1,0 +1,74 @@
+{
+  "objects": [
+    {
+      "type": "application/light",
+      "content": {
+        "lightType": "ambient",
+        "args": [[255, 255, 255], 2]
+      }
+    },
+    {
+      "type": "application/light",
+      "content": {
+        "lightType": "directional",
+        "args": [[255, 255, 255], 2],
+        "position": [1, 2, 3]
+      }
+    },
+    {
+      "position": [
+        0,
+        0,
+        0
+      ],
+      "start_url": "https://webaverse.github.io/street-base/"
+    },
+    {
+      "position": [
+        0,
+        0,
+        0
+      ],
+      "start_url": "https://webaverse.github.io/street/"
+    },
+    {
+      "type": "application/scenesettings",
+      "content": {
+        "allowFlying": false,
+        "allowNarutoRun": false
+      }
+    },
+    {
+      "type": "application/rendersettings",
+      "content": {
+        "fog": {
+          "fogType": "exp",
+          "args": [[255, 255, 255], 0.01]
+        },
+        "ssao": {
+          "kernelRadius": 16,
+          "minDistance": 0.005,
+          "maxDistance": 0.1
+        },
+        "dof": {
+          "focus": 2.0,
+          "aperture": 0.0001,
+          "maxblur": 0.005
+        },
+        "hdr": {
+          "adaptive": true,
+          "resolution": 256,
+          "adaptionRate": 100,
+          "maxLuminance": 10,
+          "minLuminance": 0,
+          "middleGrey": 3
+        },
+        "bloom": {
+          "strength": 0.1,
+          "radius": 0.5,
+          "threshold": 0.9
+        }
+      }
+    }
+  ]
+}

--- a/scenes/street.scn
+++ b/scenes/street.scn
@@ -219,5 +219,9 @@
       "quaternion": [0, 0.7071067811865475, 0, 0.7071067811865476],
       "start_url": "https://webaverse.github.io/helm/"
     }
-  ]
+  ],
+  "settings": {
+    "noFly": true,
+    "noNarutoRun": true
+  }
 }

--- a/scenes/street.scn
+++ b/scenes/street.scn
@@ -219,9 +219,5 @@
       "quaternion": [0, 0.7071067811865475, 0, 0.7071067811865476],
       "start_url": "https://webaverse.github.io/helm/"
     }
-  ],
-  "settings": {
-    "noFly": true,
-    "noNarutoRun": true
-  }
+  ]
 }

--- a/scenesettings-manager.js
+++ b/scenesettings-manager.js
@@ -1,0 +1,23 @@
+class SceneSettings {
+  constructor(json) {
+    this.allowFlying = json.allowFlying ?? true;
+    this.allowNarutoRun = json.allowNarutoRun ?? true;
+  }
+}
+
+class SceneSettingsManager {
+  constructor() {
+    this.sceneSettings = new SceneSettings({});
+  }
+
+  makeSceneSettings(json) {
+    this.sceneSettings = new SceneSettings(json);
+    return this.sceneSettings;
+  }
+
+  getSceneSettings() {
+    return this.sceneSettings;
+  }
+}
+const sceneSettingsManager = new SceneSettingsManager();
+export default sceneSettingsManager;


### PR DESCRIPTION
## Describe your changes
Adds an "application/scenesettings" totum template, which currently handles "allowFlying" and "allowNarutoRun"
This has been requested by multiple creators, since they don't want people noclipping their world

## What are the steps for a QA tester to test this pull request?
Checkout this PR. Normal scenes with no scenesettings should default to same behavior as before -- you can fly and naruto run
Now go to this link: https://local.webaverse.com/?src=.%2Fscenes%2Fsscenesettings.scn

## Issue ticket number and link
https://github.com/webaverse/app/issues/3109
Overwrites this PR: https://github.com/webaverse/app/pull/3348

## Screenshots and/or video

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I am not adding any irrelevant code or assets
- [x] I am only including the changes needed to implement the change
- [x] I have playtested and intentionally tried to find error cases but couldn't
