### PR TITLE
Fix addConvexGeometry not setting the transform properly.

### DIFF
--- a/physics-manager.js
+++ b/physics-manager.js
@@ -299,9 +299,9 @@ class PhysicsScene extends EventTarget {
   
     const physicsObject = _makePhysicsObject(
       physicsId,
-      mesh.position,
-      mesh.quaternion,
-      mesh.scale
+      physicsMesh.position,
+      physicsMesh.quaternion,
+      physicsMesh.scale
     )
     physicsObject.add(physicsMesh)
     physicsMesh.position.set(0, 0, 0)


### PR DESCRIPTION
Meshes that were using convexMesh type would have their highlighted mesh in edit mode appear in the wrong location while the actual collision hull in the physics scene would be in the right location.

physicsManager.addConvexGeometry() uses the original mesh passed as a parameter to set the transform. It should be the physicsMesh built by convertMeshToPhysicsMesh() that's used to set the transform.
