### PR TITLE
Tilde grabbing: bug fixes

### DIFF
--- a/character-controller.js
+++ b/character-controller.js
@@ -1136,31 +1136,39 @@ class LocalPlayer extends UninterpolatedPlayer {
     });
   }
   grab(app, hand = 'left') {
-    const {position, quaternion} = _getSession() ?
-      localPlayer[hand === 'left' ? 'leftHand' : 'rightHand']
-    :
-      camera;
+    if(this instanceof LocalPlayer) {
+      let position = null, quaternion = null;
 
-    app.updateMatrixWorld();
-    app.savedRotation = app.rotation.clone();
-    app.startQuaternion = quaternion.clone();
+      if(_getSession()) {
+        const h = this[hand === 'left' ? 'leftHand' : 'rightHand'];
+        position = h.position;
+        quaternion = h.quaternion;
+      } else {
+        position = this.position;
+        quaternion = camera.quaternion;
+      }
 
-    const grabAction = {
-      type: 'grab',
-      hand,
-      instanceId: app.instanceId,
-      matrix: localMatrix.copy(app.matrixWorld)
-        .premultiply(localMatrix2.compose(position, quaternion, localVector.set(1, 1, 1)).invert())
-        .toArray()
-    };
-    this.addAction(grabAction);
-    
-    physicsScene.disableAppPhysics(app)
+      app.updateMatrixWorld();
+      app.savedRotation = app.rotation.clone();
+      app.startQuaternion = quaternion.clone();
 
-    app.dispatchEvent({
-      type: 'grabupdate',
-      grab: true,
-    });
+      const grabAction = {
+        type: 'grab',
+        hand,
+        instanceId: app.instanceId,
+        matrix: localMatrix.copy(app.matrixWorld)
+          .premultiply(localMatrix2.compose(position, quaternion, localVector.set(1, 1, 1)).invert())
+          .toArray()
+      };
+      this.addAction(grabAction);
+      
+      physicsScene.disableAppPhysics(app)
+
+      app.dispatchEvent({
+        type: 'grabupdate',
+        grab: true,
+      });
+    }
   }
   ungrab() {
     const actions = Array.from(this.getActionsState());

--- a/character-controller.js
+++ b/character-controller.js
@@ -1136,39 +1136,37 @@ class LocalPlayer extends UninterpolatedPlayer {
     });
   }
   grab(app, hand = 'left') {
-    if(this instanceof LocalPlayer) {
-      let position = null, quaternion = null;
+    let position = null, quaternion = null;
 
-      if(_getSession()) {
-        const h = this[hand === 'left' ? 'leftHand' : 'rightHand'];
-        position = h.position;
-        quaternion = h.quaternion;
-      } else {
-        position = this.position;
-        quaternion = camera.quaternion;
-      }
-
-      app.updateMatrixWorld();
-      app.savedRotation = app.rotation.clone();
-      app.startQuaternion = quaternion.clone();
-
-      const grabAction = {
-        type: 'grab',
-        hand,
-        instanceId: app.instanceId,
-        matrix: localMatrix.copy(app.matrixWorld)
-          .premultiply(localMatrix2.compose(position, quaternion, localVector.set(1, 1, 1)).invert())
-          .toArray()
-      };
-      this.addAction(grabAction);
-      
-      physicsScene.disableAppPhysics(app)
-
-      app.dispatchEvent({
-        type: 'grabupdate',
-        grab: true,
-      });
+    if(_getSession()) {
+      const h = this[hand === 'left' ? 'leftHand' : 'rightHand'];
+      position = h.position;
+      quaternion = h.quaternion;
+    } else {
+      position = this.position;
+      quaternion = camera.quaternion;
     }
+
+    app.updateMatrixWorld();
+    app.savedRotation = app.rotation.clone();
+    app.startQuaternion = quaternion.clone();
+
+    const grabAction = {
+      type: 'grab',
+      hand,
+      instanceId: app.instanceId,
+      matrix: localMatrix.copy(app.matrixWorld)
+        .premultiply(localMatrix2.compose(position, quaternion, localVector.set(1, 1, 1)).invert())
+        .toArray()
+    };
+    this.addAction(grabAction);
+    
+    physicsScene.disableAppPhysics(app)
+
+    app.dispatchEvent({
+      type: 'grabupdate',
+      grab: true,
+    });
   }
   ungrab() {
     const actions = Array.from(this.getActionsState());

--- a/game.js
+++ b/game.js
@@ -80,35 +80,63 @@ const _unwearAppIfHasSitComponent = (player) => {
 }
 
 // returns whether we actually snapped
-function updateGrabbedObject(o, grabMatrix, offsetMatrix, {collisionEnabled, handSnapEnabled, physx, gridSnap}) {
+function updateGrabbedObject(
+  o,
+  grabMatrix,
+  offsetMatrix,
+  { collisionEnabled, handSnapEnabled, physx, gridSnap }
+) {
   grabMatrix.decompose(localVector, localQuaternion, localVector2);
   offsetMatrix.decompose(localVector3, localQuaternion2, localVector4);
   const offset = localVector3.length();
-  localMatrix.multiplyMatrices(grabMatrix, offsetMatrix)
+  localMatrix
+    .multiplyMatrices(grabMatrix, offsetMatrix)
     .decompose(localVector5, localQuaternion3, localVector6);
 
-  let collision = collisionEnabled && physicsScene.raycast(localVector, localQuaternion);
-  if (collision) {
-    // console.log('got collision', collision);
-    const {point} = collision;
-    o.position.fromArray(point)
-      // .add(localVector2.set(0, 0.01, 0));
+  const collision =
+    collisionEnabled && physicsScene.raycast(localVector, localQuaternion);
+    localQuaternion2.setFromAxisAngle(localVector2.set(1, 0, 0), -Math.PI * 0.5);
+  const downCollision =
+    collisionEnabled && physicsScene.raycast(localVector5, localQuaternion2);
 
-    if (o.position.distanceTo(localVector) > offset) {
-      collision = null;
+  if (!!collision) {
+    const { point } = collision;
+    localVector6.fromArray(point);
+  }
+
+  if (!!downCollision) {
+    const { point } = downCollision;
+    localVector4.fromArray(point);
+    if (ioManager.keys.shift) {
+      o.position.copy(localVector5.setY(localVector4.y));
+    } else {
+      // if collision point is closer to the player than the grab offset and collisionDown point
+      // is below collision point then place the object at collision point
+      if (
+        localVector.distanceTo(localVector6) < offset &&
+        localVector4.y < localVector6.y
+      )
+        localVector5.copy(localVector6);
+      
+      // if grabbed object would go below another object then place object at downCollision point
+      if (localVector5.y < localVector4.y) localVector5.setY(localVector4.y);
+      o.position.copy(localVector5);
     }
   }
-  if (!collision) {
-    o.position.copy(localVector5);
-  }
 
-  const handSnap = !handSnapEnabled || offset >= maxGrabDistance || !!collision;
+  const handSnap =
+    !handSnapEnabled ||
+    offset >= maxGrabDistance ||
+    !!collision ||
+    !!downCollision;
   if (handSnap) {
     snapPosition(o, gridSnap);
     o.quaternion.setFromEuler(o.savedRotation);
   } else {
     o.quaternion.copy(localQuaternion3);
   }
+
+  o.updateMatrixWorld();
 
   return {
     handSnap,
@@ -543,7 +571,6 @@ const _gameUpdate = (timestamp, timeDiff) => {
       if (grabbedObject && !_isWear(grabbedObject)) {
         const {position, quaternion} = renderer.xr.getSession() ? localPlayer[hand === 'left' ? 'leftHand' : 'rightHand'] : camera;
         localMatrix.compose(position, quaternion, localVector.set(1, 1, 1));
-        grabbedObject.updateMatrixWorld();
 
         updateGrabbedObject(grabbedObject, localMatrix, localMatrix3.fromArray(grabAction.matrix), {
           collisionEnabled: true,

--- a/game.js
+++ b/game.js
@@ -93,11 +93,9 @@ function updateGrabbedObject(
     .multiplyMatrices(grabMatrix, offsetMatrix)
     .decompose(localVector5, localQuaternion3, localVector6);
 
-  const collision =
-    collisionEnabled && physicsScene.raycast(localVector, localQuaternion);
-    localQuaternion2.setFromAxisAngle(localVector2.set(1, 0, 0), -Math.PI * 0.5);
-  const downCollision =
-    collisionEnabled && physicsScene.raycast(localVector5, localQuaternion2);
+  const collision = collisionEnabled && physicsScene.raycast(localVector, localQuaternion);
+  localQuaternion2.setFromAxisAngle(localVector2.set(1, 0, 0), -Math.PI * 0.5);
+  const downCollision = collisionEnabled && physicsScene.raycast(localVector5, localQuaternion2);
 
   if (!!collision) {
     const { point } = collision;

--- a/game.js
+++ b/game.js
@@ -569,7 +569,17 @@ const _gameUpdate = (timestamp, timeDiff) => {
       const grabAction = _getGrabAction(i);
       const grabbedObject = _getGrabbedObject(i);
       if (grabbedObject && !_isWear(grabbedObject)) {
-        const {position, quaternion} = renderer.xr.getSession() ? localPlayer[hand === 'left' ? 'leftHand' : 'rightHand'] : camera;
+        let position = null,
+          quaternion = null;
+        if (renderer.xr.getSession()) {
+          const h = localPlayer[hand === "left" ? "leftHand" : "rightHand"];
+          position = h.position;
+          quaternion = h.quaternion;
+        } else {
+          position = localVector2.copy(localPlayer.position);
+          quaternion = camera.quaternion;
+        }
+        
         localMatrix.compose(position, quaternion, localVector.set(1, 1, 1));
 
         updateGrabbedObject(grabbedObject, localMatrix, localMatrix3.fromArray(grabAction.matrix), {


### PR DESCRIPTION
This PR fixes the following issues when editing scenes:

**- Grabbed object transform out of sync**
`object.updateMatrixWorld` was called before the transform, which caused jitters.

**- Collisions**
Querying only forward collision resulted in the `object` going into the ground when the distance from localPlayer to collision point was bigger than the grab offset. I added `downCollision` to prevent that. By raycasting from `object` perpendicularly down returns the collision `point` with the ground. `object.position.y` will then be clamped to be >= `point.y`.

**- Pivot point**
Before, the grabbed object was moved around `camera.position` as pivot point. When 3rd person mode was entered, the object would move backwards with the camera. To prevent that I set the pivot point at `localPlayer.position`.

**Videos**
Before:
https://user-images.githubusercontent.com/49231818/190644219-ac9d3d79-9afb-4f5a-8b63-4cdb7ca29c0a.mp4

After:
https://user-images.githubusercontent.com/49231818/190644313-43e0136b-d9ec-4176-ab56-8b49381b403e.mp4