### PR TITLE
equip sound + sword grunt + sword sound 

### DIFF
--- a/animations-baker.js
+++ b/animations-baker.js
@@ -553,6 +553,8 @@ const {CharsetEncoder} = require('three/examples/js/libs/mmdparser.js');
           bones.push(bone);
         }
       });
+      // console.log('got bones', bones.map(b => b.name));
+      const rootBone = bones.find(b => b.name === 'mixamorigRightShoulder');; // not really a bone
       const leftHandBone = bones.find(b => b.name === 'mixamorigLeftHand');
       const rightHandBone = bones.find(b => b.name === 'mixamorigRightHand');
       const epsilon = 0.2;
@@ -617,6 +619,7 @@ const {CharsetEncoder} = require('three/examples/js/libs/mmdparser.js');
             bone.quaternion.copy(bone.initialQuaternion);
           }
         }
+        rootBone.updateMatrixWorld(true);
         const fbxScale = 100;
         const leftHand = new THREE.Vector3().setFromMatrixPosition(leftHandBone.matrixWorld).divideScalar(fbxScale);
         const rightHand = new THREE.Vector3().setFromMatrixPosition(rightHandBone.matrixWorld).divideScalar(fbxScale);
@@ -635,6 +638,7 @@ const {CharsetEncoder} = require('three/examples/js/libs/mmdparser.js');
         lastRightHandPos.set(rightHand.x, rightHand.y, rightHand.z);
       }
 
+      
       console.log('got', leftHandDeltas, rightHandDeltas, maxLeftDeltaIndex, maxRightDeltaIndex);
       
       return {

--- a/animations-baker.js
+++ b/animations-baker.js
@@ -553,8 +553,6 @@ const {CharsetEncoder} = require('three/examples/js/libs/mmdparser.js');
           bones.push(bone);
         }
       });
-      // console.log('got bones', bones.map(b => b.name));
-      const rootBone = bones.find(b => b.name === 'mixamorigRightShoulder');; // not really a bone
       const leftHandBone = bones.find(b => b.name === 'mixamorigLeftHand');
       const rightHandBone = bones.find(b => b.name === 'mixamorigRightHand');
       const epsilon = 0.2;
@@ -619,7 +617,6 @@ const {CharsetEncoder} = require('three/examples/js/libs/mmdparser.js');
             bone.quaternion.copy(bone.initialQuaternion);
           }
         }
-        rootBone.updateMatrixWorld(true);
         const fbxScale = 100;
         const leftHand = new THREE.Vector3().setFromMatrixPosition(leftHandBone.matrixWorld).divideScalar(fbxScale);
         const rightHand = new THREE.Vector3().setFromMatrixPosition(rightHandBone.matrixWorld).divideScalar(fbxScale);

--- a/animations-baker.js
+++ b/animations-baker.js
@@ -639,7 +639,7 @@ const {CharsetEncoder} = require('three/examples/js/libs/mmdparser.js');
       }
 
       
-      console.log('got', leftHandDeltas, rightHandDeltas, maxLeftDeltaIndex, maxRightDeltaIndex);
+      // console.log('got', leftHandDeltas, rightHandDeltas, maxLeftDeltaIndex, maxRightDeltaIndex);
       
       return {
         maxRightDeltaIndex,

--- a/animations-baker.js
+++ b/animations-baker.js
@@ -554,7 +554,7 @@ const {CharsetEncoder} = require('three/examples/js/libs/mmdparser.js');
         }
       });
       // console.log('got bones', bones.map(b => b.name));
-      const rootBone = bones.find(b => b.name === 'mixamorigRightShoulder');; // not really a bone
+      const rootBone = object; // not really a bone
       const leftHandBone = bones.find(b => b.name === 'mixamorigLeftHand');
       const rightHandBone = bones.find(b => b.name === 'mixamorigRightHand');
       const epsilon = 0.2;

--- a/avatars/animationHelpers.js
+++ b/avatars/animationHelpers.js
@@ -58,6 +58,7 @@ const identityQuaternion = new Quaternion();
 
 let animations;
 let animationStepIndices;
+let animationComboIndices;
 // let animationsBaseModel;
 let jumpAnimation;
 let doubleJumpAnimation;
