### PR TITLE
Dragon icon preview rotation bug

### DIFF
--- a/object-spriter.js
+++ b/object-spriter.js
@@ -10,7 +10,7 @@ import {fitCameraToBoundingBox} from './util.js';
 
 const localVector = new THREE.Vector3();
 const localVector2 = new THREE.Vector3();
-// const localVector3 = new THREE.Vector3();
+const localVector3 = new THREE.Vector3();
 // const localVector2D = new THREE.Vector2();
 // const localVector2D2 = new THREE.Vector2();
 const localVector4D = new THREE.Vector4();
@@ -101,19 +101,24 @@ const createObjectSpriteInternal = (app, {
     
       // set up side camera
       const angle = (i / numFrames) * Math.PI * 2;
-      sideCamera.position.copy(app.position)
+      const physicsObjects = app.getPhysicsObjects();
+      if (physicsObjects.length > 0) {
+        const physicsObject = physicsObjects[0];
+        const {physicsMesh} = physicsObject;
+        sideCamera.position.copy(physicsMesh.geometry.boundingBox.getCenter(localVector3))
         .add(
           localVector.set(Math.cos(angle), 0, Math.sin(angle))
             .applyQuaternion(app.quaternion)
             .multiplyScalar(2)
         );
-
-      const physicsObjects = app.getPhysicsObjects();
-      if (physicsObjects.length > 0) {
-        const physicsObject = physicsObjects[0];
-        const {physicsMesh} = physicsObject;
         fitCameraToBoundingBox(sideCamera, physicsMesh.geometry.boundingBox, 1.2);
       } else {
+        sideCamera.position.copy(app.position)
+        .add(
+          localVector.set(Math.cos(angle), 0, Math.sin(angle))
+            .applyQuaternion(app.quaternion)
+            .multiplyScalar(2)
+        );
         sideCamera.quaternion.setFromRotationMatrix(
           localMatrix.lookAt(
             sideCamera.position,


### PR DESCRIPTION
In `fitCameraToBoundingBox` function, we set the direction according to the camera position and bounding box center. So I think we should also set the camera position based on the bounding box center in object-spriter.js 

https://github.com/webaverse/app/blob/0f2afad7836158756627babdbe158722117f7ab9/util.js#L720

related:
https://github.com/webaverse/app/issues/3501

related PR (No previews for bow bug)
https://github.com/webaverse/bow/pull/11

Result:

https://user-images.githubusercontent.com/60634884/184770338-7ca9ec73-70b1-4933-b8c8-55d76dc09664.mp4


https://user-images.githubusercontent.com/60634884/184770370-47c47dae-30fb-4f4d-9d32-a2e76cd5ae29.mp4


https://user-images.githubusercontent.com/60634884/184770406-6bafe311-05ce-4276-aba3-806a57e44795.mp4


