### PR TITLE
add timestamp to avatar.setVelocity for remote player 

### DIFF
--- a/character-controller.js
+++ b/character-controller.js
@@ -1374,6 +1374,7 @@ class RemotePlayer extends InterpolatedPlayer {
           physicsScene.setCharacterControllerPosition(this.characterPhysics.characterController, localVector);
           
           this.avatar.setVelocity(
+            timestamp,
             timeDiff / 1000,
             this.lastPosition,
             this.positionInterpolant.get(),


### PR DESCRIPTION
Based on commit https://github.com/webaverse/app/commit/519fc88e2b3f1a3b4f029099d6b4bd4367ee8af5 Need to add timestamp for setting velocity of avatar of remote player, else it is throwing undefined errors

## Describe your changes
add timestamp to avatar.setVelocity for remote player,  on remote players this is called from the RemotePlayer -> observePlayerFn where the timestamp is not added as the first parameter

## What are the steps for a QA tester to test this pull request?
Run a multiplayer session and check for position update on remote player. 

## Issue ticket number and link
changes based on commit  https://github.com/webaverse/app/commit/519fc88e2b3f1a3b4f029099d6b4bd4367ee8af5

## Screenshots and/or video
![image](https://user-images.githubusercontent.com/110850849/189670777-546f6240-b6f4-40b3-af39-6d78b7dc8793.png)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I am not adding any irrelevant code or assets
- [x] I am only including the changes needed to implement the change
- [x] I have playtested and intentionally tried to find error cases but couldn't
- [ ] I have completed the entire [QA checklist](https://github.com/webaverse/app/issues/3153) on my PR
