### PR TITLE
validate no use action before dance action

### DIFF
--- a/game.js
+++ b/game.js
@@ -387,6 +387,7 @@ const _startUse = () => {
     const useComponent = wearApp.getComponent('use');
     if (useComponent) {
       const localPlayer = playersManager.getLocalPlayer();
+      localPlayer.removeAction('dance');
       const useAction = localPlayer.getAction('use');
       if (!useAction) {
         const {instanceId} = wearApp;
@@ -1293,13 +1294,16 @@ class GameManager extends EventTarget {
     if (_getGrabbedObject(0)) {
       this.menuGridSnap();
     } else {
-      localPlayer.removeAction('dance');
+      const useAction = localPlayer.getAction('use');
+      if (!useAction){
+        localPlayer.removeAction('dance');
 
-      const newAction = {
-        type: 'dance',
-        animation: 'dansu',
-      };
-      localPlayer.addAction(newAction);
+        const newAction = {
+          type: 'dance',
+          animation: 'dansu',
+        };
+        localPlayer.addAction(newAction);
+      }
     }
   }
   menuVUp() {


### PR DESCRIPTION
## Describe your changes
1- Check if objects are not currently being used to trigger 'dance' animation when user press and holds 'v' key
2- Also, In case player is dancing and presses mouse button, it will give more importance to use action (it will stop dancing and switch to use action)

## What are the steps for a QA tester to test this pull request?
1- Equip any weapon
2- Press and hold 'v' to dance
3- Click with mouse
= Player stops dancing and uses the objects he is holding

1- Equip any weapon
2- Click with mouse and hold
3- Press and hold 'v'
= Player will continue doing the object action, giving priority over dance action

## Issue ticket number and link
#3509 

## Screenshots and/or video

https://user-images.githubusercontent.com/1117257/183310840-886af42f-aca2-4f0f-80c3-fcb6fb12fd96.mp4

https://user-images.githubusercontent.com/1117257/183310837-af6439b9-71df-4117-aa8b-273144bd7ab3.mp4

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I am not adding any irrelevant code or assets
- [x] I am only including the changes needed to implement the change
- [x] I have playtested and intentionally tried to find error cases but couldn't
