### PR TITLE
Lazy load inventory

### DIFF
--- a/spritesheet-manager.js
+++ b/spritesheet-manager.js
@@ -56,7 +56,9 @@ class AssetLoadManager {
   putInQueue(promise) {
     this.pushQueueLock = this.pushQueueLock.then(() => {
       this.pushQueue.push(promise);
-      if (this.intervalID === 0) this.poll();
+      if (this.intervalID === 0) {
+        this.poll();
+      }
     });
 
     return this.pushQueueLock;

--- a/spritesheet-manager.js
+++ b/spritesheet-manager.js
@@ -1,12 +1,71 @@
 import {createObjectSprite} from './object-spriter.js';
 import offscreenEngineManager from './offscreen-engine-manager.js';
 
-class SpritesheetManager {
-  maxConcurrentLoading = 5;
-  currentlyLoading = 0;
-  waitQueue = [];
+class AssetLoader {
+  isIdle = true;
+
+  async load(promiseFunc) {
+    this.isIdle = false;
+    await promiseFunc();
+    this.isIdle = true;
+  }
+}
+
+class AssetLoadManager {
+  pushQueue = [];
+  pushQueueLock = Promise.resolve();
+  getQueue = [];
+  getIndex = -1;
+
+  maxLoaderCount = 5;
+  loaderPool = [];
+  intervalID = 0;
+
+  schedulerInterval = 10;
 
   constructor() {
+    for (let i = 0; i < this.maxLoaderCount; i++) {
+      this.loaderPool.push(new AssetLoader())
+    }
+  }
+
+  poll() {
+    this.intervalID = setInterval(() => {
+      if (this.getQueue.length > 0) {
+        for (let i = 0; i < this.loaderPool.length; i++) {
+          if (this.loaderPool[i].isIdle && this.getIndex < this.getQueue.length - 1) {
+            this.loaderPool[i].load(this.getQueue[++this.getIndex]);
+          }
+        }
+      } else if (this.pushQueue.length <= 0) {
+        clearInterval(this.intervalID);
+        this.intervalID = 0;
+      }
+
+      if (this.getIndex > -1) {
+        this.getQueue.splice(0, this.getIndex + 1);
+        this.getIndex = -1;
+      }
+
+      const t = this.pushQueue
+      this.pushQueue = this.getQueue;
+      this.getQueue = t;
+    }, this.schedulerInterval);
+  }
+
+  putInQueue(promise) {
+    this.pushQueueLock = this.pushQueueLock.then(() => {
+      this.pushQueue.push(promise);
+      if (this.intervalID === 0) this.poll();
+    });
+
+    return this.pushQueueLock;
+  }
+}
+
+class SpritesheetManager {
+  constructor() {
+    this.loadManager = new AssetLoadManager();
     this.spritesheetCache = new Map();
     this.getSpriteSheetForAppUrlInternal = offscreenEngineManager.createFunction([
       `\
@@ -35,33 +94,17 @@ class SpritesheetManager {
   }
 
   async getSpriteSheetForAppUrlAsync(appUrl, opts) {
-    const spritesheet = this.spritesheetCache.get(appUrl);
+    let spritesheet = this.spritesheetCache.get(appUrl);
 
-    if (spritesheet) return spritesheet;
-
-    return new Promise((resolve) => {
-      this.waitQueue.push({ url: appUrl, opts, resolve });
-      this.loadSpriteSheetFromQueue();
-    });
-  }
-
-  loadSpriteSheetFromQueue() {
-    if (this.currentlyLoading >= this.maxConcurrentLoading || this.waitQueue.length <= 0) return;
-
-    const loopCount = Math.min(this.maxConcurrentLoading, this.waitQueue.length);
-    for (let i = 0; i < loopCount; i++) {
-      this.currentlyLoading++;
-      const data = this.waitQueue.splice(0, 1)[0];
-
-      this.getSpriteSheetForAppUrlInternal([ data.url, data.opts ]).then((spritesheet) => {
-        this.currentlyLoading--;
-
-        this.spritesheetCache.set(data.url, spritesheet);
-        data.resolve(spritesheet);
-
-        this.loadSpriteSheetFromQueue();
+    if (!spritesheet) {
+      spritesheet = await new Promise(async (resolve) => {
+        this.loadManager.putInQueue(() => this.getSpriteSheetForAppUrlInternal([ appUrl, opts ]).then(resolve))
       });
+
+      this.spritesheetCache.set(appUrl, spritesheet);
     }
+
+    return spritesheet;
   }
 }
 const spritesheetManager = new SpritesheetManager();

--- a/src/components/general/equipment/Equipment.jsx
+++ b/src/components/general/equipment/Equipment.jsx
@@ -249,7 +249,7 @@ const EquipmentItems = ({
             <div className={styles.text}>{rightText}</div>
             <img className={styles.arrow} src="./images/chevron3.svg" />
         </div>
-        {sections.map((section, i) => {
+        {open && sections.map((section, i) => {
             const {name, tokens} = section;
 
             /* const refsMap = (() => {
@@ -439,7 +439,7 @@ export const Equipment = () => {
                                 tokens: claims,
                             },
                         ]}
-                        open={faceIndex === 0}
+                        open={open && faceIndex === 0}
                         hoverObject={hoverObject}
                         selectObject={selectObject}
                         loading={loading}
@@ -465,7 +465,7 @@ export const Equipment = () => {
                                 tokens: objects.upstreet,
                             },
                         ]}
-                        open={faceIndex === 1}
+                        open={open && faceIndex === 1}
                         hoverObject={hoverObject}
                         selectObject={selectObject}
                         loading={loading}
@@ -487,7 +487,7 @@ export const Equipment = () => {
                                 tokens: [],
                             },
                         ]}
-                        open={faceIndex === 2}
+                        open={open && faceIndex === 2}
                         hoverObject={hoverObject}
                         selectObject={selectObject}
                         loading={loading}
@@ -509,7 +509,7 @@ export const Equipment = () => {
                                 tokens: landTokenObjects,
                             },
                         ]}
-                        open={faceIndex === 3}
+                        open={open && faceIndex === 3}
                         hoverObject={hoverObject}
                         selectObject={selectObject}
                         loading={loading}


### PR DESCRIPTION
## Describe your changes
In this PR Below changes are added
1. Inventory, Season, Land and Account panels will load lazily. Background of these panels will load at the start but the items of these panels will only load upon opening those panels. Reason for this is to keep the opening animation of these panels. Caching mechanism was already there and no changes have been done to it.
2. [Optional] Currently all the items in the inventory, Season and Account panels are being load simultaneously so in the second commit this behavior has been changed. Now only predefined number of items will load at the same time and rest will wait in the queue for previous ones to complete their loading process.

## Further Improvements
1. Currently upon receiving SpriteSheet an interval starts to render those sprite into the canvas. When the amount of items increases these intervals keeps adding up and disturbs the main rendering because they are not in sync. Maybe a system can be develop keep all these canvases and render them on certain tick.
2. Character Selection and Character Panel also has same behavior of loading at the start so it can be altered.
3. Inventory does not has scrolling currently.

## What are the steps for a QA tester to test this pull request?
1. Open the scene `https://local.webaverse.com/`
4. Press `Tab` and load the inventory. Inventory will start to load. previously it will be loaded from start.
5. Press `Tab` to close the inventory.
6. Press `Tab` again to open inventory and check that items are already loaded from cache and do not load second time.
7. If there are more then 5 items in the inventory then first 5 will load first then next 5 then another 5 and so on.

## Issue ticket number and link
N/A

## Screenshots and/or video

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I am not adding any irrelevant code or assets
- [x] I am only including the changes needed to implement the change
- [x] I have playtested and intentionally tried to find error cases but couldn't
- [x] I have completed the entire [QA checklist](https://github.com/webaverse/app/issues/3153) on my PR
