### PR TITLE
localStorage manager added

### DIFF
--- a/localStorage-manager.js
+++ b/localStorage-manager.js
@@ -1,0 +1,32 @@
+/**
+ * localStorage Manager
+ * in private browsing mode, localStorage is not supported on all browsers
+ * this manager will check if localStorage is supported and use it if it is
+ * otherwise it creates a fallback in-memory storage that uses the localStorage API
+ */
+
+let _storage = {};
+
+const setItem = (key, value) => { _storage[key] = String(value); };
+
+const getItem = key => (Object.prototype.hasOwnProperty.call(_storage, key)) ? _storage[key] : null;
+
+const removeItem = key => Object.prototype.hasOwnProperty.call(_storage, key) ? delete _storage[key] && undefined : undefined;
+
+const clear = () => { _storage = {}; };
+
+const _isSupported = () => {
+  try {
+    return typeof window.localStorage === 'object' && window.localStorage;
+  } catch (e) {
+    return false;
+  }
+};
+
+const inMemoryStorage = {setItem, getItem, removeItem, clear};
+
+const localStorageManager = _isSupported() ? localStorage : inMemoryStorage;
+
+window.localStorageManager = localStorageManager;
+
+export default localStorageManager;

--- a/src/components/general/settings/TabAi.jsx
+++ b/src/components/general/settings/TabAi.jsx
@@ -9,6 +9,8 @@ import debug from '../../../../debug';
 
 import styles from './settings.module.css';
 
+import localStorageManager from '../../../../localStorage-manager.js';
+
 //
 
 const ApiTypes = [ 'NONE', 'AI21', 'GOOSEAI', 'OPENAI', 'CONVAI' ];
@@ -113,7 +115,7 @@ export const TabAi = ({ active }) => {
             }
         }
 
-        localStorage.setItem( 'AiSettings', JSON.stringify( settings ) );
+        localStorageManager.setItem( 'AiSettings', JSON.stringify( settings ) );
 
         updateLoreEndpoint(apiType);
 
@@ -122,7 +124,7 @@ export const TabAi = ({ active }) => {
     async function loadSettings () {
 
         // load local storage
-        const settingsString = localStorage.getItem( 'AiSettings' );
+        const settingsString = localStorageManager.getItem( 'AiSettings' );
         let settings;
 
         try {

--- a/src/components/general/settings/TabAudio.jsx
+++ b/src/components/general/settings/TabAudio.jsx
@@ -11,6 +11,7 @@ import overrides from '../../../../overrides';
 import styles from './settings.module.css';
 
 import audioManager from '../../../../audio-manager.js';
+import localStorageManager from '../../../../localStorage-manager.js';
 
 //
 
@@ -61,13 +62,13 @@ export const TabAudio = ({ active }) => {
             voiceEndpoint:  voiceEndpoint,
         };
 
-        localStorage.setItem( 'AudioSettings', JSON.stringify( settings ) );
+        localStorageManager.setItem( 'AudioSettings', JSON.stringify( settings ) );
 
     };
 
     function loadSettings () {
 
-        const settingsString = localStorage.getItem( 'AudioSettings' );
+        const settingsString = localStorageManager.getItem( 'AudioSettings' );
         let settings;
 
         try {

--- a/src/components/general/settings/TabControls.jsx
+++ b/src/components/general/settings/TabControls.jsx
@@ -2,6 +2,8 @@
 import React, { useState, useEffect } from 'react';
 import classNames from 'classnames';
 
+import localStorageManager from '../../../../localStorage-manager.js';
+
 import { KeyInput } from './key-input';
 
 import styles from './settings.module.css';
@@ -55,13 +57,13 @@ export const TabControls = ({ active }) => {
             inventory
         };
 
-        localStorage.setItem( 'ControlsSettings', JSON.stringify( settings ) );
+        localStorageManager.setItem( 'ControlsSettings', JSON.stringify( settings ) );
 
     };
 
     function loadSettings () {
 
-        const settingsString = localStorage.getItem( 'ControlsSettings' );
+        const settingsString = localStorageManager.getItem( 'ControlsSettings' );
         let settings;
 
         try {

--- a/src/components/general/settings/TabGraphics.jsx
+++ b/src/components/general/settings/TabGraphics.jsx
@@ -6,6 +6,8 @@ import game from '../../../../game.js';
 import metaversefileApi from '../../../../metaversefile-api'
 import { Switch } from './switch';
 
+import localStorageManager from '../../../../localStorage-manager.js';
+
 import styles from './settings.module.css';
 
 //
@@ -65,13 +67,13 @@ export const TabGraphics = ({ active }) => {
             }
         };
 
-        localStorage.setItem( 'GfxSettings', JSON.stringify( settings ) );
+        localStorageManager.setItem( 'GfxSettings', JSON.stringify( settings ) );
 
     };
 
     function loadSettings () {
 
-        const settingsString = localStorage.getItem( 'GfxSettings' );
+        const settingsString = localStorageManager.getItem( 'GfxSettings' );
         let settings;
 
         try {


### PR DESCRIPTION
## Describe your changes
localStorage fails entirely in private browsing mode on chrome and Safari.

This fixes by adding a manager which uses an identical localStorage API, but will revert to in-memory storage if localStorage is not available.

## What are the steps for a QA tester to test this pull request?
Open regular browser, change some audio settings
Open a private browser, change some audio settings
Refresh the browser, verify the audio settings remain (localStorage working) or change (in memory is active)

For AI API keys, will need to also pull in this PR: https://github.com/webaverse/preauthenticator/pull/1