### PR TITLE
darkness scene bug

### DIFF
--- a/metaverse_components/pet.js
+++ b/metaverse_components/pet.js
@@ -68,7 +68,7 @@ export default (app, component) => {
   };
   app.addEventListener('wearupdate', e => {
     if (e.wear) {
-      player = getPlayerByAppInstanceId(app.instanceId);
+      player = e.player;
       if (app.glb) {
         const {animations} = app.glb;
         


### PR DESCRIPTION
Sibling: https://github.com/webaverse/totum/tree/tcm-temp-testing

There are some issues in darkness scene.

1. We could not equip the group object at the correct position in the darkness scene(lantern and fairy)

https://user-images.githubusercontent.com/60634884/186737875-023acf57-ec9c-4cde-a748-14bba547182c.mp4

That is because we do not initialize the `app.lastMatrix` so it update the physics objects in app-manager based on the wrong lastMatrix
![unknown](https://user-images.githubusercontent.com/60634884/186738869-895dedcb-5172-49f4-942e-d2de6d800c77.png)
So I initialize the subApp.lastMatrix when we create the subApp 
https://github.com/webaverse/totum/blob/00f6f6863555126035157b92ba086cd8ae1ff1bd/type_templates/group.js#L94

2. Even we could equip the object at the initial position now, we could not equip it again if we drop the object.

https://user-images.githubusercontent.com/60634884/186740724-b16e4e48-5d17-4d95-bbfc-41797f83da6c.mp4

That is because we update the same physic object of this app twice in app-manager(subApp and app)
So I comment out app.getPhysicsObjects in totum so that it would just update subApp's physic object once.
https://github.com/webaverse/totum/blob/00f6f6863555126035157b92ba086cd8ae1ff1bd/type_templates/group.js#L110

3. We can not equip pet in darkness scene.

https://user-images.githubusercontent.com/60634884/186741689-738edc42-13dc-4ebd-89ee-7a469a0d130f.mp4

That is because the app is in the `world.appManager.apps` But we searched the app in `localPlayer.appManager.apps`.
https://github.com/webaverse/app/blob/ec8d75f24aed0787a518fbf0e665ced093deee93/metaversefile-api.js#L974
So instead of using `getPlayerByAppInstanceId(app.instanceId);` to find the player, I use `e.player`.

This is the result: (the light is not correct, would fix it with another PR)

https://user-images.githubusercontent.com/60634884/186742448-45810e23-7f8a-4bfb-b1dd-671805e6b5d4.mp4






