### PR TITLE
character portrait position in diorama

### DIFF
--- a/diorama.js
+++ b/diorama.js
@@ -676,6 +676,7 @@ const createPlayerDiorama = ({
 
       const _render = () => {
         if (autoCamera) {
+          target.updateMatrixWorld();
           // set up side camera
           target.matrixWorld.decompose(localVector, localQuaternion, localVector2);
           const targetPosition = localVector;


### PR DESCRIPTION
When chatting with another player, the diorama in the character hups window for the remote player is buggy. The character is out of frame in the character hups for remote player.

## Describe your changes
To set up side camera in diorama.js, position, quaternion and scale is obtained from target.matrixworld.decompose which does not seem to be updated for remote player.
So target would need updateMatrixWorld to update position, quaternion and scale

## What are the steps for a QA tester to test this pull request?
1.Go to 'https://local.webaverse.com/?src=.%2Fscenes%2Fprototype.scn&room=fLgYz'
2.Join another player using same link
3.Press 'Enter' to start chat for any one player and observe character hups window showing character diorama and chat on another player screen.
4. Diorama view for remote player must show the character within the frame for chat character hups window

## Issue ticket number and link
https://github.com/webaverse/app/issues/3702

## Screenshots and/or video
![image_1](https://user-images.githubusercontent.com/110850849/190590761-7f517b6d-825a-46ea-8a66-7b24a34e727b.png)
![image_2](https://user-images.githubusercontent.com/110850849/190590768-21742746-339b-49bb-8fa4-a7a79ab0ff31.png)

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I am not adding any irrelevant code or assets
- [ ] I am only including the changes needed to implement the change
- [ ] I have playtested and intentionally tried to find error cases but couldn't
- [ ] I have completed the entire [QA checklist](https://github.com/webaverse/app/issues/3153) on my PR
