### PR TITLE
revert avatars updates to velocity

### DIFF
--- a/character-controller.js
+++ b/character-controller.js
@@ -1398,13 +1398,6 @@ class RemotePlayer extends InterpolatedPlayer {
           localVector.copy(this.position);
           localVector.y -= this.avatar.height * 0.5;
           physicsScene.setCharacterControllerPosition(this.characterController, localVector);
-          
-          this.avatar.setVelocity(
-            timeDiff / 1000,
-            this.lastPosition,
-            this.positionInterpolant.get(),
-            this.quaternionInterpolant.get()
-            );
           }
         this.lastPosition.copy(this.position);
       }


### PR DESCRIPTION
## Describe your changes
Reverts some changes to accommodate multiplayer. Since we're changing velocity approach elsewhere we should revert this to not get entangled in separate bugs.

## What are the steps for a QA tester to test this pull request?
Characters should still run around smoothly, since this primarily affects single player avatar velocity. There should be no noticeable impact.