@@ -179,6 +180,7 @@ async function loadAnimations() {
   animations = animationsJson.animations
     .map(a => AnimationClip.parse(a));
   animationStepIndices = animationsJson.animationStepIndices;
+  animationComboIndices = animationsJson.animationComboIndices;
   animations.index = {};
   for (const animation of animations) {
     animations.index[animation.name] = animation;
@@ -1480,6 +1482,7 @@ export const _applyAnimation = (avatar, now) => {
 export {
   animations,
   animationStepIndices,
+  animationComboIndices,
   emoteAnimations,
   // cubicBezier,
 };

--- a/avatars/avatars.js
+++ b/avatars/avatars.js
@@ -134,6 +134,7 @@ const upVector = new THREE.Vector3(0, 1, 0);
 import {
   animations,
   animationStepIndices,
+  animationComboIndices,
 } from './animationHelpers.js';
 
 const cubicBezier = easing(0, 1, 0, 1);
@@ -2187,6 +2188,7 @@ class Avatar {
 Avatar.waitForLoad = () => loadPromise;
 Avatar.getAnimations = () => animations;
 Avatar.getAnimationStepIndices = () => animationStepIndices;
+Avatar.getanimationComboIndices = () => animationComboIndices;
 Avatar.getAnimationMappingConfig = () => animationMappingConfig;
 
 Avatar.getClosest2AnimationAngles = getClosest2AnimationAngles;

--- a/character-sfx.js
+++ b/character-sfx.js
@@ -109,9 +109,6 @@ class CharacterSfx extends EventTarget{
 
     this.lastLandState = false;
 
-    this.lastCombo = false;
-    this.playComboTime = 0;
-    this.currentComboIndex = -1;
   }
   update(timestamp, timeDiffS) {
     if (!this.player.avatar) {

--- a/character-sfx.js
+++ b/character-sfx.js
@@ -383,9 +383,8 @@ class CharacterSfx extends EventTarget{
             if (index > maxDeltaIndex) {
               this.alreadyPlayComboSound = true;
               this.playGrunt('attack');
-              const soundIndex = this.player.avatar.useAnimationIndex * 4 + Math.floor(Math.random() * 4);
+              const soundIndex = this.player.avatar.useAnimationIndex;
               dispatchComboSoundEvent(soundIndex);
-
             }
           }
         }

--- a/character-sfx.js
+++ b/character-sfx.js
@@ -361,13 +361,15 @@ class CharacterSfx extends EventTarget{
       }));
     }
     const _handleCombo = () => {
-      if (this.player.hasAction('use') && this.player.getAction('use').behavior === 'sword' && this.player.getAction('use').animationCombo) {
-        const comboAnimationName = aimAnimations[this.player.getAction('use').animationCombo[this.player.avatar.useAnimationIndex]];
-        if (comboAnimationName && comboAnimationName !== this.lastSwordComboName) {
-          this.swordComboStartTime = timeSeconds;
-          this.alreadyPlayComboSound = false;
-        }
+      if (this.player.hasAction('use') && this.player.getAction('use').behavior === 'sword') {
+        const comboAnimationName = this.player.getAction('use').animationCombo ?
+          aimAnimations[this.player.getAction('use').animationCombo[this.player.avatar.useAnimationIndex]]
+          : null;
         if (comboAnimationName) {
+          if (comboAnimationName !== this.lastSwordComboName) {
+            this.swordComboStartTime = timeSeconds;
+            this.alreadyPlayComboSound = false;
+          }
           const animations = Avatar.getAnimations();
           const animation = animations.find(a => a.name === comboAnimationName);
           const animationComboIndices = Avatar.getanimationComboIndices();

--- a/character-sfx.js
+++ b/character-sfx.js
@@ -28,17 +28,6 @@ const freestyleOffset = 900 / 2;
 const breaststrokeDuration = 1066.6666666666666;
 const breaststrokeOffset = 433.3333333333333;
 
-const silswordAnimationOffset = {
-  'swordSideSlash': 350,
-  'swordSideSlashStep': 150,
-  'swordTopDownSlash': 100,
-  'swordTopDownSlashStep': 150
-};
-const swordAnimationOffset = [
-  950, 
-  950, 
-  950
-];
 const aimAnimations = {
   swordSideIdle: 'sword_idle_side.fbx',
   swordSideIdleStatic: 'sword_idle_side_static.fbx',
@@ -250,39 +239,6 @@ class CharacterSfx extends EventTarget{
       _handleStep();
     }
 
-    //############################################################################# testBake #############################################################################
-    const _testBake = () => {
-      if (this.player.hasAction('use') && this.player.getAction('use').behavior === 'sword') {
-        const comboAnimationName = aimAnimations[this.player.getAction('use').animationCombo[this.player.avatar.useAnimationIndex]];
-        if (comboAnimationName && comboAnimationName !== this.lastSwordComboName) {
-          this.swordComboStartTime = timeSeconds;
-          this.alreadyPlayComboSound = false;
-        }
-        if (comboAnimationName) {
-          const animations = Avatar.getAnimations();
-          const animation = animations.find(a => a.name === comboAnimationName);
-          const animationComboIndices = Avatar.getanimationComboIndices();
-          const animationIndices = animationComboIndices.find(i => i.name === comboAnimationName);
-          const {leftHandDeltas, rightHandDeltas, maxLeftDeltaIndex, maxRightDeltaIndex} = animationIndices;
-          
-          const ratio = (timeSeconds - this.swordComboStartTime) / animation.duration;
-          if (ratio <= 1 && !this.alreadyPlayComboSound) {
-            const index = Math.floor(ratio * rightHandDeltas.length);
-            if (index > maxRightDeltaIndex) {
-              this.alreadyPlayComboSound = true;
-              this.playGrunt('attack');
-
-            }
-          }
-        }
-        this.lastSwordComboName = comboAnimationName;
-      }
-      
-    };
-
-    _testBake();
-    //#################################################################################################################################################################
-
     const _handleSwim = () => {
       if(this.player.hasAction('swim')){
           // const candidateAudios = soundFiles.water;
@@ -407,43 +363,40 @@ class CharacterSfx extends EventTarget{
         },
       }));
     }
-    // const _handleCombo = () => {
-    //   let currentCombo;
-    //   if(this.player.hasAction('use') && this.player.getAction('use').behavior === 'sword'){
-    //     currentCombo = this.player.getAction('use').animation ? 
-    //       this.player.getAction('use').animation // the sword app that has animation property in use action
-    //       : 
-    //       this.player.getAction('use').animationCombo[this.player.avatar.useAnimationIndex] // the sword app that has animationCombo property in use action
-    //   }
-    //   if (currentCombo) {
-    //     if (currentCombo !== this.lastCombo) {
-    //       this.playComboTime = timestamp;
-    //       this.currentComboIndex = -1;
-    //     }
-    //     if (currentCombo === 'combo') { // the sword app that has animation property in use action
-    //       this.currentComboIndex = this.currentComboIndex < 0 ? 0 : this.currentComboIndex;
-    //       if(timestamp - this.playComboTime >= swordAnimationOffset[this.currentComboIndex]){
-    //         this.playComboTime = timestamp;
-    //         this.playGrunt('attack');
-    //         this.currentComboIndex++;
-    //         const soundIndex = this.currentComboIndex * 4 + Math.floor(Math.random() * 4);
-    //         dispatchComboSoundEvent(soundIndex);
-    //       }
-    //     }
-    //     else { // the sword app that has animationCombo property in use action
-    //       if (timestamp - this.playComboTime >= silswordAnimationOffset[currentCombo] && this.currentComboIndex !== this.player.avatar.useAnimationIndex) {
-    //         this.playGrunt('attack');
-    //         this.currentComboIndex = this.player.avatar.useAnimationIndex;
-    //         const soundIndex = this.currentComboIndex * 4 + Math.floor(Math.random() * 4);
-    //         dispatchComboSoundEvent(soundIndex);
-    //       }
-    //     }
-    //   }
-    //   this.lastCombo = currentCombo;
-    // };
-    // _handleCombo();
-    
+    const _handleCombo = () => {
+      if (this.player.hasAction('use') && this.player.getAction('use').behavior === 'sword' && this.player.getAction('use').animationCombo) {
+        const comboAnimationName = aimAnimations[this.player.getAction('use').animationCombo[this.player.avatar.useAnimationIndex]];
+        if (comboAnimationName && comboAnimationName !== this.lastSwordComboName) {
+          this.swordComboStartTime = timeSeconds;
+          this.alreadyPlayComboSound = false;
+        }
+        if (comboAnimationName) {
+          const animations = Avatar.getAnimations();
+          const animation = animations.find(a => a.name === comboAnimationName);
+          const animationComboIndices = Avatar.getanimationComboIndices();
+          const animationIndices = animationComboIndices.find(i => i.name === comboAnimationName);
+          const handDeltas = this.player.getAction('use').boneAttachment === 'leftHand' ? animationIndices.rightHandDeltas : animationIndices.leftHandDeltas;
+          const maxDeltaIndex = this.player.getAction('use').boneAttachment === 'leftHand' ? animationIndices.maxRightDeltaIndex : animationIndices.maxLeftDeltaIndex;
+          
+          const ratio = (timeSeconds - this.swordComboStartTime) / animation.duration;
+          if (ratio <= 1 && !this.alreadyPlayComboSound) {
+            const index = Math.floor(ratio * handDeltas.length);
+            if (index > maxDeltaIndex) {
+              this.alreadyPlayComboSound = true;
+              this.playGrunt('attack');
+              const soundIndex = this.player.avatar.useAnimationIndex * 4 + Math.floor(Math.random() * 4);
+              dispatchComboSoundEvent(soundIndex);
 
+            }
+          }
+        }
+        this.lastSwordComboName = comboAnimationName;
+      }
+      
+    };
+
+    _handleCombo();
+    
     const _handleGasp = () =>{
       const isRunning = currentSpeed > 0.5;
       if(isRunning){

--- a/metaverse-components.js
+++ b/metaverse-components.js
@@ -3,6 +3,7 @@ import wear from './metaverse_components/wear.js';
 import pet from './metaverse_components/pet.js';
 import drop from './metaverse_components/drop.js';
 // import mob from './metaverse_components/mob.js';
+import use from './metaverse_components/use.js';
 
 const componentTemplates = {
   wear,
@@ -10,6 +11,7 @@ const componentTemplates = {
   pet,
   drop,
   // mob,
+  use,
 };
 export {
   componentTemplates,

--- a/metaverse_components/use.js
+++ b/metaverse_components/use.js
@@ -1,0 +1,41 @@
+import * as THREE from 'three';
+import metaversefile from 'metaversefile';
+
+
+
+export default (app, component) => {
+  const {useUse} = metaversefile;
+  const sounds = metaversefile.useSound();
+  const soundFiles = sounds.getSoundFiles();
+  
+  let using = false;
+  let player = null;
+  
+  
+  
+  useUse((e) => {
+    using = e.use;
+  });
+  const meleewhoosh = (e) =>{
+    if(using){
+      sounds.playSound(soundFiles.meleewhoosh[e.data.index]);
+    }
+  }
+  const _unwear = () => {
+    if (component.behavior === 'sword') {
+        player.characterSfx.removeEventListener('meleewhoosh', meleewhoosh);
+    }
+    player = null;
+  };
+  app.addEventListener('wearupdate', e => {
+    if (e.wear) {
+      player = e.player;
+      if (component.behavior === 'sword') {
+        player.characterSfx.addEventListener('meleewhoosh', meleewhoosh);
+      }
+    } else {
+      _unwear();
+    }
+  });
+  return app;
+};

--- a/metaverse_components/use.js
+++ b/metaverse_components/use.js
@@ -18,7 +18,11 @@ export default (app, component) => {
   });
   const meleewhoosh = (e) =>{
     if(using){
-      sounds.playSound(soundFiles.meleewhoosh[e.data.index]);
+      const index = e.data.index;
+      const soundRegex = new RegExp(`^combat/sword_slash${index}-[0-9]*.wav$`);
+      const soundCandidate = soundFiles.combat.filter(f => soundRegex.test(f.name));
+      const audioSpec = soundCandidate[Math.floor(Math.random() * soundCandidate.length)];
+      sounds.playSound(audioSpec);
     }
   }
   const _unwear = () => {

--- a/metaverse_components/wear.js
+++ b/metaverse_components/wear.js
@@ -29,6 +29,7 @@ const physicsScene = physicsManager.getScene();
 
 export default (app, component) => {
   const {useActivate} = metaversefile;
+  const sounds = metaversefile.useSound();
   
   let wearSpec = null;
   let modelBones = null;
@@ -40,9 +41,9 @@ export default (app, component) => {
   // const localPlayer = metaversefile.useLocalPlayer();
 
   const wearupdate = e => {
+    sounds.playSoundName(e.wear ? 'itemEquip' : 'itemUnequip');
     if (e.wear) {
       player = e.player;
-
       wearSpec = app.getComponent('wear');
       initialScale.copy(app.scale);
       // console.log('wear activate', app, wearSpec, e);

--- a/sounds.js
+++ b/sounds.js
@@ -12,6 +12,7 @@ const soundFiles = {
   sonicBoom: _getSoundFiles(/^sonicBoom\//),
   chomp: _getSoundFiles(/^food\/chomp/),
   combat: _getSoundFiles(/^combat\//),
+  meleewhoosh: _getSoundFiles(/^combat\/sword_slash/),
   gulp: _getSoundFiles(/^food\/gulp/),
   enemyDeath: _getSoundFiles(/ff7_enemy_death/),
   enemyCut: _getSoundFiles(/ff7_cut/),


### PR DESCRIPTION
1. Play the equip/drop sound in `metaverse_components/wear.js`  instead of `character-sfx.js`
(Should we just only play the equip sound for localPlayer?)
2. Because some apps like sword do not have the file `index.js` to play the sword whoosh, can we create a metaverse components `use` for the app to handle the sound event?
3. In animation-baker.js, baked the sword velocity to slash animation. And play the sword grunt and emit meleewhoosh event according to the velocity. (instead of using constant)
4. And for the redo sword animation, we haven't had the new sword animation so I just change sword animation to animationCombo in this PR: https://github.com/webaverse/sword/pull/2

Sibling:
https://github.com/webaverse/sword/pull/2

related:
https://github.com/webaverse/app/issues/3659

Result:

https://user-images.githubusercontent.com/60634884/187808725-518c0de0-fa6d-43c2-aff2-49e407a16fe5.mp4



