### PR TITLE
Fix tilde grab for physics cube

### DIFF
--- a/character-controller.js
+++ b/character-controller.js
@@ -1171,11 +1171,12 @@ class LocalPlayer extends UninterpolatedPlayer {
     };
     this.addAction(grabAction);
     
-    const physicsObjects = app.getPhysicsObjects();
-    for (const physicsObject of physicsObjects) {
-      //physicsScene.disableGeometry(physicsObject);
-      physicsScene.disableGeometryQueries(physicsObject);
-    }
+    physicsScene.disableAppPhysics(app)
+    // const physicsObjects = app.getPhysicsObjects();
+    // for (const physicsObject of physicsObjects) {
+    //   physicsScene.disableGeometry(physicsObject);
+    //   physicsScene.disableGeometryQueries(physicsObject);
+    // }
 
     app.dispatchEvent({
       type: 'grabupdate',
@@ -1189,10 +1190,12 @@ class LocalPlayer extends UninterpolatedPlayer {
       const action = actions[i];
       if (action.type === 'grab') {
         const app = metaversefile.getAppByInstanceId(action.instanceId);
-        const physicsObjects = app.getPhysicsObjects();
-        for (const physicsObject of physicsObjects) {
-          physicsScene.enableGeometryQueries(physicsObject);
-        }
+
+        physicsScene.enableAppPhysics(app)
+        // const physicsObjects = app.getPhysicsObjects();
+        // for (const physicsObject of physicsObjects) {
+        //   physicsScene.enableGeometryQueries(physicsObject);
+        // }
         this.removeActionIndex(i + removeOffset);
         removeOffset -= 1;
 

--- a/character-controller.js
+++ b/character-controller.js
@@ -1172,11 +1172,6 @@ class LocalPlayer extends UninterpolatedPlayer {
     this.addAction(grabAction);
     
     physicsScene.disableAppPhysics(app)
-    // const physicsObjects = app.getPhysicsObjects();
-    // for (const physicsObject of physicsObjects) {
-    //   physicsScene.disableGeometry(physicsObject);
-    //   physicsScene.disableGeometryQueries(physicsObject);
-    // }
 
     app.dispatchEvent({
       type: 'grabupdate',
@@ -1192,10 +1187,7 @@ class LocalPlayer extends UninterpolatedPlayer {
         const app = metaversefile.getAppByInstanceId(action.instanceId);
 
         physicsScene.enableAppPhysics(app)
-        // const physicsObjects = app.getPhysicsObjects();
-        // for (const physicsObject of physicsObjects) {
-        //   physicsScene.enableGeometryQueries(physicsObject);
-        // }
+
         this.removeActionIndex(i + removeOffset);
         removeOffset -= 1;
 

--- a/physics-manager.js
+++ b/physics-manager.js
@@ -427,6 +427,20 @@ class PhysicsScene extends EventTarget {
   disableActor(physicsObject) {
     physx.physxWorker.disableActorPhysics(this.scene, physicsObject.physicsId)
   }
+  enableAppPhysics(app){
+    const physicsObjects = app.getPhysicsObjects();
+    for (let i = 0; i < physicsObjects.length; i++) {
+      const physicsObject = physicsObjects[i]
+      this.enableActor(physicsObject);
+    } 
+  }
+  disableAppPhysics(app){
+    const physicsObjects = app.getPhysicsObjects();
+    for (let i = 0; i < physicsObjects.length; i++) {
+      const physicsObject = physicsObjects[i]
+      this.disableActor(physicsObject);
+    } 
+  }
   disableGeometry(physicsObject) {
     physx.physxWorker.disableGeometryPhysics(
       this.scene,


### PR DESCRIPTION
## Describe your changes
1- Created 2 new function in physicsManager to enable or disable physics in desired app:
    - This functions enable/disable the physics actors of every physics object that the app has to stop them from being calculated
    
2- Called this functions when grabbing/ungrabbing objects instead of deactivating geometry to also include non geometry colliders (in this case box colliders too)

## What are the steps for a QA tester to test this pull request?
1- go to street.scn
2- press `tilde` to enter edit mode
3- click on "physics cube" and move it around (you should be able to move it without problem)
4- click again to release the cube
5- the cube will fall 

## Issue ticket number and link
#3533

## Screenshots and/or video

https://user-images.githubusercontent.com/1117257/183537844-c42ba2b7-e0c4-48a3-b234-8df92eb552ce.mp4

I also tested on other objects to check if activating/deactivating actors affected them, and it doesnt.

https://user-images.githubusercontent.com/1117257/183537950-239c4667-d71f-4d47-8e3c-a79dd00e9b3a.mp4

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I am not adding any irrelevant code or assets
- [x] I am only including the changes needed to implement the change
- [x] I have playtested and intentionally tried to find error cases but couldn't
- [x] But I still wish someone to make some local tests just to be sure there is no regression :)
