### PR TITLE
3394 notification popup for actions

### DIFF
--- a/src/PopupNotification.jsx
+++ b/src/PopupNotification.jsx
@@ -1,0 +1,36 @@
+import * as React from "react";
+import styles from "./PopupNotification.module.css";
+import { AppContext } from "./components/app";
+
+const PopupNotification = function ({
+  popupNotification
+}) {
+  const ref = React.useRef();
+  const { setPopupNotification } = React.useContext( AppContext );
+
+  React.useEffect(() => {
+  if(popupNotification) {
+    ref.current.style.opacity = 1;
+  }
+}, [popupNotification])
+
+  React.useEffect(() => {
+    if(popupNotification) {
+      const timeout = setTimeout(() => {
+        ref.current.style.opacity = 0;
+        setPopupNotification(null);
+      }, 5000)
+      return () => {
+        clearTimeout(timeout);
+      };
+    }
+  }, [popupNotification])
+  return (
+    <>
+      {popupNotification && (
+        <div ref={ref} className={styles.popupNotificationWrap}>{popupNotification}</div>
+      )}
+    </>
+  );
+};
+export { PopupNotification };

--- a/src/PopupNotification.jsx
+++ b/src/PopupNotification.jsx
@@ -16,12 +16,15 @@ const PopupNotification = function ({
 
   React.useEffect(() => {
     if(popupNotification) {
+      const timeoutFade = setTimeout(() => {
+        ref.current.style.opacity = 0;
+      }, 3000)
       const timeout = setTimeout(() => {
         ref.current.style.opacity = 0;
         setPopupNotification(null);
-      }, 5000)
+      }, 3500)
       return () => {
-        clearTimeout(timeout);
+        clearTimeout(timeout,timeoutFade);
       };
     }
   }, [popupNotification])

--- a/src/PopupNotification.jsx
+++ b/src/PopupNotification.jsx
@@ -2,6 +2,9 @@ import * as React from "react";
 import styles from "./PopupNotification.module.css";
 import { AppContext } from "./components/app";
 
+const timeoutFadeDelay = 3000;
+const timeoutDisplayDelay = 3500;
+
 const PopupNotification = function ({
   popupNotification
 }) {
@@ -15,19 +18,16 @@ const PopupNotification = function ({
   }, [popupNotification]);
 
   React.useEffect(() => {
-      let timeout;
-      let timeoutFade;
       if ( popupNotification ) {
-          timeout = setTimeout(() => {
+          const timeoutFade = setTimeout(() => {
               ref.current.style.opacity = 0;
-          }, 3000);
-          timeoutFade = setTimeout(() => {
-              ref.current.style.opacity = 0;
+          }, timeoutFadeDelay);
+          const timeoutDisplay = setTimeout(() => {
               setPopupNotification(null);
-          }, 3500);
+          }, timeoutDisplayDelay);
           return () => {
-              clearTimeout(timeout);
               clearTimeout(timeoutFade);
+              clearTimeout(timeoutDisplay);
           };
       }
   }, [popupNotification]);

--- a/src/PopupNotification.jsx
+++ b/src/PopupNotification.jsx
@@ -6,34 +6,39 @@ const PopupNotification = function ({
   popupNotification
 }) {
   const ref = React.useRef();
-  const { setPopupNotification } = React.useContext( AppContext );
+  const { setPopupNotification } = React.useContext(AppContext);
 
   React.useEffect(() => {
-  if(popupNotification) {
-    ref.current.style.opacity = 1;
-  }
-}, [popupNotification])
+      if ( popupNotification ) {
+          ref.current.style.opacity = 1;
+      }
+  }, [popupNotification]);
 
   React.useEffect(() => {
-    if(popupNotification) {
-      const timeoutFade = setTimeout(() => {
-        ref.current.style.opacity = 0;
-      }, 3000)
-      const timeout = setTimeout(() => {
-        ref.current.style.opacity = 0;
-        setPopupNotification(null);
-      }, 3500)
-      return () => {
-        clearTimeout(timeout,timeoutFade);
-      };
-    }
-  }, [popupNotification])
+      let timeout;
+      let timeoutFade;
+      if ( popupNotification ) {
+          timeout = setTimeout(() => {
+              ref.current.style.opacity = 0;
+          }, 3000);
+          timeoutFade = setTimeout(() => {
+              ref.current.style.opacity = 0;
+              setPopupNotification(null);
+          }, 3500);
+          return () => {
+              clearTimeout(timeout);
+              clearTimeout(timeoutFade);
+          };
+      }
+  }, [popupNotification]);
+
   return (
     <>
-      {popupNotification && (
-        <div ref={ref} className={styles.popupNotificationWrap}>{popupNotification}</div>
-      )}
+      { popupNotification && (
+        <div ref={ ref } className={ styles.popupNotificationWrap }>{ popupNotification }</div>
+      ) }
     </>
   );
 };
+
 export { PopupNotification };

--- a/src/PopupNotification.module.css
+++ b/src/PopupNotification.module.css
@@ -1,0 +1,20 @@
+.popupNotificationWrap {
+    position: fixed;
+    padding: 12px 16px;
+    top: 60px;
+    font-size: 20px;
+    border-radius: 4px;
+    left: 50%;
+    -webkit-transform: translateX(-50%);
+    transform: translateX(-50%);
+    background: rgba(33,33,33,0.7);
+    border: 1px solid rgba(99,99,99,0.7);
+    -webkit-transition: opacity 0.3s;
+    -moz-transition: opacity 0.3s;
+    -o-transition: opacity 0.3s;
+    transition: opacity 0.3s;
+    opacity: 0;
+    color: #FFF;
+    z-index: 10000;
+    font-size: bold;
+}

