### PR TITLE
darkness bug

### DIFF
--- a/app-manager.js
+++ b/app-manager.js
@@ -633,7 +633,7 @@ class AppManager extends EventTarget {
         const _updatePhysicsObjects = () => {
           // update attached physics objects with a relative transform
           const physicsObjects = app.getPhysicsObjects();
-          if (physicsObjects.length > 0) {
+          if (physicsObjects.length > 0 && !app.isGroupComponent) {
             const lastMatrixInverse = localMatrix.copy(app.lastMatrix).invert();
 
             for (const physicsObject of physicsObjects) {

--- a/metaverse_components/pet.js
+++ b/metaverse_components/pet.js
@@ -68,8 +68,7 @@ export default (app, component) => {
   };
   app.addEventListener('wearupdate', e => {
     if (e.wear) {
-      // player = getPlayerByAppInstanceId(app.instanceId);
-      player = e.player;
+      player = e.player
       if (app.glb) {
         const {animations} = app.glb;
         

--- a/metaverse_components/pet.js
+++ b/metaverse_components/pet.js
@@ -68,7 +68,8 @@ export default (app, component) => {
   };
   app.addEventListener('wearupdate', e => {
     if (e.wear) {
-      player = getPlayerByAppInstanceId(app.instanceId);
+      // player = getPlayerByAppInstanceId(app.instanceId);
+      player = e.player;
       if (app.glb) {
         const {animations} = app.glb;
         


### PR DESCRIPTION
Sibling: https://github.com/webaverse/totum/pull/128

In darkness scene, we cannot equip the group object (lantern and fairy) because the physic is updated twice in app-manager (group app and subApp). So I add `isGroupComponent` for the subApp.
And In darkness scene, we could not equip the pet because the app is in the `world.appManager.apps` But we searched the app in `localPlayer.appManager.apps`.  https://github.com/webaverse/app/blob/ec8d75f24aed0787a518fbf0e665ced093deee93/metaversefile-api.js#L974

related: https://github.com/webaverse/app/issues/2995

result:

https://user-images.githubusercontent.com/60634884/184435203-2d3ef08e-7df6-42ae-87b2-3b2fe9bdf792.mp4


