### PR TITLE
Fix avatar physics capsule size mismatch

### DIFF
--- a/avatars/avatars.js
+++ b/avatars/avatars.js
@@ -639,9 +639,12 @@ class Avatar {
       rightToe: _getOffset(modelBones.Right_toe),
     });
 
+    // default avatar body height/width ratio
+    const heightFactor = 1.6;
+    const widthFactor = 0.6;
     // height is defined as eyes to root
     this.height = getHeight(object);
-    this.width = 0.36; // TODO : calculate this instead of hard coding it
+    this.width = widthFactor/heightFactor * this.height;
     this.shoulderWidth = modelBones.Left_arm.getWorldPosition(new THREE.Vector3()).distanceTo(modelBones.Right_arm.getWorldPosition(new THREE.Vector3()));
     this.leftArmLength = this.shoulderTransforms.leftArm.armLength;
     this.rightArmLength = this.shoulderTransforms.rightArm.armLength;

--- a/character-physics.js
+++ b/character-physics.js
@@ -59,7 +59,7 @@ class CharacterPhysics {
 
     // avatar.height is the height of eye from the floor
     // convert to full height by adding some more
-    const heightOffset = radius * 2;
+    const heightOffset = radius * 1.5;
     this.yOffset = -heightOffset / 2; // add this after physx cct position output
     height = height + heightOffset; 
 

--- a/character-physics.js
+++ b/character-physics.js
@@ -37,7 +37,6 @@ const groundStickOffset = 0.03;
 
 const physicsScene = physicsManager.getScene();
 
-const CHARACTER_CONTROLLER_HEIGHT_FACTOR = 1.6;
 class CharacterPhysics {
   constructor(character) {
     this.character = character;
@@ -55,15 +54,20 @@ class CharacterPhysics {
     this.characterWidth = characterWidth;
     this.characterHeight = characterHeight;
 
-    const radius = (this.characterWidth / CHARACTER_CONTROLLER_HEIGHT_FACTOR) * this.characterHeight;
-    const height = this.characterHeight - radius * 2;
+    const radius = this.characterWidth / 2;
+    var height = this.characterHeight - radius * 2;
 
-    const contactOffset = (0.1 / CHARACTER_CONTROLLER_HEIGHT_FACTOR) * this.characterHeight;
-    const stepOffset = (0.5 / CHARACTER_CONTROLLER_HEIGHT_FACTOR) * this.characterHeight;
+    // avatar.height is the height of eye from the floor
+    // convert to full height by adding some more
+    const heightOffset = radius * 2;
+    this.yOffset = -heightOffset / 2; // add this after physx cct position output
+    height = height + heightOffset; 
+
+    const contactOffset = 0.1 * this.characterHeight;
+    const stepOffset = 0.5 * this.characterHeight;
 
     const position = this.character.position
-      .clone()
-      .add(new THREE.Vector3(0, -this.characterHeight / 2, 0));
+      .clone();
 
     if (this.characterController) {
       physicsScene.destroyCharacterController(this.characterController);
@@ -79,7 +83,6 @@ class CharacterPhysics {
   }
   setPosition(p) {
     localVector.copy(p);
-    localVector.y -= this.characterHeight * 0.5;
     physicsScene.setCharacterControllerPosition(
       this.characterController,
       localVector
@@ -157,6 +160,7 @@ class CharacterPhysics {
         timeDiffS,
         this.characterController.position
       );
+      this.characterController.position.y += this.yOffset;
       // const collided = flags !== 0;
       let grounded = !!(flags & 0x1);
 
@@ -175,6 +179,7 @@ class CharacterPhysics {
           0,
           localVector4
         );
+        localVector4.y += this.yOffset;
         const newGrounded = !!(flags & 0x1);
         if (newGrounded) {
           grounded = true;

--- a/character-physics.js
+++ b/character-physics.js
@@ -55,7 +55,7 @@ class CharacterPhysics {
     this.characterHeight = characterHeight;
 
     const radius = this.characterWidth / 2;
-    var height = this.characterHeight - radius * 2;
+    let height = this.characterHeight - radius * 2;
 
     // avatar.height is the height of eye from the floor
     // convert to full height by adding some more

--- a/physics-manager.js
+++ b/physics-manager.js
@@ -630,14 +630,10 @@ class PhysicsScene extends EventTarget {
         position,
         physicsId
       )
-    
-    radius = radius + contactOffset;
-    height = height + radius * 2;
   
-    const halfHeight = height / 2;
     const physicsObject = new THREE.Object3D()
     const physicsMesh = new THREE.Mesh(
-      new CapsuleGeometry(radius, radius, halfHeight * 2),
+      new CapsuleGeometry(radius, radius, height + contactOffset * 2),
       redMaterial
     )
     physicsMesh.visible = false


### PR DESCRIPTION
## Describe your changes
- Updated character controller physx entity's height to cover full body
- Updated physics collider rendering to match physx

## What are the steps for a QA tester to test this pull request?
- See collider of npc or avatar using tilde to check it's boundary compared to mesh.
- Jump onto npc or avatar's top to see land height matches it's height

## Issue ticket number and link
#3601 

## Screenshots and/or video
See below

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I am not adding any irrelevant code or assets
- [x] I am only including the changes needed to implement the change
- [x] I have playtested and intentionally tried to find error cases but couldn't
