### PR TITLE
Fixed the tilde grab frame sync issue.

### DIFF
--- a/game.js
+++ b/game.js
@@ -543,8 +543,7 @@ const _gameUpdate = (timestamp, timeDiff) => {
       if (grabbedObject && !_isWear(grabbedObject)) {
         const {position, quaternion} = renderer.xr.getSession() ? localPlayer[hand === 'left' ? 'leftHand' : 'rightHand'] : camera;
         localMatrix.compose(position, quaternion, localVector.set(1, 1, 1));
-        grabbedObject.updateMatrixWorld();
-
+       
         updateGrabbedObject(grabbedObject, localMatrix, localMatrix3.fromArray(grabAction.matrix), {
           collisionEnabled: true,
           handSnapEnabled: true,

--- a/game.js
+++ b/game.js
@@ -552,6 +552,7 @@ const _gameUpdate = (timestamp, timeDiff) => {
           gridSnap: gameManager.getGridSnap(),
         });
 
+        grabbedObject.updateMatrixWorld();
         grabUseMesh.setComponent('value', localPlayer.actionInterpolants.activate.getNormalized());
       }
     }


### PR DESCRIPTION
Signed-off-by: techecho7 <108707280+techecho7@users.noreply.github.com>

## Describe your changes
Tilde grab wasn't frame synced when user grabs the chest and rotate the camera.
So I updated the _updateGrab function of the game.js to smooth it.

## What are the steps for a QA tester to test this pull request?
1. Go to street.scn.
2. Aim the chest with pointer and press tilde (~) key to grab it.
3. Rotate the camera.

## Issue ticket number and link
https://github.com/webaverse/app/issues/3646

## Screenshots and/or video
This is the video before fixing.

https://user-images.githubusercontent.com/108707280/185684460-875312a6-0046-4b4e-b752-9ea2068f7f40.mp4

And this is the video after fixing.

https://user-images.githubusercontent.com/108707280/185684605-2d55b06e-7d09-4bb7-95a6-7fe7d04bf44d.mp4

## Checklist before requesting a review
- [ O ] I have performed a self-review of my code
- [ O ] I am not adding any irrelevant code or assets
- [ O ] I am only including the changes needed to implement the change
- [ O ] I have playtested and intentionally tried to find error cases but couldn't
- [ O ] I have completed the entire [QA checklist](https://github.com/webaverse/app/issues/3153) on my PR