### PR TITLE
Adding actionability for "jump" action in vehicles

### DIFF
--- a/character-controller.js
+++ b/character-controller.js
@@ -397,17 +397,14 @@ class PlayerBase extends THREE.Object3D {
       };
       _transplantNewApp();
 
-      const _disableAppPhysics = () => {
-        // don't disable physics if the app is a pet
-        if (!app.hasComponent('pet')) {
-          const physicsObjects = app.getPhysicsObjects();
-          for (const physicsObject of physicsObjects) {
-            physicsScene.disableGeometryQueries(physicsObject);
-            physicsScene.disableGeometry(physicsObject);
-          }
+      const _initPhysics = () => {
+        const physicsObjects = app.getPhysicsObjects();
+        for (const physicsObject of physicsObjects) {
+          physicsScene.disableGeometryQueries(physicsObject);
+          physicsScene.disableGeometry(physicsObject);
         }
       };
-      _disableAppPhysics();
+      _initPhysics();
 
       const wearComponent = app.getComponent('wear');
       const holdAnimation = wearComponent? wearComponent.holdAnimation : null;

--- a/game.js
+++ b/game.js
@@ -74,7 +74,7 @@ const _unwearAppIfHasSitComponent = (player) => {
     const app = metaversefileApi.getAppByInstanceId(instanceId);
     const hasSitComponent = app.hasComponent('sit');
     if (hasSitComponent) {
-        app.unwear();
+      app.unwear();
     }
   }
 }


### PR DESCRIPTION
## Describe your changes
This PR adds the option to enable "jump" action on vehicles ( sittable apps )
"jumpable" component can be added to the .metaversefile of vehicle apps
```   
{
  "key" : "jumpable",
  "value" : true
},
```
The default value of this component is false

**if you don't add this component/set it to false you can not** jump when you're sitting on a vehicle, if you set "jumpable" to "true" : you should be able to jump when you're sitting on a vehicle and that automatically drops the vehicle

## What are the steps for a QA tester to test this pull request?
Add the component that is mentioned above to a vehicle's metaversfile and set it to true/false and test to see if the gameplay matches.

## Issue ticket number and link
Related : https://github.com/webaverse/app/pull/3524

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I am not adding any irrelevant code or assets
- [x] I am only including the changes needed to implement the change
- [x] I have playtested and intentionally tried to find error cases but couldn't
