### PR TITLE
change to characterhups for remote players

### DIFF
--- a/character-controller.js
+++ b/character-controller.js
@@ -1381,6 +1381,11 @@ class RemotePlayer extends InterpolatedPlayer {
             );
           }
         this.lastPosition.copy(this.position);
+
+        // to set up side camera in diorama.js, position, quaternion and scale is obtained
+        // from target.matrixworld.decompose which does not seem to be updated for remote player
+        // hence calculating/composing it here with obtainted position and quaternion data 
+        this.matrixWorld.compose(this.position, this.quaternion, localVector.set(1, 1, 1));
       }
     }
     this.playerMap.observe(observePlayerFn);

--- a/character-controller.js
+++ b/character-controller.js
@@ -1381,11 +1381,6 @@ class RemotePlayer extends InterpolatedPlayer {
             );
           }
         this.lastPosition.copy(this.position);
-
-        // to set up side camera in diorama.js, position, quaternion and scale is obtained
-        // from target.matrixworld.decompose which does not seem to be updated for remote player
-        // hence calculating/composing it here with obtainted position and quaternion data 
-        this.matrixWorld.compose(this.position, this.quaternion, localVector.set(1, 1, 1));
       }
     }
     this.playerMap.observe(observePlayerFn);

--- a/diorama.js
+++ b/diorama.js
@@ -676,6 +676,8 @@ const createPlayerDiorama = ({
 
       const _render = () => {
         if (autoCamera) {
+          // update character portrait position
+          target.updateMatrixWorld()
           // set up side camera
           target.matrixWorld.decompose(localVector, localQuaternion, localVector2);
           const targetPosition = localVector;


### PR DESCRIPTION
When chatting with another player, the diorama in the character hups window for the remote player is buggy. The character is out of frame in the character hups for remote player. 

## Describe your changes
To set up side camera in diorama.js, position, quaternion and scale is obtained from target.matrixworld.decompose which does not seem to be updated for remote player. Hence calculating/composing it in character-controller.js where position and quaternion data is obtained

## What are the steps for a QA tester to test this pull request?
1.Go to 'https://local.webaverse.com/?src=.%2Fscenes%2Fprototype.scn&room=fLgYz'
2.Join another player using same link
3.Press 'Enter' to start chat for any one player and observe character hups window showing character diorama and chat on another player screen.
4. Diorama view for remote player must show the character within the frame for chat character hups window

note: require this pr as well, https://github.com/webaverse/app/pull/3703

## Issue ticket number and link
#3702

## Screenshots and/or video
![Img_1](https://user-images.githubusercontent.com/110850849/189680042-e650ffb9-f5f6-4232-a6d1-23ab72577bab.png)
![Img_2](https://user-images.githubusercontent.com/110850849/189680049-44ea7dcd-6d7d-4fdf-9c10-9f2f302f8df4.png)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I am not adding any irrelevant code or assets
- [x] I am only including the changes needed to implement the change
- [x] I have playtested and intentionally tried to find error cases but couldn't
- [ ] I have completed the entire [QA checklist](https://github.com/webaverse/app/issues/3153) on my PR