--- a/src/components/app/App.jsx
+++ b/src/components/app/App.jsx
@@ -38,6 +38,7 @@ import {handleStoryKeyControls} from '../../../story';
 import styles from './App.module.css';
 import '../../fonts.css';
 import raycastManager from '../../../raycast-manager';
+import { PopupNotification } from '../../PopupNotification';
 
 //
 
@@ -140,6 +141,9 @@ export const App = () => {
     const [ selectedRoom, setSelectedRoom ] = useState( _getCurrentRoom() );
     const [ apps, setApps ] = useState( world.appManager.getApps().slice() );
 
+    // Popup notification state
+    const [ popupNotification, setPopupNotification ] = useState(null);
+
     //
 
     const selectApp = ( app, physicsId, position ) => {
@@ -206,6 +210,7 @@ export const App = () => {
             if ( event.ctrlKey && event.code === 'KeyH' ) {
 
                 setUIMode( uiMode === 'normal' ? 'none' : 'normal' );
+                setPopupNotification('Press CTR+H to toggle the UI tools');
                 return false;
 
             }
@@ -326,8 +331,9 @@ export const App = () => {
             onDragEnd={onDragEnd}
             onDragOver={onDragOver}
         >
-            <AppContext.Provider value={{ state, setState, app, setSelectedApp, selectedApp, uiMode }}>
+            <AppContext.Provider value={{ state, setState, app, setSelectedApp, selectedApp, uiMode, setPopupNotification, popupNotification }}>
                 <Header setSelectedApp={ setSelectedApp } selectedApp={ selectedApp } />
+                <PopupNotification popupNotification={ popupNotification } />
                 <DomRenderer />
                 <Canvas app={app} />
                 <Crosshair />

--- a/src/components/app/App.jsx
+++ b/src/components/app/App.jsx
@@ -210,7 +210,9 @@ export const App = () => {
             if ( event.ctrlKey && event.code === 'KeyH' ) {
 
                 setUIMode( uiMode === 'normal' ? 'none' : 'normal' );
-                setPopupNotification('Press CTR+H to toggle the UI tools');
+                if(uiMode === 'normal') {
+                    setPopupNotification('Press CTRL + H to unhide UI');
+                }
                 return false;
 
             }

--- a/src/components/general/action-menu/ActionMenu.jsx
+++ b/src/components/general/action-menu/ActionMenu.jsx
@@ -10,7 +10,7 @@ import styles from './action-menu.module.css';
 
 export const ActionMenu = ({ setUIMode, className }) => {
 
-    const { state, setState, app, uiMode } = useContext( AppContext );
+    const { state, setState, app, uiMode, setPopupNotification } = useContext( AppContext );
     const [ xrSupported, setXrSupported ] = useState( false );
 
     //
@@ -61,6 +61,7 @@ export const ActionMenu = ({ setUIMode, className }) => {
     const handleModeBtnClick = () => {
 
         setUIMode( uiMode === 'normal' ? 'none' : 'normal' );
+        setPopupNotification('Press CTR+H to toggle the UI tools');
 
     };
 

--- a/src/components/general/action-menu/ActionMenu.jsx
+++ b/src/components/general/action-menu/ActionMenu.jsx
@@ -61,7 +61,9 @@ export const ActionMenu = ({ setUIMode, className }) => {
     const handleModeBtnClick = () => {
 
         setUIMode( uiMode === 'normal' ? 'none' : 'normal' );
-        setPopupNotification('Press CTR+H to toggle the UI tools');
+        if(uiMode === 'normal') {
+            setPopupNotification('Press CTRL + H to unhide UI');
+        }
 
     };
 

--- a/src/components/general/action-menu/ActionMenu.jsx
+++ b/src/components/general/action-menu/ActionMenu.jsx
@@ -61,7 +61,7 @@ export const ActionMenu = ({ setUIMode, className }) => {
     const handleModeBtnClick = () => {
 
         setUIMode( uiMode === 'normal' ? 'none' : 'normal' );
-        if(uiMode === 'normal') {
+        if ( uiMode === 'normal' ) {
             setPopupNotification('Press CTRL + H to unhide UI');
         }
 

--- a/src/components/general/map-gen/MapGen.jsx
+++ b/src/components/general/map-gen/MapGen.jsx
@@ -596,6 +596,8 @@ export const MapGen = () => {
 
                   case 77: { // M
 
+                      break; // XXX
+
                       if ( state.openedPanel === 'MapGenPanel' ) {
 
                           setState({ openedPanel: null });


### PR DESCRIPTION
**Describe your changes**
Added a notification component which appears when you hide or show the UI tools using CTR+H or the hide button in the actions menu.
NOTICE: This component is now dynamic and can be used from ANYWHERE. Just import "setPopupNotification" hook from the AppContext and whenever you set a message in any use case it will appear and disappear after 5 seconds.
**What are the steps for a QA tester to test this pull request?**
Click the hide button in the actions menu and see the notification appear and disappear after 5 seconds.
Same when pressing the CTR+H keys on the keyboard
**Issue ticket number and link**
Issue: 3394
https://github.com/webaverse/app/issues/3394

Screenshots and/or video