### PR TITLE
Disable character intro when the avatar selection menu is closed.

### DIFF
--- a/src/components/general/character-select/CharacterSelect.jsx
+++ b/src/components/general/character-select/CharacterSelect.jsx
@@ -355,6 +355,7 @@ export const CharacterSelect = () => {
             setEnabled(false);
         }
         if (!opened) {
+            setNpcPlayer(null);
             setHighlightCharacter(null);
             setSelectCharacter(null);
             setArrowPosition(null);


### PR DESCRIPTION
## Describe your changes
-set the npcPlayer state to null when the menu closes so the preview will be reset.
## What are the steps for a QA tester to test this pull request?
-Open the avatar selection menu, hover over some characters until the preview shows, close the menu and reopen it, the preview should not be active until you hover over some characters again and see the preview show up.
## Issue ticket number and link
https://github.com/webaverse/app/issues/3363
## Screenshots and/or video

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I am not adding any irrelevant code or assets
- [x] I am only including the changes needed to implement the change
- [x] I have playtested and intentionally tried to find error cases but couldn't
