### PR TITLE
Formalize same UI for 'inventory' and 'From upstreet' items

### DIFF
--- a/src/components/general/equipment/equipment.module.css
+++ b/src/components/general/equipment/equipment.module.css
@@ -154,6 +154,9 @@
   flex-direction: column;
   cursor: pointer;
   user-select: none;
+  margin: 0 15px 15px 0;
+  width: 100px;
+  background-color: #333333;
 }
 .object .background,
 .object .highlight
@@ -209,14 +212,19 @@
 .object .level
 {
   font-family: 'PlazaRegular';
+  margin-top: 8px;
 }
 .object .name {
   margin-right: auto;
-  font-size: 18px;
+  font-size: 14px;
 }
 .object .level {
-  font-size: 13px;
-  color: #666;
+  font-size: 12px;
+  color: #999;
+}
+
+.object.highlighted .level {
+  color: #DDD;
 }
 
 /* */


### PR DESCRIPTION
## Describe your changes
- made both lists in the inventory and upstream to look the same have similar structure so we are consistent with the design. Only difference is the highlight.
## What are the steps for a QA tester to test this pull request?
- find some items to add to your claims list and check both lists, inventory and from upstream in the account tab. Both lists should be the same in structure with color differance.
## Issue ticket number and link
https://github.com/webaverse/app/issues/3388
## Screenshots and/or video
<img width="472" alt="Screen Shot 2022-08-09 at 19 51 06" src="https://user-images.githubusercontent.com/55106546/183700331-aad62a2e-b072-4a9a-b42c-9576f925ff74.png">
<img width="476" alt="Screen Shot 2022-08-09 at 19 51 16" src="https://user-images.githubusercontent.com/55106546/183700337-0c7dc101-5ac6-4444-8613-4a5457c9bf92.png">

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I am not adding any irrelevant code or assets
- [x] I am only including the changes needed to implement the change
- [x] I have playtested and intentionally tried to find error cases but couldn't
